### PR TITLE
Expose Vault's reentrancy guard

### DIFF
--- a/pkg/interfaces/contracts/test/IVaultMainMock.sol
+++ b/pkg/interfaces/contracts/test/IVaultMainMock.sol
@@ -50,4 +50,8 @@ interface IVaultMainMock {
         uint256 tokenIndex,
         uint256 yieldFeePercentage
     ) external pure returns (uint256);
+
+    function guardedCheckEntered() external;
+
+    function unguardedCheckNotEntered() external view;
 }

--- a/pkg/vault/contracts/VaultCommon.sol
+++ b/pkg/vault/contracts/VaultCommon.sol
@@ -55,6 +55,14 @@ abstract contract VaultCommon is IVaultEvents, IVaultErrors, VaultStorage, Reent
     }
 
     /**
+     * @notice Expose the state of the Vault's reentrancy guard.
+     * @return True if the Vault is currently executing a nonReentrant function
+     */
+    function reentrancyGuardEntered() public view returns (bool) {
+        return _reentrancyGuardEntered();
+    }
+
+    /**
      * @notice Records the `debt` for a given handler and token.
      * @param token   The ERC20 token for which the `debt` will be accounted.
      * @param debt    The amount of `token` taken from the Vault in favor of the `handler`.

--- a/pkg/vault/contracts/test/VaultMock.sol
+++ b/pkg/vault/contracts/test/VaultMock.sol
@@ -154,4 +154,12 @@ contract VaultMock is IVaultMainMock, Vault {
             (, lastLiveBalances[i]) = poolTokenBalances.unchecked_at(i);
         }
     }
+
+    function guardedCheckEntered() external nonReentrant {
+        require(reentrancyGuardEntered());
+    }
+
+    function unguardedCheckNotEntered() external view {
+        require(!reentrancyGuardEntered());
+    }
 }

--- a/pkg/vault/test/Vault.test.ts
+++ b/pkg/vault/test/Vault.test.ts
@@ -547,4 +547,14 @@ describe('Vault', function () {
       });
     });
   });
+
+  describe('reentrancy guard state', () => {
+    it('reentrancy guard should be false when not in Vault context', async () => {
+      expect(await vault.unguardedCheckNotEntered()).to.not.be.reverted;
+    });
+
+    it('reentrancy guard should be true when in Vault context', async () => {
+      expect(await vault.guardedCheckEntered()).to.not.be.reverted;
+    });
+  });
 });


### PR DESCRIPTION
# Description

This oversight in V2 caused us to really go through contortions (i.e., two versions of a VaultReentrancyLib) to determine whether the Vault had been entered. Now we can simply ask.

Thankfully OZ already provided an internal interface for this, so we can continue to inherit their implementation.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #207 
