### PR TITLE
Unused WeightedPool storage

### DIFF
--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -18,11 +18,6 @@ import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers
 contract WeightedPool is IBasePool, BalancerPoolToken {
     uint256 private immutable _totalTokens;
 
-    IERC20 internal immutable _token0;
-    IERC20 internal immutable _token1;
-    IERC20 internal immutable _token2;
-    IERC20 internal immutable _token3;
-
     uint256 internal immutable _normalizedWeight0;
     uint256 internal immutable _normalizedWeight1;
     uint256 internal immutable _normalizedWeight2;
@@ -63,11 +58,6 @@ contract WeightedPool is IBasePool, BalancerPoolToken {
         }
 
         // Immutable variables cannot be initialized inside an if statement, so we must do conditional assignments
-        _token0 = params.tokens[0];
-        _token1 = params.tokens[1];
-        _token2 = numTokens > 2 ? params.tokens[2] : IERC20(address(0));
-        _token3 = numTokens > 3 ? params.tokens[3] : IERC20(address(0));
-
         _normalizedWeight0 = params.normalizedWeights[0];
         _normalizedWeight1 = params.normalizedWeights[1];
         _normalizedWeight2 = numTokens > 2 ? params.normalizedWeights[2] : 0;


### PR DESCRIPTION
# Description

While developing the new pool type (and debating what storage I needed), realized we have leftover code in WeightedPool for storing tokens that's never used. We *could* read them in `getPoolTokens` I suppose, but the loop and logic would probably negate the advantage of immutable storage.

Unless there is plan to use this for something later?

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

