### PR TITLE
refactor: iterate over cached length within `for` loops

### DIFF
--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -41,13 +41,14 @@ contract WeightedPool is IBasePool, IMinimumSwapFee, BalancerPoolToken {
     error NormalizedWeightInvariant();
 
     constructor(NewPoolParams memory params, IVault vault) BalancerPoolToken(vault, params.name, params.symbol) {
-        InputHelpers.ensureInputLengthMatch(params.numTokens, params.normalizedWeights.length);
+        uint256 numTokens = params.numTokens;
+        InputHelpers.ensureInputLengthMatch(numTokens, params.normalizedWeights.length);
 
-        _totalTokens = params.numTokens;
+        _totalTokens = numTokens;
 
         // Ensure each normalized weight is above the minimum
         uint256 normalizedSum = 0;
-        for (uint8 i = 0; i < params.numTokens; ++i) {
+        for (uint8 i = 0; i < numTokens; ++i) {
             uint256 normalizedWeight = params.normalizedWeights[i];
 
             if (normalizedWeight < WeightedMath._MIN_WEIGHT) {
@@ -63,8 +64,8 @@ contract WeightedPool is IBasePool, IMinimumSwapFee, BalancerPoolToken {
         // Immutable variables cannot be initialized inside an if statement, so we must do conditional assignments
         _normalizedWeight0 = params.normalizedWeights[0];
         _normalizedWeight1 = params.normalizedWeights[1];
-        _normalizedWeight2 = params.numTokens > 2 ? params.normalizedWeights[2] : 0;
-        _normalizedWeight3 = params.numTokens > 3 ? params.normalizedWeights[3] : 0;
+        _normalizedWeight2 = numTokens > 2 ? params.normalizedWeights[2] : 0;
+        _normalizedWeight3 = numTokens > 3 ? params.normalizedWeights[3] : 0;
     }
 
     /// @inheritdoc IBasePool

--- a/pkg/solidity-utils/contracts/math/BasePoolMath.sol
+++ b/pkg/solidity-utils/contracts/math/BasePoolMath.sol
@@ -44,6 +44,7 @@ library BasePoolMath {
 
         uint256 bptRatio = bptAmountOut.divUp(bptTotalSupply);
 
+        // Create a new array to hold the amounts of each token to be deposited.
         amountsIn = new uint256[](balances.length);
         for (uint256 i = 0; i < balances.length; ++i) {
             amountsIn[i] = balances[i].mulUp(bptRatio);
@@ -83,6 +84,7 @@ library BasePoolMath {
 
         uint256 bptRatio = bptAmountIn.divDown(bptTotalSupply);
 
+        // Create a new array to hold the amounts of each token to be withdrawn.
         amountsOut = new uint256[](balances.length);
         for (uint256 i = 0; i < balances.length; ++i) {
             amountsOut[i] = balances[i].mulDown(bptRatio);
@@ -248,7 +250,7 @@ library BasePoolMath {
         uint256[] memory newBalances = new uint256[](numTokens);
 
         // Copy currentBalances to newBalances
-        for (uint256 i = 0; i < currentBalances.length; ++i) {
+        for (uint256 i = 0; i < numTokens; ++i) {
             newBalances[i] = currentBalances[i];
         }
 

--- a/pkg/solidity-utils/contracts/math/StableMath.sol
+++ b/pkg/solidity-utils/contracts/math/StableMath.sol
@@ -181,23 +181,24 @@ library StableMath {
         // First loop calculates the sum of all token balances, which will be used to calculate
         // the current weights of each token, relative to this sum
         uint256 sumBalances = 0;
-        for (uint256 i = 0; i < balances.length; ++i) {
+        uint256 numTokens = balances.length;
+        for (uint256 i = 0; i < numTokens; ++i) {
             sumBalances += balances[i];
         }
 
         // Calculate the weighted balance ratio without considering fees
-        uint256[] memory balanceRatiosWithFee = new uint256[](amountsIn.length);
+        uint256[] memory balanceRatiosWithFee = new uint256[](numTokens);
         // The weighted sum of token balance ratios with fee
         uint256 invariantRatioWithFees = 0;
-        for (uint256 i = 0; i < balances.length; ++i) {
+        for (uint256 i = 0; i < numTokens; ++i) {
             uint256 currentWeight = balances[i].divDown(sumBalances);
             balanceRatiosWithFee[i] = (balances[i] + amountsIn[i]).divDown(balances[i]);
             invariantRatioWithFees = invariantRatioWithFees + (balanceRatiosWithFee[i].mulDown(currentWeight));
         }
 
         // Second loop calculates new amounts in, taking into account the fee on the percentage excess
-        uint256[] memory newBalances = new uint256[](balances.length);
-        for (uint256 i = 0; i < balances.length; ++i) {
+        uint256[] memory newBalances = new uint256[](numTokens);
+        for (uint256 i = 0; i < numTokens; ++i) {
             uint256 amountInWithoutFee;
 
             // Check if the balance ratio is greater than the ideal ratio to charge fees or not
@@ -275,22 +276,23 @@ library StableMath {
         // First loop calculates the sum of all token balances, which will be used to calculate
         // the current weights of each token relative to this sum
         uint256 sumBalances = 0;
-        for (uint256 i = 0; i < balances.length; ++i) {
+        uint256 numTokens = balances.length;
+        for (uint256 i = 0; i < numTokens; ++i) {
             sumBalances += balances[i];
         }
 
         // Calculate the weighted balance ratio without considering fees
-        uint256[] memory balanceRatiosWithoutFee = new uint256[](amountsOut.length);
+        uint256[] memory balanceRatiosWithoutFee = new uint256[](numTokens);
         uint256 invariantRatioWithoutFees = 0;
-        for (uint256 i = 0; i < balances.length; ++i) {
+        for (uint256 i = 0; i < numTokens; ++i) {
             uint256 currentWeight = balances[i].divUp(sumBalances);
             balanceRatiosWithoutFee[i] = (balances[i] - amountsOut[i]).divUp(balances[i]);
             invariantRatioWithoutFees = invariantRatioWithoutFees + (balanceRatiosWithoutFee[i].mulUp(currentWeight));
         }
 
         // Second loop calculates new amounts in, taking into account the fee on the percentage excess
-        uint256[] memory newBalances = new uint256[](balances.length);
-        for (uint256 i = 0; i < balances.length; ++i) {
+        uint256[] memory newBalances = new uint256[](numTokens);
+        for (uint256 i = 0; i < numTokens; ++i) {
             // Swap fees are typically charged on 'token in', but there is no 'token in' here, so we apply it to
             // 'token out'. This results in slightly larger price impact.
 
@@ -359,11 +361,12 @@ library StableMath {
         uint256 tokenIndex
     ) internal pure returns (uint256) {
         // Rounds result up overall
-        uint256 ampTimesTotal = amplificationParameter * balances.length;
+        uint256 numTokens = balances.length;
+        uint256 ampTimesTotal = amplificationParameter * numTokens;
         uint256 sum = balances[0];
-        uint256 P_D = balances[0] * balances.length;
-        for (uint256 j = 1; j < balances.length; ++j) {
-            P_D = (P_D * balances[j] * balances.length) / invariant;
+        uint256 P_D = balances[0] * numTokens;
+        for (uint256 j = 1; j < numTokens; ++j) {
+            P_D = (P_D * balances[j] * numTokens) / invariant;
             sum = sum + balances[j];
         }
         sum = sum - balances[tokenIndex];

--- a/pkg/vault/contracts/VaultAdmin.sol
+++ b/pkg/vault/contracts/VaultAdmin.sol
@@ -343,7 +343,8 @@ contract VaultAdmin is IVaultAdmin, VaultCommon, Authentication {
     /// @inheritdoc IVaultAdmin
     function collectPoolCreatorFees(address pool) external nonReentrant onlyVault {
         EnumerableMap.IERC20ToUint256Map storage poolCreatorFees = _poolCreatorFees[pool];
-        for (uint256 i = 0; i < poolCreatorFees.length(); ++i) {
+        uint256 numTokens = poolCreatorFees.length();
+        for (uint256 i = 0; i < numTokens; ++i) {
             (IERC20 token, uint256 amount) = poolCreatorFees.unchecked_at(i);
 
             if (amount > 0) {


### PR DESCRIPTION
# Description

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->
Cache the length of the array being compared to the iterator in a `for` loop in order to save gas. Cacheing is applied in case the `length` property is to be accessed three times or more within a same logic.

Further discussion about gas savings in `for` loops can be read in PR https://github.com/balancer/balancer-v3-monorepo/pull/476.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
Closes #475.
