### PR TITLE
Remove trusted router check from recovery mode exit

### DIFF
--- a/pkg/vault/contracts/VaultExtension.sol
+++ b/pkg/vault/contracts/VaultExtension.sol
@@ -554,10 +554,8 @@ contract VaultExtension is IVaultExtension, VaultCommon, Proxy {
             poolBalances.unchecked_setAt(i, packedBalances.setRawBalance(balancesRaw[i]));
         }
 
-        // Trusted routers use Vault's allowances, which are infinite anyways for pool tokens.
-        if (!_isTrustedRouter(msg.sender)) {
-            _spendAllowance(address(pool), from, msg.sender, exactBptAmountIn);
-        }
+        // If allowance is max (or if it's a trusted router) this will have no effect.
+        _spendAllowance(address(pool), from, msg.sender, exactBptAmountIn);
 
         // When removing liquidity, we must burn tokens concurrently with updating pool balances,
         // as the pool's math relies on totalSupply.


### PR DESCRIPTION
# Description

Checking for trusted routers before spending allowance is just an 'optimization' (which may end up not being convenient if we actually implement trusted routers), as spending allowance in that case is unnecessary.

In any case, in recovery mode we should minimize the code as much as possible rather than optimizing anything.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A