### PR TITLE
Multitoken API / Facade tokens refactor (only BPT)

### DIFF
--- a/pkg/interfaces/contracts/vault/IVault.sol
+++ b/pkg/interfaces/contracts/vault/IVault.sol
@@ -69,7 +69,7 @@ interface IVault {
      * @param token                          Token's address
      * @return                               Total supply of the token
      */
-    function totalSupplyOfERC20(address token) external view returns (uint256);
+    function totalSupply(address token) external view returns (uint256);
 
     /**
      * @notice Gets balance of an account for a given ERC20 token
@@ -77,26 +77,30 @@ interface IVault {
      * @param account                        Account's address
      * @return                               Balance of the account for the token
      */
-    function balanceOfERC20(address token, address account) external view returns (uint256);
+    function balanceOf(address token, address account) external view returns (uint256);
 
     /**
-     * @notice Transfers ERC20 token from owner to a recipient
+     * @notice Transfers pool token from owner to a recipient.
+     * @dev Notice that the pool token address is not included in the params. This function is exclusively called by
+     * the pool contract, so msg.sender is used as the token address.
      * @param owner                          Owner's address
      * @param to                             Recipient's address
      * @param amount                         Amount of tokens to transfer
      * @return                               True if successful, false otherwise
      */
-    function transferERC20(address owner, address to, uint256 amount) external returns (bool);
+    function transfer(address owner, address to, uint256 amount) external returns (bool);
 
     /**
-     * @notice Transfers from a sender to a recipient using an allowance
+     * @notice Transfers pool token from a sender to a recipient using an allowance
+     * @dev Notice that the pool token address is not included in the params. This function is exclusively called by
+     * the pool contract, so msg.sender is used as the token address.
      * @param spender                        Address allowed to perform the transfer
      * @param from                           Sender's address
      * @param to                             Recipient's address
      * @param amount                         Amount of tokens to transfer
      * @return                               True if successful, false otherwise
      */
-    function transferFromERC20(address spender, address from, address to, uint256 amount) external returns (bool);
+    function transferFrom(address spender, address from, address to, uint256 amount) external returns (bool);
 
     /**
      * @notice Gets allowance of a spender for a given ERC20 token and owner
@@ -105,16 +109,18 @@ interface IVault {
      * @param spender                        Spender's address
      * @return                               Amount of tokens the spender is allowed to spend
      */
-    function allowanceOfERC20(address token, address owner, address spender) external view returns (uint256);
+    function allowance(address token, address owner, address spender) external view returns (uint256);
 
     /**
-     * @notice Approves a spender to spend tokens on behalf of sender
-     * @param sender                         Owner's address
+     * @notice Approves a spender to spend pool tokens on behalf of sender
+     * @dev Notice that the pool token address is not included in the params. This function is exclusively called by
+     * the pool contract, so msg.sender is used as the token address.
+     * @param owner                          Owner's address
      * @param spender                        Spender's address
      * @param amount                         Amount of tokens to approve
      * @return                               True if successful, false otherwise
      */
-    function approveERC20(address sender, address spender, uint256 amount) external returns (bool);
+    function approve(address owner, address spender, uint256 amount) external returns (bool);
 
     /*******************************************************************************
                               Transient Accounting

--- a/pkg/vault/contracts/BasePoolToken.sol
+++ b/pkg/vault/contracts/BasePoolToken.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.4;
 
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 
-import { ERC20FacadeToken } from "./ERC20FacadeToken.sol";
+import { ERC20PoolToken } from "./ERC20PoolToken.sol";
 
-contract BasePoolToken is ERC20FacadeToken {
-    constructor(IVault vault_, string memory name_, string memory symbol_) ERC20FacadeToken(vault_, name_, symbol_) {
+contract BasePoolToken is ERC20PoolToken {
+    constructor(IVault vault_, string memory name_, string memory symbol_) ERC20PoolToken(vault_, name_, symbol_) {
         // solhint-disable-previous-line no-empty-blocks
     }
 }

--- a/pkg/vault/contracts/ERC20MultiToken.sol
+++ b/pkg/vault/contracts/ERC20MultiToken.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.4;
 
 import { IERC20Errors } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/tokens/IERC20Errors.sol";
 
-import { ERC20FacadeToken } from "./ERC20FacadeToken.sol";
+import { ERC20PoolToken } from "./ERC20PoolToken.sol";
 
 /**
  * @notice Store Token data and handle accounting for all tokens in the Vault.
@@ -19,35 +19,35 @@ abstract contract ERC20MultiToken is IERC20Errors {
     mapping(address => mapping(address => mapping(address => uint256))) private _allowances;
 
     // token -> total supply
-    mapping(address => uint256) private _totalSupply;
+    mapping(address => uint256) private _totalSupplyOf;
 
-    function _totalSupplyOfERC20(address token) internal view returns (uint256) {
-        return _totalSupply[token];
+    function _totalSupply(address token) internal view returns (uint256) {
+        return _totalSupplyOf[token];
     }
 
-    function _balanceOfERC20(address token, address account) internal view returns (uint256) {
+    function _balanceOf(address token, address account) internal view returns (uint256) {
         return _balances[token][account];
     }
 
-    function _allowanceOfERC20(address token, address owner, address spender) internal view returns (uint256) {
+    function _allowance(address token, address owner, address spender) internal view returns (uint256) {
         return _allowances[token][owner][spender];
     }
 
-    function _mintERC20(address token, address to, uint256 amount) internal {
+    function _mint(address token, address to, uint256 amount) internal {
         if (to == address(0)) {
             revert ERC20InvalidReceiver(to);
         }
 
-        _totalSupply[token] += amount;
+        _totalSupplyOf[token] += amount;
         unchecked {
             // Overflow not possible: balance + amount is at most totalSupply + amount, which is checked above.
             _balances[token][to] += amount;
         }
 
-        ERC20FacadeToken(token).emitTransfer(address(0), to, amount);
+        ERC20PoolToken(token).emitTransfer(address(0), to, amount);
     }
 
-    function _burnERC20(address token, address from, uint256 amount) internal {
+    function _burn(address token, address from, uint256 amount) internal {
         if (from == address(0)) {
             revert ERC20InvalidSender(from);
         }
@@ -60,13 +60,13 @@ abstract contract ERC20MultiToken is IERC20Errors {
         unchecked {
             _balances[token][from] = accountBalance - amount;
             // Overflow not possible: amount <= accountBalance <= totalSupply.
-            _totalSupply[token] -= amount;
+            _totalSupplyOf[token] -= amount;
         }
 
-        ERC20FacadeToken(token).emitTransfer(from, address(0), amount);
+        ERC20PoolToken(token).emitTransfer(from, address(0), amount);
     }
 
-    function _transferERC20(address token, address from, address to, uint256 amount) internal {
+    function _transfer(address token, address from, address to, uint256 amount) internal {
         if (from == address(0)) {
             revert ERC20InvalidSender(from);
         }
@@ -87,10 +87,10 @@ abstract contract ERC20MultiToken is IERC20Errors {
             _balances[token][to] += amount;
         }
 
-        ERC20FacadeToken(token).emitTransfer(from, to, amount);
+        ERC20PoolToken(token).emitTransfer(from, to, amount);
     }
 
-    function _approveERC20(address token, address owner, address spender, uint256 amount) internal {
+    function _approve(address token, address owner, address spender, uint256 amount) internal {
         if (owner == address(0)) {
             revert ERC20InvalidApprover(owner);
         }
@@ -100,7 +100,7 @@ abstract contract ERC20MultiToken is IERC20Errors {
         }
 
         _allowances[token][owner][spender] = amount;
-        ERC20FacadeToken(token).emitApprove(owner, spender, amount);
+        ERC20PoolToken(token).emitApprove(owner, spender, amount);
     }
 
     function _spendAllowance(address token, address owner, address spender, uint256 amount) internal {
@@ -111,7 +111,7 @@ abstract contract ERC20MultiToken is IERC20Errors {
             }
 
             unchecked {
-                _approveERC20(token, owner, spender, currentAllowance - amount);
+                _approve(token, owner, spender, currentAllowance - amount);
             }
         }
     }

--- a/pkg/vault/contracts/ERC20PoolToken.sol
+++ b/pkg/vault/contracts/ERC20PoolToken.sol
@@ -9,9 +9,9 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
 /**
- * @notice A full ERC20 compatible token with all the data and implementation delegated to the ERC20Multitoken contract
+ * @notice A full ERC20 compatible token with all the data and implementation delegated to the ERC20MultiToken contract
  */
-contract ERC20FacadeToken is IERC20, IERC20Metadata, IVaultErrors {
+contract ERC20PoolToken is IERC20, IERC20Metadata, IVaultErrors {
     IVault private immutable _vault;
 
     string private _name;
@@ -48,37 +48,37 @@ contract ERC20FacadeToken is IERC20, IERC20Metadata, IVaultErrors {
 
     /// @inheritdoc IERC20
     function totalSupply() public view returns (uint256) {
-        return _vault.totalSupplyOfERC20(address(this));
+        return _vault.totalSupply(address(this));
     }
 
     /// @inheritdoc IERC20
     function balanceOf(address account) public view returns (uint256) {
-        return _vault.balanceOfERC20(address(this), account);
+        return _vault.balanceOf(address(this), account);
     }
 
     /// @inheritdoc IERC20
     function transfer(address to, uint256 amount) public returns (bool) {
         // Vault will perform the transfer and call emitTransfer to emit the event from this contract.
-        _vault.transferERC20(msg.sender, to, amount);
+        _vault.transfer(msg.sender, to, amount);
         return true;
     }
 
     /// @inheritdoc IERC20
     function allowance(address owner, address spender) public view returns (uint256) {
-        return _vault.allowanceOfERC20(address(this), owner, spender);
+        return _vault.allowance(address(this), owner, spender);
     }
 
     /// @inheritdoc IERC20
     function approve(address spender, uint256 amount) public returns (bool) {
         // Vault will perform the approval and call emitApprove to emit the event from this contract.
-        _vault.approveERC20(msg.sender, spender, amount);
+        _vault.approve(msg.sender, spender, amount);
         return true;
     }
 
     /// @inheritdoc IERC20
     function transferFrom(address from, address to, uint256 amount) public returns (bool) {
         // Vault will perform the transfer and call emitTransfer to emit the event from this contract.
-        _vault.transferFromERC20(msg.sender, from, to, amount);
+        _vault.transferFrom(msg.sender, from, to, amount);
         return true;
     }
 

--- a/pkg/vault/contracts/Vault.sol
+++ b/pkg/vault/contracts/Vault.sol
@@ -162,7 +162,7 @@ contract Vault is IVault, IVaultErrors, Authentication, ERC20MultiToken, Reentra
     /// @inheritdoc IVault
     function mint(IERC20 token, address to, uint256 amount) public withHandler {
         _takeDebt(token, amount, msg.sender);
-        _mintERC20(address(token), to, amount);
+        _mint(address(token), to, amount);
     }
 
     /// @inheritdoc IVault
@@ -178,7 +178,7 @@ contract Vault is IVault, IVaultErrors, Authentication, ERC20MultiToken, Reentra
     function burn(IERC20 token, address owner, uint256 amount) public withHandler {
         _supplyCredit(token, amount, msg.sender);
         _spendAllowance(address(token), owner, address(this), amount);
-        _burnERC20(address(token), owner, amount);
+        _burn(address(token), owner, amount);
     }
 
     /// @inheritdoc IVault
@@ -330,36 +330,36 @@ contract Vault is IVault, IVaultErrors, Authentication, ERC20MultiToken, Reentra
     *******************************************************************************/
 
     /// @inheritdoc IVault
-    function totalSupplyOfERC20(address token) external view returns (uint256) {
-        return _totalSupplyOfERC20(token);
+    function totalSupply(address token) external view returns (uint256) {
+        return _totalSupply(token);
     }
 
     /// @inheritdoc IVault
-    function balanceOfERC20(address token, address account) external view returns (uint256) {
-        return _balanceOfERC20(token, account);
+    function balanceOf(address token, address account) external view returns (uint256) {
+        return _balanceOf(token, account);
     }
 
     /// @inheritdoc IVault
-    function allowanceOfERC20(address token, address owner, address spender) external view returns (uint256) {
-        return _allowanceOfERC20(token, owner, spender);
+    function allowance(address token, address owner, address spender) external view returns (uint256) {
+        return _allowance(token, owner, spender);
     }
 
     /// @inheritdoc IVault
-    function transferERC20(address owner, address to, uint256 amount) external returns (bool) {
-        _transferERC20(msg.sender, owner, to, amount);
+    function transfer(address owner, address to, uint256 amount) external returns (bool) {
+        _transfer(msg.sender, owner, to, amount);
         return true;
     }
 
     /// @inheritdoc IVault
-    function approveERC20(address handler, address spender, uint256 amount) external returns (bool) {
-        _approveERC20(msg.sender, handler, spender, amount);
+    function approve(address owner, address spender, uint256 amount) external returns (bool) {
+        _approve(msg.sender, owner, spender, amount);
         return true;
     }
 
     /// @inheritdoc IVault
-    function transferFromERC20(address spender, address from, address to, uint256 amount) external returns (bool) {
+    function transferFrom(address spender, address from, address to, uint256 amount) external returns (bool) {
         _spendAllowance(msg.sender, from, spender, amount);
-        _transferERC20(msg.sender, from, to, amount);
+        _transfer(msg.sender, from, to, amount);
         return true;
     }
 

--- a/pkg/vault/contracts/test/ERC20PoolMock.sol
+++ b/pkg/vault/contracts/test/ERC20PoolMock.sol
@@ -9,10 +9,10 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { IVault, PoolConfig } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 
-import { ERC20FacadeToken } from "../ERC20FacadeToken.sol";
 import { PoolConfigBits, PoolConfigLib } from "../lib/PoolConfigLib.sol";
+import { ERC20PoolToken } from "../ERC20PoolToken.sol";
 
-contract ERC20PoolMock is ERC20FacadeToken, IBasePool {
+contract ERC20PoolMock is ERC20PoolToken, IBasePool {
     using FixedPoint for uint256;
 
     IVault private immutable _vault;
@@ -26,7 +26,7 @@ contract ERC20PoolMock is ERC20FacadeToken, IBasePool {
         address factory,
         IERC20[] memory tokens,
         bool registerPool
-    ) ERC20FacadeToken(vault, name, symbol) {
+    ) ERC20PoolToken(vault, name, symbol) {
         _vault = vault;
 
         if (registerPool) {

--- a/pkg/vault/contracts/test/VaultMock.sol
+++ b/pkg/vault/contracts/test/VaultMock.sol
@@ -25,11 +25,11 @@ contract VaultMock is Vault {
     }
 
     function burnERC20(address poolToken, address from, uint256 amount) external {
-        _burnERC20(poolToken, from, amount);
+        _burn(poolToken, from, amount);
     }
 
     function mintERC20(address poolToken, address to, uint256 amount) external {
-        _mintERC20(poolToken, to, amount);
+        _mint(poolToken, to, amount);
     }
 
     function setConfig(address pool, PoolConfig calldata config) external {

--- a/pkg/vault/test/ERC20PoolTokenTest.test.ts
+++ b/pkg/vault/test/ERC20PoolTokenTest.test.ts
@@ -10,7 +10,7 @@ import { impersonate } from '@balancer-labs/v3-helpers/src/signers';
 import { setupEnvironment } from './poolSetup';
 import '@balancer-labs/v3-common/setupTests';
 
-describe('ERC20FacadeToken', function () {
+describe('ERC20PoolToken', function () {
   let vault: VaultMock;
   let poolA: ERC20PoolMock;
   let poolB: ERC20PoolMock;
@@ -67,16 +67,16 @@ describe('ERC20FacadeToken', function () {
       expect(await poolB.balanceOf(user.address)).to.equal(0);
 
       // balanceOf indirectly, through vault
-      expect(await vault.balanceOfERC20(poolAAddress, user.address)).to.equal(bptAmount);
-      expect(await vault.balanceOfERC20(poolBAddress, user.address)).to.equal(0);
+      expect(await vault.balanceOf(poolAAddress, user.address)).to.equal(bptAmount);
+      expect(await vault.balanceOf(poolBAddress, user.address)).to.equal(0);
 
       // user has the total supply (directly on pool token)
       expect(await poolA.totalSupply()).to.equal(bptAmount);
       expect(await poolB.totalSupply()).to.equal(0);
 
       // user has the total supply (indirectly, through vault)
-      expect(await vault.totalSupplyOfERC20(poolAAddress)).to.equal(bptAmount);
-      expect(await vault.totalSupplyOfERC20(poolBAddress)).to.equal(0);
+      expect(await vault.totalSupply(poolAAddress)).to.equal(bptAmount);
+      expect(await vault.totalSupply(poolBAddress)).to.equal(0);
     });
 
     it('minting ERC20 BPT emits a transfer event on the token', async () => {
@@ -109,13 +109,13 @@ describe('ERC20FacadeToken', function () {
       expect(await poolA.balanceOf(user.address)).to.equal(remainingBalance);
 
       // balanceOf indirectly, through vault
-      expect(await vault.balanceOfERC20(poolAAddress, user.address)).to.equal(remainingBalance);
+      expect(await vault.balanceOf(poolAAddress, user.address)).to.equal(remainingBalance);
 
       // user has the total supply (directly on pool token)
       expect(await poolA.totalSupply()).to.equal(remainingBalance);
 
       // user has the total supply (indirectly, through vault)
-      expect(await vault.totalSupplyOfERC20(poolAAddress)).to.equal(remainingBalance);
+      expect(await vault.totalSupply(poolAAddress)).to.equal(remainingBalance);
     });
 
     it('burning ERC20 BPT emits a transfer event on the token', async () => {
@@ -164,7 +164,7 @@ describe('ERC20FacadeToken', function () {
       });
 
       it('indirect ERC20 BPT transfer emits a transfer event on the token', async () => {
-        await expect(await vault.connect(registeredPoolSigner).transferERC20(user.address, other.address, bptAmount))
+        await expect(await vault.connect(registeredPoolSigner).transfer(user.address, other.address, bptAmount))
           .to.emit(poolA, 'Transfer')
           .withArgs(user.address, other.address, bptAmount);
       });
@@ -177,25 +177,25 @@ describe('ERC20FacadeToken', function () {
     });
 
     it('transfers ERC20 BPT through the vault', async () => {
-      await vault.connect(registeredPoolSigner).transferERC20(user.address, other.address, bptAmount);
+      await vault.connect(registeredPoolSigner).transfer(user.address, other.address, bptAmount);
 
       itTransfersBPTCorrectly();
     });
 
     it('cannot transfer ERC20 BPT from zero address', async () => {
-      await expect(vault.connect(registeredPoolSigner).transferERC20(ZERO_ADDRESS, other.address, bptAmount))
+      await expect(vault.connect(registeredPoolSigner).transfer(ZERO_ADDRESS, other.address, bptAmount))
         .to.be.revertedWithCustomError(vault, 'ERC20InvalidSender')
         .withArgs(ZERO_ADDRESS);
     });
 
     it('cannot transfer ERC20 BPT to zero address', async () => {
-      await expect(vault.connect(registeredPoolSigner).transferERC20(user.address, ZERO_ADDRESS, bptAmount))
+      await expect(vault.connect(registeredPoolSigner).transfer(user.address, ZERO_ADDRESS, bptAmount))
         .to.be.revertedWithCustomError(vault, 'ERC20InvalidReceiver')
         .withArgs(ZERO_ADDRESS);
     });
 
     it('cannot transfer more than balance', async () => {
-      await expect(vault.connect(registeredPoolSigner).transferERC20(user.address, other.address, totalSupply + 1n))
+      await expect(vault.connect(registeredPoolSigner).transfer(user.address, other.address, totalSupply + 1n))
         .to.be.revertedWithCustomError(vault, 'ERC20InsufficientBalance')
         .withArgs(user.address, totalSupply, totalSupply + 1n);
     });
@@ -221,8 +221,8 @@ describe('ERC20FacadeToken', function () {
         expect(await poolA.allowance(user.address, relayer.address)).to.equal(bptAmount);
         expect(await poolA.allowance(user.address, other.address)).to.equal(0);
 
-        expect(await vault.allowanceOfERC20(poolAAddress, user.address, relayer.address)).to.equal(bptAmount);
-        expect(await vault.allowanceOfERC20(poolAAddress, user.address, other.address)).to.equal(0);
+        expect(await vault.allowance(poolAAddress, user.address, relayer.address)).to.equal(bptAmount);
+        expect(await vault.allowance(poolAAddress, user.address, other.address)).to.equal(0);
       });
 
       it('direct ERC20 approval emits an event on the token', async () => {
@@ -232,7 +232,7 @@ describe('ERC20FacadeToken', function () {
       });
 
       it('indirect ERC20 approval emits an event on the token', async () => {
-        await expect(await vault.connect(registeredPoolSigner).approveERC20(user.address, relayer.address, bptAmount))
+        await expect(await vault.connect(registeredPoolSigner).approve(user, relayer, bptAmount))
           .to.emit(poolA, 'Approval')
           .withArgs(user.address, relayer.address, bptAmount);
       });
@@ -248,20 +248,20 @@ describe('ERC20FacadeToken', function () {
 
     context('sets approval through the vault', async () => {
       sharedBeforeEach('set approval', async () => {
-        await vault.connect(registeredPoolSigner).approveERC20(user.address, relayer.address, bptAmount);
+        await vault.connect(registeredPoolSigner).approve(user, relayer, bptAmount);
       });
 
       itSetsApprovalsCorrectly();
     });
 
     it('cannot approve from zero address', async () => {
-      await expect(vault.connect(registeredPoolSigner).approveERC20(ZERO_ADDRESS, other.address, bptAmount))
+      await expect(vault.connect(registeredPoolSigner).approve(ZERO_ADDRESS, other.address, bptAmount))
         .to.be.revertedWithCustomError(vault, 'ERC20InvalidApprover')
         .withArgs(ZERO_ADDRESS);
     });
 
     it('cannot approve to zero address', async () => {
-      await expect(vault.connect(registeredPoolSigner).approveERC20(user.address, ZERO_ADDRESS, bptAmount))
+      await expect(vault.connect(registeredPoolSigner).approve(user, ZERO_ADDRESS, bptAmount))
         .to.be.revertedWithCustomError(vault, 'ERC20InvalidSpender')
         .withArgs(ZERO_ADDRESS);
     });
@@ -298,7 +298,7 @@ describe('ERC20FacadeToken', function () {
 
     context('transfers ERC20 BPT through the vault', async () => {
       sharedBeforeEach('indirect transferFrom', async () => {
-        await vault.connect(registeredPoolSigner).transferERC20(user.address, relayer.address, bptAmount);
+        await vault.connect(registeredPoolSigner).transfer(user.address, relayer.address, bptAmount);
       });
 
       itTransfersBPTCorrectly();
@@ -314,7 +314,7 @@ describe('ERC20FacadeToken', function () {
       await expect(
         await vault
           .connect(registeredPoolSigner)
-          .transferFromERC20(relayer.address, user.address, relayer.address, bptAmount)
+          .transferFrom(relayer.address, user.address, relayer.address, bptAmount)
       )
         .to.emit(poolA, 'Transfer')
         .withArgs(user.address, relayer.address, bptAmount);
@@ -322,7 +322,7 @@ describe('ERC20FacadeToken', function () {
 
     it('cannot transfer ERC20 BPT to zero address', async () => {
       await expect(
-        vault.connect(registeredPoolSigner).transferFromERC20(relayer.address, user.address, ZERO_ADDRESS, bptAmount)
+        vault.connect(registeredPoolSigner).transferFrom(relayer.address, user.address, ZERO_ADDRESS, bptAmount)
       )
         .to.be.revertedWithCustomError(vault, 'ERC20InvalidReceiver')
         .withArgs(ZERO_ADDRESS);
@@ -333,9 +333,7 @@ describe('ERC20FacadeToken', function () {
       await poolA.connect(user).approve(relayer.address, MAX_UINT256);
 
       await expect(
-        vault
-          .connect(registeredPoolSigner)
-          .transferFromERC20(relayer.address, user.address, other.address, totalSupply + 1n)
+        vault.connect(registeredPoolSigner).transferFrom(relayer.address, user.address, other.address, totalSupply + 1n)
       )
         .to.be.revertedWithCustomError(vault, 'ERC20InsufficientBalance')
         .withArgs(user.address, totalSupply, totalSupply + 1n);
@@ -343,9 +341,7 @@ describe('ERC20FacadeToken', function () {
 
     it('cannot transfer more than ERC20 BPT allowance', async () => {
       await expect(
-        vault
-          .connect(registeredPoolSigner)
-          .transferFromERC20(relayer.address, user.address, other.address, bptAmount + 1n)
+        vault.connect(registeredPoolSigner).transferFrom(relayer.address, user.address, other.address, bptAmount + 1n)
       )
         .to.be.revertedWithCustomError(vault, 'ERC20InsufficientAllowance')
         .withArgs(relayer.address, bptAmount, bptAmount + 1n);

--- a/pkg/vault/test/foundry/ERC20PoolTokenTest.t.sol
+++ b/pkg/vault/test/foundry/ERC20PoolTokenTest.t.sol
@@ -12,12 +12,12 @@ import { AssetHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers
 import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/ArrayHelpers.sol";
 import { BasicAuthorizerMock } from "@balancer-labs/v3-solidity-utils/contracts/test/BasicAuthorizerMock.sol";
 
-import { ERC20FacadeToken } from "../../contracts/ERC20FacadeToken.sol";
+import { ERC20PoolToken } from "../../contracts/ERC20PoolToken.sol";
 import { ERC20PoolMock } from "../../contracts/test/ERC20PoolMock.sol";
 import { Vault } from "../../contracts/Vault.sol";
 import { VaultMock } from "../../contracts/test/VaultMock.sol";
 
-contract ERC20FacadeTokenTest is Test {
+contract ERC20PoolTokenTest is Test {
     using AssetHelpers for address[];
     using ArrayHelpers for address[2];
 


### PR DESCRIPTION
# Description

#84 not only extends the multitoken API to any token (including non-BPTs); it also refactors some names that were still lingering in `main` from the time where we had ERC20 and ERC721 APIs coexisting together.

This PR is only a refactor that should take some burden from the open PRs; it doesn't add any functionality.
In summary:
- All ERC20 operations were removed of their ERC20 suffix. With this changes, the multitoken API looks much more similar to a regular ERC20 API.
- Pool token operations as refactored in #97 are the only ones, so instead of e.g. `poolTokenTransfer` we just got `transfer` for now.
- Facade --> pool token

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A