### PR TITLE
Remove unused function from PackedTokenBalance

### DIFF
--- a/pkg/vault/contracts/lib/PackedTokenBalance.sol
+++ b/pkg/vault/contracts/lib/PackedTokenBalance.sol
@@ -44,11 +44,6 @@ library PackedTokenBalance {
         return toPackedBalance(newRawBalance, getLastLiveBalanceScaled18(balance));
     }
 
-    /// @dev Replace a raw balance value, without modifying the live balance. TODO: remove? only used in tests.
-    function setLastLiveBalanceScaled18(bytes32 balance, uint256 newLastLiveBalance) internal pure returns (bytes32) {
-        return toPackedBalance(getRawBalance(balance), newLastLiveBalance);
-    }
-
     /// @dev Packs together `rawBalance` and `lastLiveBalanceScaled18` amounts to create a balance value.
     function toPackedBalance(uint256 balanceRaw, uint256 balanceLastLiveScaled18) internal pure returns (bytes32) {
         if (balanceRaw > _MAX_BALANCE || balanceLastLiveScaled18 > _MAX_BALANCE) {

--- a/pkg/vault/test/foundry/PackedTokenBalance.t.sol
+++ b/pkg/vault/test/foundry/PackedTokenBalance.t.sol
@@ -37,15 +37,6 @@ contract PackedTokenBalanceTest is Test {
 
         assertEq(newRecoveredRaw, newBalanceValue);
         assertEq(newRecoveredLive, recoveredLive);
-
-        // Set new live balance (should not change raw).
-        newBalance = PackedTokenBalance.setLastLiveBalanceScaled18(balance, newBalanceValue);
-
-        newRecoveredRaw = PackedTokenBalance.getRawBalance(newBalance);
-        newRecoveredLive = PackedTokenBalance.getLastLiveBalanceScaled18(newBalance);
-
-        assertEq(newRecoveredRaw, recoveredRaw);
-        assertEq(newRecoveredLive, newBalanceValue);
     }
 
     function testOverflow__Fuzz(bytes32 balance, uint128 validBalanceValue, uint256 overMaxBalanceValue) public {
@@ -59,8 +50,5 @@ contract PackedTokenBalanceTest is Test {
 
         vm.expectRevert(PackedTokenBalance.BalanceOverflow.selector);
         PackedTokenBalance.setRawBalance(balance, overMaxBalanceValue);
-
-        vm.expectRevert(PackedTokenBalance.BalanceOverflow.selector);
-        PackedTokenBalance.setLastLiveBalanceScaled18(balance, overMaxBalanceValue);
     }
 }


### PR DESCRIPTION
# Description

PackedTokenBalance stores both the raw and last live balances for a token. They are tightly coupled (i.e., every time we change the raw we will change the live), but we will never set the live balances independently. The library function to do so was only used in tests, and since it doesn't really makes sense (and costs bytecode), just remove it.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #432 
