### PR TITLE
Buffer pools can use proportional add

### DIFF
--- a/pkg/vault/contracts/ERC4626BufferPool.sol
+++ b/pkg/vault/contracts/ERC4626BufferPool.sol
@@ -18,7 +18,6 @@ import {
     SwapKind
 } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 import { IRateProvider } from "@balancer-labs/v3-interfaces/contracts/vault/IRateProvider.sol";
-import { IPoolLiquidity } from "@balancer-labs/v3-interfaces/contracts/vault/IPoolLiquidity.sol";
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 
 import { BasePoolMath } from "@balancer-labs/v3-solidity-utils/contracts/math/BasePoolMath.sol";
@@ -34,7 +33,6 @@ contract ERC4626BufferPool is
     IBasePool,
     IBufferPool,
     IRateProvider,
-    IPoolLiquidity,
     BalancerPoolToken,
     BasePoolHooks,
     BasePoolAuthentication,
@@ -118,34 +116,7 @@ contract ERC4626BufferPool is
         uint256[] memory,
         bytes memory
     ) external view override onlyVault returns (bool) {
-        // Only support custom add liquidity.
-        return kind == AddLiquidityKind.CUSTOM;
-    }
-
-    /// @inheritdoc IPoolLiquidity
-    function onAddLiquidityCustom(
-        address,
-        uint256[] memory,
-        uint256 exactBptAmountOut,
-        uint256[] memory balancesScaled18,
-        bytes memory
-    )
-        external
-        view
-        onlyVault
-        returns (
-            uint256[] memory amountsInScaled18,
-            uint256 bptAmountOut,
-            uint256[] memory swapFeeAmountsScaled18,
-            bytes memory returnData
-        )
-    {
-        // This is a proportional join
-        bptAmountOut = exactBptAmountOut;
-        returnData = "";
-
-        amountsInScaled18 = BasePoolMath.computeProportionalAmountsIn(balancesScaled18, totalSupply(), bptAmountOut);
-        swapFeeAmountsScaled18 = new uint256[](balancesScaled18.length);
+        return kind == AddLiquidityKind.PROPORTIONAL;
     }
 
     /// @inheritdoc BasePoolHooks
@@ -505,18 +476,6 @@ contract ERC4626BufferPool is
     ) external pure returns (uint256) {
         // This pool doesn't support single token add/remove liquidity, so this function is not needed.
         // Should never get here, but need to implement the interface.
-        revert IVaultErrors.OperationNotSupported();
-    }
-
-    /// @inheritdoc IPoolLiquidity
-    function onRemoveLiquidityCustom(
-        address,
-        uint256,
-        uint256[] memory,
-        uint256[] memory,
-        bytes memory
-    ) external pure returns (uint256, uint256[] memory, uint256[] memory, bytes memory) {
-        // Should throw `DoesNotSupportRemoveLiquidityCustom` before getting here, but need to implement the interface.
         revert IVaultErrors.OperationNotSupported();
     }
 }

--- a/pkg/vault/contracts/factories/ERC4626BufferPoolFactory.sol
+++ b/pkg/vault/contracts/factories/ERC4626BufferPoolFactory.sol
@@ -125,7 +125,7 @@ contract ERC4626BufferPoolFactory is BasePoolFactory {
         return
             LiquidityManagement({
                 disableUnbalancedLiquidity: false,
-                enableAddLiquidityCustom: true,
+                enableAddLiquidityCustom: false,
                 enableRemoveLiquidityCustom: false
             });
     }

--- a/pkg/vault/test/ERC4626BufferPool.test.ts
+++ b/pkg/vault/test/ERC4626BufferPool.test.ts
@@ -137,7 +137,7 @@ describe('ERC4626BufferPool', function () {
       expect(poolConfig.hooks.shouldCallBeforeSwap).to.be.true;
       expect(poolConfig.hooks.shouldCallAfterSwap).to.be.false;
       expect(poolConfig.liquidityManagement.disableUnbalancedLiquidity).to.be.false;
-      expect(poolConfig.liquidityManagement.enableAddLiquidityCustom).to.be.true;
+      expect(poolConfig.liquidityManagement.enableAddLiquidityCustom).to.be.false;
       expect(poolConfig.liquidityManagement.enableRemoveLiquidityCustom).to.be.false;
     });
   });
@@ -266,7 +266,7 @@ describe('ERC4626BufferPool', function () {
       });
     });
 
-    it('can add liquidity custom', async () => {
+    it('can add liquidity proportional', async () => {
       await baseToken.mint(bob, 2n * (TOKEN_AMOUNT + MIN_BPT));
       await baseToken.connect(bob).approve(wrappedToken, TOKEN_AMOUNT + MIN_BPT);
       await wrappedToken.connect(bob).deposit(TOKEN_AMOUNT + MIN_BPT, bob);
@@ -277,7 +277,7 @@ describe('ERC4626BufferPool', function () {
       const bptAmount = await pool.balanceOf(alice);
       const MAX_AMOUNT = TOKEN_AMOUNT + MIN_BPT;
 
-      await router.connect(bob).addLiquidityCustom(pool, [MAX_AMOUNT, MAX_AMOUNT], bptAmount, false, '0x');
+      await router.connect(bob).addLiquidityProportional(pool, [MAX_AMOUNT, MAX_AMOUNT], bptAmount, false, '0x');
 
       // Should withdraw almost all. Contrived test to ensure proportional amounts in calculated correctly.
       expect(await baseToken.balanceOf(bob)).to.equal((MIN_BPT * 3n) / 2n);


### PR DESCRIPTION
# Description

Buffer pools currently use custom add liquidity to implement proportional join, since at the time we wrote them, there was no proportional add liquidity. Now that there is, we can simplify buffer pools by using it.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

