### PR TITLE
Relax CI: do not run test with FFI

### DIFF
--- a/pkg/solidity-utils/package.json
+++ b/pkg/solidity-utils/package.json
@@ -25,7 +25,7 @@
     "lint:typescript": "NODE_NO_WARNINGS=1 eslint . --ext .ts --ignore-path ../../.eslintignore  --max-warnings 0",
     "test": "yarn test:hardhat && yarn test:forge",
     "test:hardhat": "hardhat test",
-    "test:forge": "forge test --ffi -vvv",
+    "test:forge": "forge test --no-match-test \"FFI\" -vvv",
     "test:stress": "FOUNDRY_PROFILE=intense forge test --ffi -vvv",
     "coverage": "./coverage.sh",
     "coverage:hardhat": "hardhat coverage",

--- a/pkg/solidity-utils/test/foundry/LogExpMath.t.sol
+++ b/pkg/solidity-utils/test/foundry/LogExpMath.t.sol
@@ -31,7 +31,7 @@ contract LogExpMathTest is Test {
      * forge-config: default.fuzz.runs = 256
      * forge-config: intense.fuzz.runs = 10000
      */
-    function testPowMatchesJSFuzzed(uint256 base, uint256 exponent) external {
+    function testPowMatchesJSFuzzedFFI(uint256 base, uint256 exponent) external {
         base = bound(base, LOWER_BASE_BOUND, UPPER_BASE_BOUND);
         exponent = bound(exponent, LOWER_EXPONENT_BOUND, UPPER_EXPONENT_BOUND);
 


### PR DESCRIPTION
# Description

This is the test that consumes the most, and we don't need to run it every PR. This should move the test to the intense profile.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A