### PR TITLE
Forbid registering BPT as one of the pool tokens

### DIFF
--- a/pkg/vault/contracts/VaultExtension.sol
+++ b/pkg/vault/contracts/VaultExtension.sol
@@ -207,7 +207,7 @@ contract VaultExtension is IVaultExtension, VaultCommon, Authentication {
             IERC20 token = tokenData.token;
 
             // Ensure that the token address is valid
-            if (token == IERC20(address(0))) {
+            if (address(token) == address(0) || address(token) == pool) {
                 revert InvalidToken();
             }
 

--- a/pkg/vault/test/Vault.test.ts
+++ b/pkg/vault/test/Vault.test.ts
@@ -144,8 +144,17 @@ describe('Vault', function () {
         .withArgs(await poolB.getAddress());
     });
 
-    it('cannot register a pool with an invalid token', async () => {
+    it('cannot register a pool with an invalid token (zero address)', async () => {
       await expect(vault.manualRegisterPool(poolB, invalidTokens)).to.be.revertedWithCustomError(
+        vaultExtension,
+        'InvalidToken'
+      );
+    });
+
+    it('cannot register a pool with an invalid token (pool address)', async () => {
+      const poolBTokensWithItself = Array.from(poolBTokens);
+      poolBTokensWithItself.push(poolBAddress);
+      await expect(vault.manualRegisterPool(poolB, poolBTokensWithItself)).to.be.revertedWithCustomError(
         vaultExtension,
         'InvalidToken'
       );


### PR DESCRIPTION
# Description

Having BPT as one of the pool tokens was a workaround in V2. Combined with transient accounting, I really don't think we want this to happen in V3; the Vault has full control over the BPT supply, and swaps are fundamentally different from joins and exits (starting with settlement time).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A