### PR TITLE
Solve Forge-Gas-Snapshot tolerance issue

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3870,9 +3870,9 @@ __metadata:
   linkType: hard
 
 "forge-gas-snapshot@https://github.com/ylv-io/forge-gas-snapshot":
-  version: 0.1.1
-  resolution: "forge-gas-snapshot@https://github.com/ylv-io/forge-gas-snapshot.git#commit=6510bea46378bddef9ccf9e582ab198a21e3a36c"
-  checksum: a726ddec47928e687ced4f77aae400e3e5644e6b9ca99936294cc4bcbdb8e1f398717199b09128371a11b79566416c8fa2b01a42220f194cd9b52a12b77effb7
+  version: 0.1.2
+  resolution: "forge-gas-snapshot@https://github.com/ylv-io/forge-gas-snapshot.git#commit=3f100432151b9da7a61a3d2b54d5fd6c6b29359b"
+  checksum: 38a230ec18d1d97d550c7007f14ce2c5f8e7f6ca0a91be8389b8953ef9ab9c8d1d84f968c29b1ab9b20acd05e4aec765fffdbcffcc96e20719ec1124c5db419d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds 0.1% gas tolerance threshold to quite the noise on PRs. The [commit](https://github.com/ylv-io/forge-gas-snapshot/commit/75d2a718f5a39d38d317e7e5df60fddd0e6aae62) from forge-gas-snapshot.

# Description

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [x] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
