### PR TITLE
Fix testPermit__Fuzz test

### DIFF
--- a/pkg/vault/test/foundry/BalancerPoolTokenTest.t.sol
+++ b/pkg/vault/test/foundry/BalancerPoolTokenTest.t.sol
@@ -240,9 +240,12 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     function testPermit__Fuzz(uint248 privKey, address to, uint256 amount, uint256 deadline) public {
         deadline = bound(deadline, block.timestamp, MAX_UINT256);
         vm.assume(privKey != 0);
-        vm.assume(to != address(0));
 
         address usr = vm.addr(privKey);
+
+        vm.assume(to != address(0));
+        vm.assume(to != address(usr));
+        vm.assume(to != address(vault));
 
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(
             privKey,


### PR DESCRIPTION
# Description

Fix testPermit fuzzing test.
Looks like foundry is not that random when picking up addresses to send to fuzzing tests.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #367 
