### PR TITLE
Comments reword: `wethIsEth` for swaps

### DIFF
--- a/pkg/interfaces/contracts/vault/IBatchRouter.sol
+++ b/pkg/interfaces/contracts/vault/IBatchRouter.sol
@@ -61,7 +61,7 @@ interface IBatchRouter {
      * @notice Executes a swap operation involving multiple paths (steps), specifying exact input token amounts.
      * @param paths Swap paths from token in to token out, specifying exact amounts in.
      * @param deadline Deadline for the swap
-     * @param wethIsEth If true, incoming ETH will be wrapped to WETH; otherwise the Vault will pull WETH tokens
+     * @param wethIsEth If true, incoming ETH will be wrapped to WETH and outgoing WETH will be unwrapped to ETH.
      * @param userData Additional (optional) data required for the swap
      * @return pathAmountsOut Calculated amounts of output tokens corresponding to the last step of each given path
      * @return tokensOut Calculated output token addresses
@@ -81,7 +81,7 @@ interface IBatchRouter {
      * @notice Executes a swap operation involving multiple paths (steps), specifying exact output token amounts.
      * @param paths Swap paths from token in to token out, specifying exact amounts out
      * @param deadline Deadline for the swap
-     * @param wethIsEth If true, incoming ETH will be wrapped to WETH; otherwise the Vault will pull WETH tokens
+     * @param wethIsEth If true, incoming ETH will be wrapped to WETH and outgoing WETH will be unwrapped to ETH.
      * @param userData Additional (optional) data required for the swap
      * @return pathAmountsIn Calculated amounts of input tokens corresponding to the first step of each given path
      * @return tokensIn Calculated input token addresses

--- a/pkg/interfaces/contracts/vault/IRouter.sol
+++ b/pkg/interfaces/contracts/vault/IRouter.sol
@@ -286,7 +286,7 @@ interface IRouter {
      * @param amountGiven Amount given based on kind of the swap (e.g., tokenIn for exact in)
      * @param limit Maximum or minimum amount based on the kind of swap (e.g., maxAmountIn for exact out)
      * @param deadline Deadline for the swap
-     * @param wethIsEth If true, incoming ETH will be wrapped to WETH; otherwise the Vault will pull WETH tokens
+     * @param wethIsEth If true, incoming ETH will be wrapped to WETH and outgoing WETH will be unwrapped to ETH.
      * @param userData Additional (optional) data required for the swap
      */
     struct SwapSingleTokenHookParams {
@@ -330,7 +330,7 @@ interface IRouter {
      * @param minAmountOut Minimum amount of tokens to be received
      * @param deadline Deadline for the swap
      * @param userData Additional (optional) data required for the swap
-     * @param wethIsEth If true, incoming ETH will be wrapped to WETH; otherwise the Vault will pull WETH tokens
+     * @param wethIsEth If true, incoming ETH will be wrapped to WETH and outgoing WETH will be unwrapped to ETH.
      * @return amountOut Calculated amount of output tokens to be received in exchange for the given input tokens
      */
     function swapSingleTokenExactIn(
@@ -353,7 +353,7 @@ interface IRouter {
      * @param maxAmountIn Maximum amount of tokens to be sent
      * @param deadline Deadline for the swap
      * @param userData Additional (optional) data required for the swap
-     * @param wethIsEth If true, incoming ETH will be wrapped to WETH; otherwise the Vault will pull WETH tokens
+     * @param wethIsEth If true, incoming ETH will be wrapped to WETH and outgoing WETH will be unwrapped to ETH.
      * @return amountIn Calculated amount of input tokens to be sent in exchange for the requested output tokens
      */
     function swapSingleTokenExactOut(


### PR DESCRIPTION
# Description

WETH can either be an input or an output for swaps, and the comments weren't reflecting that accordingly.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A