### PR TITLE
Remove unused WordCodec function

### DIFF
--- a/pkg/solidity-utils/contracts/helpers/WordCodec.sol
+++ b/pkg/solidity-utils/contracts/helpers/WordCodec.sol
@@ -39,7 +39,6 @@ library WordCodec {
     // Masks are values with the least significant N bits set. They can be used to extract an encoded value from a word,
     // or to insert a new one replacing the old.
     uint256 private constant _MASK_1 = 2 ** (1) - 1;
-    uint256 private constant _MASK_192 = 2 ** (192) - 1;
 
     // In-place insertion
 
@@ -150,17 +149,6 @@ library WordCodec {
         assembly {
             result := and(shr(offset, word), 1)
         }
-    }
-
-    /**
-     * @dev Inserts a 192 bit value shifted by an offset into a 256 bit word, replacing the old value.
-     * Returns the new word.
-     *
-     * Assumes `value` can be represented using 192 bits.
-     */
-    function insertBits192(bytes32 word, bytes32 value, uint256 offset) internal pure returns (bytes32) {
-        bytes32 clearedWord = bytes32(uint256(word) & ~(_MASK_192 << offset));
-        return clearedWord | bytes32((uint256(value) & _MASK_192) << offset);
     }
 
     /**


### PR DESCRIPTION
# Description

`insertBits192` was specific to the V2 BasePool; I don't think we need it in V3. All pools had a `miscData` field, with 64 bits reserved for the swap fee, and 192 "free" bits that could be used by derived pools.

As a bonus, removing this gets to 100% coverage on the WordCodec tests.

Merge into wordcodec-tests.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

