### PR TITLE
Alternative version to sort addresses and tokens

### DIFF
--- a/pkg/pool-weighted/test/WeightedPool.test.ts
+++ b/pkg/pool-weighted/test/WeightedPool.test.ts
@@ -22,7 +22,7 @@ import { actionId } from '@balancer-labs/v3-helpers/src/models/misc/actions';
 import { MONTH } from '@balancer-labs/v3-helpers/src/time';
 import { TokenConfig, TokenType } from '@balancer-labs/v3-helpers/src/models/types/types';
 import * as expectEvent from '@balancer-labs/v3-helpers/src/test/expectEvent';
-import { sortTokens } from '@balancer-labs/v3-helpers/src/models/tokens/sortingHelper';
+import { sortAddresses } from '@balancer-labs/v3-helpers/src/models/tokens/sortingHelper';
 
 describe('WeightedPool', function () {
   const MAX_PROTOCOL_SWAP_FEE = fp(0.5);
@@ -63,7 +63,7 @@ describe('WeightedPool', function () {
     tokenBAddress = await tokenB.getAddress();
     tokenCAddress = await tokenC.getAddress();
 
-    [poolTokens] = sortTokens([tokenAAddress, tokenBAddress, tokenCAddress]);
+    poolTokens = sortAddresses([tokenAAddress, tokenBAddress, tokenCAddress]);
 
     pool = await deploy('v3-vault/PoolMock', {
       args: [vault, 'Pool', 'POOL', buildTokenConfig(poolTokens), true, 365 * 24 * 3600, ZERO_ADDRESS],

--- a/pkg/vault/test/BatchSwap.test.ts
+++ b/pkg/vault/test/BatchSwap.test.ts
@@ -13,7 +13,7 @@ import { BalanceChange, expectBalanceChange } from '@balancer-labs/v3-helpers/sr
 import * as VaultDeployer from '@balancer-labs/v3-helpers/src/models/vault/VaultDeployer';
 import { ERC20TestToken } from '@balancer-labs/v3-solidity-utils/typechain-types';
 import { buildTokenConfig } from './poolSetup';
-import { sortTokens } from '@balancer-labs/v3-helpers/src/models/tokens/sortingHelper';
+import { sortAddresses, sortAddresses } from '@balancer-labs/v3-helpers/src/models/tokens/sortingHelper';
 
 describe('BatchSwap', function () {
   let vault: Vault;
@@ -45,9 +45,9 @@ describe('BatchSwap', function () {
     token0 = await tokens.get(0).getAddress();
     token1 = await tokens.get(1).getAddress();
     token2 = await tokens.get(2).getAddress();
-    [poolATokens] = sortTokens([token0, token1]);
-    [poolBTokens] = sortTokens([token1, token2]);
-    [poolCTokens] = sortTokens([token0, token2]);
+    poolATokens = sortAddresses([token0, token1]);
+    poolBTokens = sortAddresses([token1, token2]);
+    poolCTokens = sortAddresses([token0, token2]);
 
     // Pool A has tokens 0 and 1.
     poolA = await deploy('v3-vault/PoolMock', {
@@ -66,17 +66,17 @@ describe('BatchSwap', function () {
   });
 
   sharedBeforeEach('nested pools', async () => {
-    [poolABTokens] = sortTokens([await poolA.getAddress(), await poolB.getAddress()]);
+    poolABTokens = sortAddresses([await poolA.getAddress(), await poolB.getAddress()]);
     poolAB = await deploy('v3-vault/PoolMock', {
       args: [vaultAddress, 'Pool A-B', 'POOL-AB', buildTokenConfig(poolABTokens), true, 0, ZERO_ADDRESS],
     });
 
-    [poolACTokens] = sortTokens([await poolA.getAddress(), await poolC.getAddress()]);
+    poolACTokens = sortAddresses([await poolA.getAddress(), await poolC.getAddress()]);
     poolAC = await deploy('v3-vault/PoolMock', {
       args: [vaultAddress, 'Pool A-C', 'POOL-AC', buildTokenConfig(poolACTokens), true, 0, ZERO_ADDRESS],
     });
 
-    [poolBCTokens] = sortTokens([await poolB.getAddress(), await poolC.getAddress()]);
+    poolBCTokens = sortAddresses([await poolB.getAddress(), await poolC.getAddress()]);
     poolBC = await deploy('v3-vault/PoolMock', {
       args: [vaultAddress, 'Pool B-C', 'POOL-BC', buildTokenConfig(poolBCTokens), true, 0, ZERO_ADDRESS],
     });

--- a/pkg/vault/test/Vault.test.ts
+++ b/pkg/vault/test/Vault.test.ts
@@ -20,7 +20,7 @@ import * as expectEvent from '@balancer-labs/v3-helpers/src/test/expectEvent';
 import TypesConverter from '@balancer-labs/v3-helpers/src/models/types/TypesConverter';
 import { TokenType } from '@balancer-labs/v3-helpers/src/models/types/types';
 import { IVaultMock } from '@balancer-labs/v3-interfaces/typechain-types';
-import { sortTokens } from '@balancer-labs/v3-helpers/src/models/tokens/sortingHelper';
+import { sortAddresses } from '@balancer-labs/v3-helpers/src/models/tokens/sortingHelper';
 
 describe('Vault', function () {
   const PAUSE_WINDOW_DURATION = MONTH * 3;
@@ -71,10 +71,10 @@ describe('Vault', function () {
     poolBAddress = await poolB.getAddress();
 
     const tokenCAddress = await tokenC.getAddress();
-    [poolATokens] = sortTokens([tokenAAddress, tokenBAddress, tokenCAddress]);
-    [poolBTokens] = sortTokens([tokenAAddress, tokenCAddress]);
-    [invalidTokens] = sortTokens([tokenAAddress, ZERO_ADDRESS, tokenCAddress]);
-    [duplicateTokens] = sortTokens([tokenAAddress, tokenBAddress, tokenAAddress]);
+    poolATokens = sortAddresses([tokenAAddress, tokenBAddress, tokenCAddress]);
+    poolBTokens = sortAddresses([tokenAAddress, tokenCAddress]);
+    invalidTokens = sortAddresses([tokenAAddress, ZERO_ADDRESS, tokenCAddress]);
+    duplicateTokens = sortAddresses([tokenAAddress, tokenBAddress, tokenAAddress]);
 
     // Copy and reverse A tokens.
     unsortedTokens = Array.from(poolATokens);
@@ -163,7 +163,7 @@ describe('Vault', function () {
       const poolBTokensWithItself = Array.from(poolBTokens);
       poolBTokensWithItself.push(poolBAddress);
 
-      const [finalTokens] = sortTokens(poolBTokensWithItself);
+      const finalTokens = sortAddresses(poolBTokensWithItself);
 
       await expect(vault.manualRegisterPool(poolB, finalTokens)).to.be.revertedWithCustomError(
         vaultExtension,

--- a/pkg/vault/test/poolSetup.ts
+++ b/pkg/vault/test/poolSetup.ts
@@ -4,7 +4,7 @@ import { VaultMock } from '../typechain-types/contracts/test/VaultMock';
 import { ERC20TestToken } from '@balancer-labs/v3-solidity-utils/typechain-types/contracts/test/ERC20TestToken';
 import { PoolMock } from '@balancer-labs/v3-vault/typechain-types/contracts/test/PoolMock';
 import { ZERO_ADDRESS } from '@balancer-labs/v3-helpers/src/constants';
-import { sortTokens } from '@balancer-labs/v3-helpers/src/models/tokens/sortingHelper';
+import { sortAddresses } from '@balancer-labs/v3-helpers/src/models/tokens/sortingHelper';
 import * as VaultDeployer from '@balancer-labs/v3-helpers/src/models/vault/VaultDeployer';
 import { IVaultMock } from '@balancer-labs/v3-interfaces/typechain-types';
 import TypesConverter from '@balancer-labs/v3-helpers/src/models/types/TypesConverter';
@@ -34,8 +34,8 @@ export async function setupEnvironment(pauseWindowDuration: number): Promise<{
   const tokenBAddress = await tokenB.getAddress();
   const tokenCAddress = await tokenC.getAddress();
 
-  const [poolATokens] = sortTokens([tokenAAddress, tokenBAddress, tokenCAddress]);
-  const [poolBTokens] = sortTokens([tokenAAddress, tokenCAddress]);
+  const poolATokens = sortAddresses([tokenAAddress, tokenBAddress, tokenCAddress]);
+  const poolBTokens = sortAddresses([tokenAAddress, tokenCAddress]);
 
   const poolA: PoolMock = await deploy('v3-vault/PoolMock', {
     args: [vaultAddress, 'Pool A', 'POOLA', buildTokenConfig(poolATokens), true, 365 * 24 * 3600, ZERO_ADDRESS],

--- a/pvt/helpers/src/models/tokens/ERC20TokenList.ts
+++ b/pvt/helpers/src/models/tokens/ERC20TokenList.ts
@@ -9,8 +9,9 @@ import {
   TokenMint,
   TokensDeploymentOptions,
 } from './types';
-import { ERC20TestToken, ERC20TestToken__factory } from '@balancer-labs/v3-solidity-utils/typechain-types';
+import { ERC20TestToken } from '@balancer-labs/v3-solidity-utils/typechain-types';
 import { AddressLike } from 'ethers';
+import { sortTokens } from './sortingHelper';
 
 export const ETH_TOKEN_ADDRESS = ZERO_ADDRESS;
 
@@ -165,10 +166,7 @@ export default class ERC20TokenList {
   }
 
   async sort(): Promise<ERC20TokenList> {
-    const addresses = (await Promise.all(this.tokens.map((token) => token.getAddress()))).sort((addressA, addressB) =>
-      addressA.toLowerCase() > addressB.toLowerCase() ? 1 : -1
-    );
-    return new ERC20TokenList(await Promise.all(addresses.map((address) => ERC20TestToken__factory.connect(address))));
+    return new ERC20TokenList((await sortTokens(this.tokens)) as unknown as ERC20TestToken[]);
   }
 
   async scaledBalances(rawBalance: () => number): Promise<bigint[]> {

--- a/pvt/helpers/src/models/tokens/ERC20TokensDeployer.ts
+++ b/pvt/helpers/src/models/tokens/ERC20TokensDeployer.ts
@@ -6,7 +6,6 @@ import ERC20TokenList from './ERC20TokenList';
 import TypesConverter from '../types/TypesConverter';
 import { RawTokenDeployment, RawTokensDeployment, TokenDeployment, TokensDeploymentOptions } from './types';
 import { ERC20TestToken } from '@balancer-labs/v3-solidity-utils/typechain-types';
-import { sortTokens } from './sortingHelper';
 
 class ERC20TokensDeployer {
   async deploy(
@@ -21,14 +20,13 @@ class ERC20TokensDeployer {
       varyDecimals
     );
     const tokens = await Promise.all(deployments.map(this.deployToken));
+    let tokenList = new ERC20TokenList(tokens);
 
     if (sorted) {
-      const [, finalTokens] = sortTokens(await Promise.all(tokens.map((token) => token.getAddress())), tokens);
-
-      return new ERC20TokenList(finalTokens as ERC20TestToken[]);
+      tokenList = await tokenList.sort();
     }
 
-    return new ERC20TokenList(tokens);
+    return tokenList;
   }
 
   async deployToken(params: RawTokenDeployment): Promise<ERC20TestToken> {

--- a/pvt/helpers/src/models/tokens/sortingHelper.ts
+++ b/pvt/helpers/src/models/tokens/sortingHelper.ts
@@ -1,18 +1,15 @@
-function assert(condition: boolean, error: string): asserts condition {
-  if (!condition) throw new Error(error);
+import { BaseContract } from 'ethers';
+
+const cmpAddresses = (tokenA: string, tokenB: string): number => (tokenA.toLowerCase() > tokenB.toLowerCase() ? 1 : -1);
+
+export function sortAddresses(tokens: string[]): string[] {
+  return tokens.sort((tokenA, tokenB) => cmpAddresses(tokenA, tokenB));
 }
 
-const cmpTokens = (tokenA: string, tokenB: string): number => (tokenA.toLowerCase() > tokenB.toLowerCase() ? 1 : -1);
-
-const transposeMatrix = (matrix: unknown[][]): unknown[][] =>
-  matrix[0].map((_, columnIndex) => matrix.map((row) => row[columnIndex]));
-
-export function sortTokens(tokens: string[], ...others: unknown[][]): [string[], ...unknown[][]] {
-  others.forEach((array) => assert(tokens.length === array.length, 'array length mismatch'));
-
-  const transpose = transposeMatrix([tokens, ...others]) as [string, ...unknown[]][];
-  const sortedTranspose = transpose.sort(([tokenA], [tokenB]) => cmpTokens(tokenA, tokenB));
-  const [sortedTokens, ...sortedOthers] = transposeMatrix(sortedTranspose) as [string[], ...unknown[][]];
-
-  return [sortedTokens, ...sortedOthers];
+export async function sortTokens(tokens: BaseContract[]): Promise<BaseContract[]> {
+  const sortableArray = (await Promise.all(
+    tokens.map(async (token) => [await token.getAddress(), token])
+  )) as unknown as [string, BaseContract][];
+  const sortedArray = sortableArray.sort((a, b) => (a[0].toLowerCase() > b[0].toLowerCase() ? 1 : -1));
+  return sortedArray.map((x) => x[1]);
 }


### PR DESCRIPTION
# Description

Suggestion to simplify token ordering.
Namely:
- `sortAddresses` is a one liner that works with plain addresses, and returns an array directly.
- `sortTokens` works for any contract that can get the address asynchronously.

In any case you get an array directly and we minimize the weird `unknown[][]` castings. In general `sortAddresses` should work in most cases, and whenever there's something async we can use `sortTokens`.

On top of #353.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A