### PR TITLE
Expose reentrancy guard status

### DIFF
--- a/pkg/solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol
+++ b/pkg/solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol
@@ -78,7 +78,7 @@ abstract contract ReentrancyGuard {
      * @dev Returns true if the reentrancy guard is currently set to "entered", which indicates there is a
      * `nonReentrant` function in the call stack.
      */
-    function _reentrancyGuardEntered() internal view returns (bool) {
+    function reentrancyGuardEntered() public view returns (bool) {
         return _status == _ENTERED;
     }
 }

--- a/pkg/solidity-utils/contracts/test/ReentrancyMock.sol
+++ b/pkg/solidity-utils/contracts/test/ReentrancyMock.sol
@@ -41,10 +41,10 @@ contract ReentrancyMock is ReentrancyGuard {
     }
 
     function guardedCheckEntered() public nonReentrant {
-        require(_reentrancyGuardEntered());
+        require(reentrancyGuardEntered());
     }
 
     function unguardedCheckNotEntered() public view {
-        require(!_reentrancyGuardEntered());
+        require(!reentrancyGuardEntered());
     }
 }


### PR DESCRIPTION
# Description

Having been reminded of our V3 wish list, this was an item on it. The reentrancy fix was greatly complicated in V2 by the fact that we couldn't simply ask whether the Vault had been entered.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

