### PR TITLE
Separate user-provided from system configuration

### DIFF
--- a/pkg/interfaces/contracts/vault/IVault.sol
+++ b/pkg/interfaces/contracts/vault/IVault.sol
@@ -5,12 +5,16 @@ pragma solidity ^0.8.4;
 import { Asset } from "../solidity-utils/misc/Asset.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-/// @notice Struct to represent a pool configuration
-struct PoolConfig {
-    bool isRegisteredPool;
+struct PoolHooks {
     bool shouldCallAfterSwap;
     bool shouldCallAfterAddLiquidity;
     bool shouldCallAfterRemoveLiquidity;
+}
+
+/// @notice Struct to represent a pool configuration
+struct PoolConfig {
+    bool isRegisteredPool;
+    PoolHooks hooks;
 }
 
 /// @notice Interface for the Vault
@@ -25,7 +29,7 @@ interface IVault {
      * @param tokens An array of token addresses the pool will manage.
      * @param config Config for the pool
      */
-    function registerPool(address factory, IERC20[] memory tokens, PoolConfig calldata config) external;
+    function registerPool(address factory, IERC20[] memory tokens, PoolHooks calldata config) external;
 
     /**
      * @notice Checks if a pool is registered

--- a/pkg/vault/contracts/lib/PoolConfigLib.sol
+++ b/pkg/vault/contracts/lib/PoolConfigLib.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.4;
 
-import { PoolConfig } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import { PoolConfig, PoolHooks } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import { WordCodec } from "@balancer-labs/v3-solidity-utils/contracts/helpers/WordCodec.sol";
 
 // @notice Config type to store entire configuration of the pool
@@ -54,9 +54,9 @@ library PoolConfigLib {
             PoolConfigBits.wrap(
                 bytes32(0)
                     .insertBool(config.isRegisteredPool, POOL_REGISTERED_OFFSET)
-                    .insertBool(config.shouldCallAfterSwap, AFTER_SWAP_OFFSET)
-                    .insertBool(config.shouldCallAfterAddLiquidity, AFTER_ADD_LIQUIDITY_OFFSET)
-                    .insertBool(config.shouldCallAfterRemoveLiquidity, AFTER_REMOVE_LIQUIDITY_OFFSET)
+                    .insertBool(config.hooks.shouldCallAfterSwap, AFTER_SWAP_OFFSET)
+                    .insertBool(config.hooks.shouldCallAfterAddLiquidity, AFTER_ADD_LIQUIDITY_OFFSET)
+                    .insertBool(config.hooks.shouldCallAfterRemoveLiquidity, AFTER_REMOVE_LIQUIDITY_OFFSET)
             );
     }
 
@@ -64,9 +64,11 @@ library PoolConfigLib {
         return
             PoolConfig({
                 isRegisteredPool: config.isPoolRegistered(),
-                shouldCallAfterAddLiquidity: config.shouldCallAfterAddLiquidity(),
-                shouldCallAfterRemoveLiquidity: config.shouldCallAfterRemoveLiquidity(),
-                shouldCallAfterSwap: config.shouldCallAfterSwap()
+                hooks: PoolHooks({
+                    shouldCallAfterAddLiquidity: config.shouldCallAfterAddLiquidity(),
+                    shouldCallAfterRemoveLiquidity: config.shouldCallAfterRemoveLiquidity(),
+                    shouldCallAfterSwap: config.shouldCallAfterSwap()
+                })
             });
     }
 }

--- a/pkg/vault/contracts/test/ERC20PoolMock.sol
+++ b/pkg/vault/contracts/test/ERC20PoolMock.sol
@@ -30,7 +30,7 @@ contract ERC20PoolMock is ERC20PoolToken, IBasePool {
         _vault = vault;
 
         if (registerPool) {
-            vault.registerPool(factory, tokens, PoolConfigBits.wrap(0).toPoolConfig());
+            vault.registerPool(factory, tokens, PoolConfigBits.wrap(0).toPoolConfig().hooks);
         }
     }
 

--- a/pkg/vault/contracts/test/VaultMock.sol
+++ b/pkg/vault/contracts/test/VaultMock.sol
@@ -40,13 +40,13 @@ contract VaultMock is Vault {
 
     // Used for testing the ReentrancyGuard
     function reentrantRegisterPool(address factory, IERC20[] memory tokens) external nonReentrant {
-        this.registerPool(factory, tokens, PoolConfigBits.wrap(0).toPoolConfig());
+        this.registerPool(factory, tokens, PoolConfigBits.wrap(0).toPoolConfig().hooks);
     }
 
     // Used for testing pool registration, which is ordinarily done in the constructor of the pool.
     // The Mock pool has an argument for whether or not to register on deployment. To call register pool
     // separately, deploy it with the registration flag false, then call this function.
     function manualRegisterPool(address factory, IERC20[] memory tokens) external whenNotPaused {
-        _registerPool(factory, tokens, PoolConfigBits.wrap(0).toPoolConfig());
+        _registerPool(factory, tokens, PoolConfigBits.wrap(0).toPoolConfig().hooks);
     }
 }

--- a/pkg/vault/test/foundry/Hooks.t.sol
+++ b/pkg/vault/test/foundry/Hooks.t.sol
@@ -55,7 +55,7 @@ contract VaultSwapTest is Test {
         );
 
         PoolConfig memory config = vault.getPoolConfig(address(pool));
-        config.shouldCallAfterSwap = true;
+        config.hooks.shouldCallAfterSwap = true;
         vault.setConfig(address(pool), config);
 
         USDC.mint(bob, USDC_AMOUNT_IN);


### PR DESCRIPTION
# Description

We are mixing user-provided configuration (hooks), with system-determined pool state (registration and initialization status). It's odd to pass the registration flag into the registerPool call, where it will just be overwritten.

In subsequent PRs, when we add explicit initialization, it really won't work to mix the flags, since then a pool could say register itself as initialized, when it really wasn't. (And then would never be able to be initialized, due to the checks.)

Merge into internal-balances.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [X] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

