### PR TITLE
Temporarily turn off Slither on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,6 @@ jobs:
       - name: Lint
         run: yarn lint
 
-  static-analysis:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up environment
-        uses: ./.github/actions/setup
-      - name: Install Slither
-        run: yarn slither-install
-      - name: Run Slither
-        run: yarn slither
-
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Description

In its current state and configuration, Slither is not helpful in CI. Revisit when we can get it to give consistent, deterministic results (and possibly a better way to see what's in the exceptions file to compare when we change it; maybe a tool to summarize and sort just the rules, and then we check in the summary that can be easily diffed: something like that).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
