### PR TITLE
Optimize modifiers

### DIFF
--- a/pkg/vault/contracts/BalancerPoolToken.sol
+++ b/pkg/vault/contracts/BalancerPoolToken.sol
@@ -35,10 +35,14 @@ contract BalancerPoolToken is IERC20, IERC20Metadata, IERC20Permit, EIP712, Nonc
     string private _symbol;
 
     modifier onlyVault() {
+        _ensureOnlyVault();
+        _;
+    }
+
+    function _ensureOnlyVault() private view {
         if (msg.sender != address(_vault)) {
             revert IVaultErrors.SenderIsNotVault(msg.sender);
         }
-        _;
     }
 
     constructor(IVault vault_, string memory name_, string memory symbol_) EIP712(name_, "1") {

--- a/pkg/vault/contracts/Router.sol
+++ b/pkg/vault/contracts/Router.sol
@@ -35,10 +35,14 @@ contract Router is IRouter, ReentrancyGuard {
     mapping(address => uint256) private _currentSwapTokenOutAmounts;
 
     modifier onlyVault() {
+        _ensureOnlyVault();
+        _;
+    }
+
+    function _ensureOnlyVault() private view {
         if (msg.sender != address(_vault)) {
             revert IVaultErrors.SenderIsNotVault(msg.sender);
         }
-        _;
     }
 
     constructor(IVault vault, IWETH weth) {


### PR DESCRIPTION
# Description

Inspired by Juani's refactor of the `withHandler` modifier to save 600 bytes, I checked the rest of the codebase and saw the Router and BalancerPoolToken could use the same treatment. (Technically, transient and query as well, but they are only used once, so it would probably *add* bytecode.)

Looks like the Router one saves 900 bytes, and the BalancerPoolToken one about 100 (minor, but might help a bit with new pools).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
