### PR TITLE
Add messages to forge assertions

### DIFF
--- a/pkg/pool-weighted/test/foundry/WeightedPool.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedPool.t.sol
@@ -95,22 +95,22 @@ contract WeightedPoolTest is BaseVaultTest {
 
     function testInitialize() public {
         // Tokens are transferred from lp
-        assertEq(defaultBalance - usdc.balanceOf(lp), USDC_AMOUNT);
-        assertEq(defaultBalance - dai.balanceOf(lp), DAI_AMOUNT);
+        assertEq(defaultBalance - usdc.balanceOf(lp), USDC_AMOUNT, "LP: Wrong USDC balance");
+        assertEq(defaultBalance - dai.balanceOf(lp), DAI_AMOUNT, "LP: Wrong DAI balance");
 
         // Tokens are stored in the Vault
-        assertEq(usdc.balanceOf(address(vault)), USDC_AMOUNT);
-        assertEq(dai.balanceOf(address(vault)), DAI_AMOUNT);
+        assertEq(usdc.balanceOf(address(vault)), USDC_AMOUNT, "Vault: Wrong USDC balance");
+        assertEq(dai.balanceOf(address(vault)), DAI_AMOUNT, "Vault: Wrong DAI balance");
 
         // Tokens are deposited to the pool
         (, , uint256[] memory balances, , ) = vault.getPoolTokenInfo(address(pool));
-        assertEq(balances[0], DAI_AMOUNT);
-        assertEq(balances[1], USDC_AMOUNT);
+        assertEq(balances[0], DAI_AMOUNT, "Pool: Wrong DAI balance");
+        assertEq(balances[1], USDC_AMOUNT, "Pool: Wrong USDC balance");
 
         // should mint correct amount of BPT tokens
         // Account for the precision loss
-        assertApproxEqAbs(weightedPool.balanceOf(lp), bptAmountOut, DELTA);
-        assertApproxEqAbs(bptAmountOut, DAI_AMOUNT, DELTA);
+        assertApproxEqAbs(weightedPool.balanceOf(lp), bptAmountOut, DELTA, "LP: Wrong bptAmountOut");
+        assertApproxEqAbs(bptAmountOut, DAI_AMOUNT, DELTA, "Wrong bptAmountOut");
     }
 
     function testAddLiquidity() public {
@@ -119,21 +119,21 @@ contract WeightedPoolTest is BaseVaultTest {
         bptAmountOut = router.addLiquidityUnbalanced(address(pool), amountsIn, DAI_AMOUNT - DELTA, false, bytes(""));
 
         // Tokens are transferred from Bob
-        assertEq(defaultBalance - usdc.balanceOf(bob), USDC_AMOUNT);
-        assertEq(defaultBalance - dai.balanceOf(bob), DAI_AMOUNT);
+        assertEq(defaultBalance - usdc.balanceOf(bob), USDC_AMOUNT, "LP: Wrong USDC balance");
+        assertEq(defaultBalance - dai.balanceOf(bob), DAI_AMOUNT, "LP: Wrong DAI balance");
 
         // Tokens are stored in the Vault
-        assertEq(usdc.balanceOf(address(vault)), USDC_AMOUNT * 2);
-        assertEq(dai.balanceOf(address(vault)), DAI_AMOUNT * 2);
+        assertEq(usdc.balanceOf(address(vault)), USDC_AMOUNT * 2, "Vault: Wrong USDC balance");
+        assertEq(dai.balanceOf(address(vault)), DAI_AMOUNT * 2, "Vault: Wrong DAI balance");
 
         // Tokens are deposited to the pool
         (, , uint256[] memory balances, , ) = vault.getPoolTokenInfo(address(pool));
-        assertEq(balances[0], DAI_AMOUNT * 2);
-        assertEq(balances[1], USDC_AMOUNT * 2);
+        assertEq(balances[0], DAI_AMOUNT * 2, "Pool: Wrong DAI balance");
+        assertEq(balances[1], USDC_AMOUNT * 2, "Pool: Wrong USDC balance");
 
         // should mint correct amount of BPT tokens
-        assertApproxEqAbs(weightedPool.balanceOf(bob), bptAmountOut, DELTA);
-        assertApproxEqAbs(bptAmountOut, DAI_AMOUNT, DELTA);
+        assertApproxEqAbs(weightedPool.balanceOf(bob), bptAmountOut, DELTA, "LP: Wrong bptAmountOut");
+        assertApproxEqAbs(bptAmountOut, DAI_AMOUNT, DELTA, "Wrong bptAmountOut");
     }
 
     function testRemoveLiquidity() public {
@@ -162,25 +162,25 @@ contract WeightedPoolTest is BaseVaultTest {
         vm.stopPrank();
 
         // Tokens are transferred to Bob
-        assertApproxEqAbs(usdc.balanceOf(bob), defaultBalance, DELTA, "USDC user balance is invalid");
-        assertApproxEqAbs(dai.balanceOf(bob), defaultBalance, DELTA, "DAI user balance is invalid");
+        assertApproxEqAbs(usdc.balanceOf(bob), defaultBalance, DELTA, "LP: Wrong USDC balance");
+        assertApproxEqAbs(dai.balanceOf(bob), defaultBalance, DELTA, "LP: Wrong DAI balance");
 
         // Tokens are stored in the Vault
-        assertApproxEqAbs(usdc.balanceOf(address(vault)), USDC_AMOUNT, DELTA, "USDC vault balance is invalid");
-        assertApproxEqAbs(dai.balanceOf(address(vault)), DAI_AMOUNT, DELTA, "DAI vault balance is invalid");
+        assertApproxEqAbs(usdc.balanceOf(address(vault)), USDC_AMOUNT, DELTA, "Vault: Wrong USDC balance");
+        assertApproxEqAbs(dai.balanceOf(address(vault)), DAI_AMOUNT, DELTA, "Vault: Wrong DAI balance");
 
         // Tokens are deposited to the pool
         (, , uint256[] memory balances, , ) = vault.getPoolTokenInfo(address(pool));
-        assertApproxEqAbs(balances[0], DAI_AMOUNT, DELTA, "USDC pool balance is invalid");
-        assertApproxEqAbs(balances[1], USDC_AMOUNT, DELTA, "DAI pool balance is invalid");
+        assertApproxEqAbs(balances[0], DAI_AMOUNT, DELTA, "Pool: Wrong DAI balance");
+        assertApproxEqAbs(balances[1], USDC_AMOUNT, DELTA, "Pool: Wrong USDC balance");
 
         // amountsOut are correct
-        assertApproxEqAbs(amountsOut[0], DAI_AMOUNT, DELTA);
-        assertApproxEqAbs(amountsOut[1], USDC_AMOUNT, DELTA);
+        assertApproxEqAbs(amountsOut[0], DAI_AMOUNT, DELTA, "Wrong DAI AmountOut");
+        assertApproxEqAbs(amountsOut[1], USDC_AMOUNT, DELTA, "Wrong USDC AmountOut");
 
         // should mint correct amount of BPT tokens
-        assertEq(weightedPool.balanceOf(bob), 0);
-        assertEq(bobBptBalance, bptAmountIn);
+        assertEq(weightedPool.balanceOf(bob), 0, "LP: Wrong BPT balance");
+        assertEq(bobBptBalance, bptAmountIn, "LP: Wrong bptAmountIn");
     }
 
     function testSwap() public {
@@ -197,17 +197,17 @@ contract WeightedPoolTest is BaseVaultTest {
         );
 
         // Tokens are transferred from Bob
-        assertEq(usdc.balanceOf(bob), defaultBalance + amountCalculated);
-        assertEq(dai.balanceOf(bob), defaultBalance - DAI_AMOUNT_IN);
+        assertEq(usdc.balanceOf(bob), defaultBalance + amountCalculated, "LP: Wrong USDC balance");
+        assertEq(dai.balanceOf(bob), defaultBalance - DAI_AMOUNT_IN, "LP: Wrong DAI balance");
 
         // Tokens are stored in the Vault
-        assertEq(usdc.balanceOf(address(vault)), USDC_AMOUNT - amountCalculated);
-        assertEq(dai.balanceOf(address(vault)), DAI_AMOUNT + DAI_AMOUNT_IN);
+        assertEq(usdc.balanceOf(address(vault)), USDC_AMOUNT - amountCalculated, "Vault: Wrong USDC balance");
+        assertEq(dai.balanceOf(address(vault)), DAI_AMOUNT + DAI_AMOUNT_IN, "Vault: Wrong DAI balance");
 
         // Tokens are deposited to the pool
         (, , uint256[] memory balances, , ) = vault.getPoolTokenInfo(address(pool));
-        assertEq(balances[0], DAI_AMOUNT + DAI_AMOUNT_IN);
-        assertEq(balances[1], USDC_AMOUNT - amountCalculated);
+        assertEq(balances[0], DAI_AMOUNT + DAI_AMOUNT_IN, "Pool: Wrong DAI balance");
+        assertEq(balances[1], USDC_AMOUNT - amountCalculated, "Pool: Wrong USDC balance");
     }
 
     function less(uint256 amount, uint256 base) internal pure returns (uint256) {

--- a/pkg/pool-weighted/test/foundry/WeightedPool8020Factory.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedPool8020Factory.t.sol
@@ -58,9 +58,9 @@ contract WeightedPool8020FactoryTest is Test {
         );
 
         uint256[] memory poolWeights = pool.getNormalizedWeights();
-        assertEq(poolWeights[0], 8e17);
-        assertEq(poolWeights[1], 2e17);
-        assertEq(pool.symbol(), "Pool8020");
+        assertEq(poolWeights[0], 8e17, "Higher weight token is not 80%");
+        assertEq(poolWeights[1], 2e17, "Lower weight token is not 20%");
+        assertEq(pool.symbol(), "Pool8020", "Wrong pool symbol");
     }
 
     function testInvalidPoolMinTokens() public {
@@ -118,8 +118,8 @@ contract WeightedPool8020FactoryTest is Test {
             )
         );
 
-        assertFalse(address(pool) == address(secondPool));
-        assertEq(address(secondPool), expectedPoolAddress);
+        assertFalse(address(pool) == address(secondPool), "Two deployed pool addresses are equal");
+        assertEq(address(secondPool), expectedPoolAddress, "Unexpected pool address");
     }
 
     function testPoolSender(bytes32 salt) public {
@@ -141,11 +141,11 @@ contract WeightedPool8020FactoryTest is Test {
                 salt
             )
         );
-        assertFalse(address(pool) == expectedPoolAddress);
+        assertFalse(address(pool) == expectedPoolAddress, "Unexpected pool address");
 
         vm.prank(alice);
         address aliceExpectedPoolAddress = factory.getDeploymentAddress(salt);
-        assertTrue(address(pool) == aliceExpectedPoolAddress);
+        assertTrue(address(pool) == aliceExpectedPoolAddress, "Unexpected pool address");
     }
 
     function testPoolCrossChainProtection(bytes32 salt, uint16 chainId) public {
@@ -179,6 +179,6 @@ contract WeightedPool8020FactoryTest is Test {
         );
 
         // Same sender and salt, should still be different because of the chainId.
-        assertFalse(address(poolL2) == address(poolMainnet));
+        assertFalse(address(poolL2) == address(poolMainnet), "L2 and mainnet pool addresses are equal");
     }
 }

--- a/pkg/vault/test/foundry/Router.t.sol
+++ b/pkg/vault/test/foundry/Router.t.sol
@@ -144,7 +144,7 @@ contract RouterTest is BaseVaultTest {
     }
 
     function testInitializeWETHNoBalance() public {
-        require(weth.balanceOf(broke) == 0);
+        require(weth.balanceOf(broke) == 0, "Precondition: WETH balance non-zero");
 
         bool wethIsEth = false;
         // Revert when sending ETH while wethIsEth is false (caller holds no weth).
@@ -176,7 +176,7 @@ contract RouterTest is BaseVaultTest {
         // weth was deposited, pool tokens were minted to Alice.
         assertEq(weth.balanceOf(alice), defaultBalance - ethAmountIn, "Wrong WETH balance");
         assertEq(wethPoolNoInit.balanceOf(alice), bptAmountOut, "Wrong WETH pool balance");
-        assertGt(bptAmountOut, 0, "Wrong bptAmountOut");
+        assertGt(bptAmountOut, 0, "bptAmountOut is zero");
     }
 
     function testInitializeNativeNoBalance() public {
@@ -212,7 +212,7 @@ contract RouterTest is BaseVaultTest {
         // weth was deposited, pool tokens were minted to Alice.
         assertEq(address(alice).balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
         assertEq(wethPoolNoInit.balanceOf(alice), bptAmountOut, "Wrong WETH pool balance");
-        assertGt(bptAmountOut, 0);
+        assertGt(bptAmountOut, 0, "bptAmountOut is zero");
     }
 
     function testInitializeNativeExcessEth() public {
@@ -230,9 +230,9 @@ contract RouterTest is BaseVaultTest {
         );
 
         // weth was deposited, excess ETH was returned, pool tokens were minted to Alice.
-        assertEq(address(alice).balance, defaultBalance - ethAmountIn);
-        assertEq(wethPoolNoInit.balanceOf(alice), bptAmountOut);
-        assertGt(bptAmountOut, 0);
+        assertEq(address(alice).balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
+        assertEq(wethPoolNoInit.balanceOf(alice), bptAmountOut, "Wrong WETH pool balance");
+        assertGt(bptAmountOut, 0, "bptAmountOut is zero");
     }
 
     function testAddLiquidityWETHNoBalance() public {
@@ -265,8 +265,8 @@ contract RouterTest is BaseVaultTest {
         snapEnd();
 
         // weth was deposited, pool tokens were minted to Alice.
-        assertEq(defaultBalance - weth.balanceOf(alice), ethAmountIn);
-        assertEq(wethPool.balanceOf(alice), bptAmountOut);
+        assertEq(defaultBalance - weth.balanceOf(alice), ethAmountIn, "Wrong ETH balance");
+        assertEq(wethPool.balanceOf(alice), bptAmountOut, "Wrong WETH pool balance");
     }
 
     function testAddLiquidityNativeNoBalance() public {
@@ -299,8 +299,8 @@ contract RouterTest is BaseVaultTest {
         snapEnd();
 
         // weth was deposited, pool tokens were minted to Alice.
-        assertEq(address(alice).balance, defaultBalance - ethAmountIn);
-        assertEq(wethPool.balanceOf(alice), bptAmountOut);
+        assertEq(address(alice).balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
+        assertEq(wethPool.balanceOf(alice), bptAmountOut, "Wrong WETH pool balance");
     }
 
     function testAddLiquidityNativeExcessEth() public {
@@ -316,8 +316,8 @@ contract RouterTest is BaseVaultTest {
         );
 
         // weth was deposited, excess was returned, pool tokens were minted to Alice.
-        assertEq(address(alice).balance, defaultBalance - ethAmountIn);
-        assertEq(wethPool.balanceOf(alice), bptAmountOut);
+        assertEq(address(alice).balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
+        assertEq(wethPool.balanceOf(alice), bptAmountOut, "Wrong WETH pool balance");
     }
 
     function testRemoveLiquidityWETH() public {
@@ -348,9 +348,9 @@ contract RouterTest is BaseVaultTest {
         snapEnd();
 
         // Liquidity position was removed, Alice gets weth back
-        assertEq(weth.balanceOf(alice), defaultBalance + ethAmountIn);
-        assertEq(wethPool.balanceOf(alice), 0);
-        assertEq(address(alice).balance, defaultBalance - ethAmountIn);
+        assertEq(weth.balanceOf(alice), defaultBalance + ethAmountIn, "Wrong WETH balance");
+        assertEq(wethPool.balanceOf(alice), 0, "WETH pool balance is > 0");
+        assertEq(address(alice).balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
     }
 
     function testRemoveLiquidityNative() public {
@@ -380,13 +380,13 @@ contract RouterTest is BaseVaultTest {
         snapEnd();
 
         // Liquidity position was removed, Alice gets ETH back
-        assertEq(weth.balanceOf(alice), defaultBalance);
-        assertEq(wethPool.balanceOf(alice), 0);
-        assertEq(address(alice).balance, aliceNativeBalanceBefore + ethAmountIn);
+        assertEq(weth.balanceOf(alice), defaultBalance, "Wrong WETH balance");
+        assertEq(wethPool.balanceOf(alice), 0, "WETH pool balance is > 0");
+        assertEq(address(alice).balance, aliceNativeBalanceBefore + ethAmountIn, "Wrong ETH balance");
     }
 
     function testSwapExactInWETH() public {
-        require(weth.balanceOf(alice) == defaultBalance);
+        require(weth.balanceOf(alice) == defaultBalance, "Precondition: wrong WETH balance");
 
         bool wethIsEth = false;
 
@@ -404,12 +404,12 @@ contract RouterTest is BaseVaultTest {
         );
         snapEnd();
 
-        assertEq(weth.balanceOf(alice), defaultBalance - ethAmountIn);
-        assertEq(dai.balanceOf(alice), defaultBalance + outputTokenAmount);
+        assertEq(weth.balanceOf(alice), defaultBalance - ethAmountIn, "Wrong WETH balance");
+        assertEq(dai.balanceOf(alice), defaultBalance + outputTokenAmount, "Wrong DAI balance");
     }
 
     function testSwapExactOutWETH() public {
-        require(weth.balanceOf(alice) == defaultBalance);
+        require(weth.balanceOf(alice) == defaultBalance, "Precondition: wrong WETH balance");
         bool wethIsEth = false;
 
         vm.prank(alice);
@@ -424,13 +424,13 @@ contract RouterTest is BaseVaultTest {
             ""
         );
 
-        assertEq(weth.balanceOf(alice), defaultBalance - outputTokenAmount);
-        assertEq(dai.balanceOf(alice), defaultBalance + daiAmountOut);
+        assertEq(weth.balanceOf(alice), defaultBalance - outputTokenAmount, "Wrong WETH balance");
+        assertEq(dai.balanceOf(alice), defaultBalance + daiAmountOut, "Wrong DAI balance");
     }
 
     function testSwapExactInNative() public {
-        require(weth.balanceOf(alice) == defaultBalance);
-        require(alice.balance == defaultBalance);
+        require(weth.balanceOf(alice) == defaultBalance, "Precondition: wrong WETH balance");
+        require(alice.balance == defaultBalance, "Precondition: wrong ETH balance");
 
         bool wethIsEth = true;
 
@@ -448,14 +448,14 @@ contract RouterTest is BaseVaultTest {
         );
         snapEnd();
 
-        assertEq(weth.balanceOf(alice), defaultBalance);
-        assertEq(dai.balanceOf(alice), defaultBalance + ethAmountIn);
-        assertEq(alice.balance, defaultBalance - ethAmountIn);
+        assertEq(weth.balanceOf(alice), defaultBalance, "Wrong WETH balance");
+        assertEq(dai.balanceOf(alice), defaultBalance + ethAmountIn, "Wrong DAI balance");
+        assertEq(alice.balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
     }
 
     function testSwapExactOutNative() public {
-        require(weth.balanceOf(alice) == defaultBalance);
-        require(alice.balance == defaultBalance);
+        require(weth.balanceOf(alice) == defaultBalance, "Precondition: wrong WETH balance");
+        require(alice.balance == defaultBalance, "Precondition: wrong ETH balance");
 
         bool wethIsEth = true;
 
@@ -471,14 +471,14 @@ contract RouterTest is BaseVaultTest {
             ""
         );
 
-        assertEq(weth.balanceOf(alice), defaultBalance);
-        assertEq(dai.balanceOf(alice), defaultBalance + daiAmountOut);
-        assertEq(alice.balance, defaultBalance - daiAmountOut);
+        assertEq(weth.balanceOf(alice), defaultBalance, "Wrong WETH balance");
+        assertEq(dai.balanceOf(alice), defaultBalance + daiAmountOut, "Wrong DAI balance");
+        assertEq(alice.balance, defaultBalance - daiAmountOut, "Wrong ETH balance");
     }
 
     function testSwapNativeExcessEth() public {
-        require(weth.balanceOf(alice) == defaultBalance);
-        require(alice.balance == defaultBalance);
+        require(weth.balanceOf(alice) == defaultBalance, "Precondition: wrong WETH balance");
+        require(alice.balance == defaultBalance, "Precondition: wrong ETH balance");
 
         bool wethIsEth = true;
 
@@ -495,9 +495,9 @@ contract RouterTest is BaseVaultTest {
         );
 
         // Only ethAmountIn is sent to the router
-        assertEq(weth.balanceOf(alice), defaultBalance);
-        assertEq(dai.balanceOf(alice), defaultBalance + ethAmountIn);
-        assertEq(alice.balance, defaultBalance - ethAmountIn);
+        assertEq(weth.balanceOf(alice), defaultBalance, "Wrong WETH balance");
+        assertEq(dai.balanceOf(alice), defaultBalance + ethAmountIn, "Wrong DAI balance");
+        assertEq(alice.balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
     }
 
     function testGetSingleInputArray() public {
@@ -522,13 +522,13 @@ contract RouterTest is BaseVaultTest {
     }
 
     function checkRemoveLiquidityPreConditions() internal view {
-        require(weth.balanceOf(alice) == defaultBalance, "Wrong WETH balance");
-        require(wethPool.balanceOf(alice) == bptAmountOut, "Wrong weth pool balance");
+        require(weth.balanceOf(alice) == defaultBalance, "Precondition: Wrong WETH balance");
+        require(wethPool.balanceOf(alice) == bptAmountOut, "Precondition: Wrong weth pool balance");
     }
 
     function checkAddLiquidityPreConditions() internal view {
-        require(weth.balanceOf(alice) == defaultBalance, "Wrong WETH balance");
-        require(alice.balance == defaultBalance, "Wrong ETH balance");
-        require(wethPool.balanceOf(alice) == 0, "Wrong weth pool balance");
+        require(weth.balanceOf(alice) == defaultBalance, "Precondition: Wrong WETH balance");
+        require(alice.balance == defaultBalance, "Precondition: Wrong ETH balance");
+        require(wethPool.balanceOf(alice) == 0, "Precondition: Wrong weth pool balance");
     }
 }

--- a/pkg/vault/test/foundry/VaultFactory.t.sol
+++ b/pkg/vault/test/foundry/VaultFactory.t.sol
@@ -41,8 +41,8 @@ contract VaultFactoryTest is Test {
 
         (bool isPaused, uint256 pauseWindowEndTime, uint256 bufferWindowEndTime) = vault.getVaultPausedState();
         assertEq(isPaused, false);
-        assertEq(pauseWindowEndTime, block.timestamp + 90 days);
-        assertEq(bufferWindowEndTime, block.timestamp + 90 days + 30 days);
+        assertEq(pauseWindowEndTime, block.timestamp + 90 days, "Wrong pause window end time");
+        assertEq(bufferWindowEndTime, block.timestamp + 90 days + 30 days, "Wrong buffer window end time");
     }
 
     function testCreateNotAuthorized() public {

--- a/pkg/vault/test/foundry/VaultLiquidity.t.sol
+++ b/pkg/vault/test/foundry/VaultLiquidity.t.sol
@@ -150,8 +150,8 @@ contract VaultLiquidityTest is BaseVaultTest {
         snapEnd();
 
         // amountsOut are correct
-        assertEq(amountsOut[0], defaultAmount);
-        assertEq(amountsOut[1], defaultAmount);
+        assertEq(amountsOut[0], defaultAmount, "Wrong AmountOut[0]");
+        assertEq(amountsOut[1], defaultAmount, "Wrong AmountOut[1]");
     }
 
     function testRemoveLiquidityProportional() public {
@@ -175,8 +175,8 @@ contract VaultLiquidityTest is BaseVaultTest {
         (amountsOut, ) = router.getSingleInputArrayAndTokenIndex(pool, dai, amountOut);
 
         // amountsOut are correct
-        assertEq(amountsOut[0], defaultAmount);
-        assertEq(amountsOut[1], 0);
+        assertEq(amountsOut[0], defaultAmount, "Wrong AmountOut[0]");
+        assertEq(amountsOut[1], 0, "AmountOut[1] > 0");
     }
 
     function testRemoveLiquiditySingleTokenExactIn() public {
@@ -212,8 +212,8 @@ contract VaultLiquidityTest is BaseVaultTest {
         );
 
         // amountsOut are correct
-        assertEq(amountsOut[0], defaultAmount);
-        assertEq(amountsOut[1], defaultAmount);
+        assertEq(amountsOut[0], defaultAmount, "Wrong AmountOut[0]");
+        assertEq(amountsOut[1], defaultAmount, "Wrong AmountOut[1]");
     }
 
     function testRemoveLiquidityCustom() public {

--- a/pkg/vault/test/foundry/VaultSwapRate.t.sol
+++ b/pkg/vault/test/foundry/VaultSwapRate.t.sol
@@ -58,8 +58,8 @@ contract VaultSwapWithRatesTest is BaseVaultTest {
     function testInitialRateProviderState() public {
         (, , , , IRateProvider[] memory rateProviders) = vault.getPoolTokenInfo(address(pool));
 
-        assertEq(address(rateProviders[0]), address(rateProvider));
-        assertEq(address(rateProviders[1]), address(0));
+        assertEq(address(rateProviders[0]), address(rateProvider), "Wrong rate provider");
+        assertEq(address(rateProviders[1]), address(0), "Rate provider should be 0");
     }
 
     function testSwapGivenInWithRate() public {


### PR DESCRIPTION
# Description

In reviewing new tests added to yield-fees, I noticed we were not consistently using messages on test assertions. I don't think they're needed on every single test. Some are really trivial and unlikely to fail. But they should at least be numerical tests that could fail. This also calls out preconditions (which we should also use more explicitly and frequently).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

