### PR TITLE
Minor renaming to match "compute" vs. "calc" convention

### DIFF
--- a/pkg/solidity-utils/contracts/math/StableMath.sol
+++ b/pkg/solidity-utils/contracts/math/StableMath.sol
@@ -168,7 +168,7 @@ library StableMath {
         return finalBalanceIn - balances[tokenIndexIn] + 1;
     }
 
-    function _calcBptOutGivenExactTokensIn(
+    function computeBptOutGivenExactTokensIn(
         uint256 amp,
         uint256[] memory balances,
         uint256[] memory amountsIn,
@@ -224,7 +224,7 @@ library StableMath {
         }
     }
 
-    function _calcTokenInGivenExactBptOut(
+    function computeTokenInGivenExactBptOut(
         uint256 amp,
         uint256[] memory balances,
         uint256 tokenIndex,
@@ -263,7 +263,7 @@ library StableMath {
      * amountsTokenOut -> amountsOutProportional ->
      * amountOutPercentageExcess -> amountOutBeforeFee -> newInvariant -> amountBPTIn
      */
-    function _calcBptInGivenExactTokensOut(
+    function computeBptInGivenExactTokensOut(
         uint256 amp,
         uint256[] memory balances,
         uint256[] memory amountsOut,
@@ -315,7 +315,7 @@ library StableMath {
         return bptTotalSupply.mulUp(invariantRatio.complement());
     }
 
-    function _calcTokenOutGivenExactBptIn(
+    function computeTokenOutGivenExactBptIn(
         uint256 amp,
         uint256[] memory balances,
         uint256 tokenIndex,

--- a/pkg/solidity-utils/contracts/math/WeightedMath.sol
+++ b/pkg/solidity-utils/contracts/math/WeightedMath.sol
@@ -217,7 +217,7 @@ library WeightedMath {
             // The use of `normalizedWeight.complement()` assumes that the sum of all weights equals FixedPoint.ONE.
             // This may not be the case when weights are stored in a denormalized format or during a gradual weight
             // change due rounding errors during normalization or interpolation. This will result in a small difference
-            // between the output of this function and the equivalent `_calcBptOutGivenExactTokensIn` call.
+            // between the output of this function and the equivalent `computeBptOutGivenExactTokensIn` call.
             uint256 invariantRatioWithFees = balanceRatioWithFee.mulDown(normalizedWeight) +
                 normalizedWeight.complement();
 

--- a/pkg/solidity-utils/contracts/test/StableMathMock.sol
+++ b/pkg/solidity-utils/contracts/test/StableMathMock.sol
@@ -54,7 +54,7 @@ contract StableMathMock {
         uint256 swapFee
     ) external pure returns (uint256) {
         return
-            StableMath._calcBptOutGivenExactTokensIn(
+            StableMath.computeBptOutGivenExactTokensIn(
                 amp,
                 balances,
                 amountsIn,
@@ -74,7 +74,7 @@ contract StableMathMock {
         uint256 swapFee
     ) external pure returns (uint256) {
         return
-            StableMath._calcTokenInGivenExactBptOut(
+            StableMath.computeTokenInGivenExactBptOut(
                 amp,
                 balances,
                 tokenIndex,
@@ -95,7 +95,7 @@ contract StableMathMock {
         uint256 swapFee
     ) external pure returns (uint256) {
         return
-            StableMath._calcTokenOutGivenExactBptIn(
+            StableMath.computeTokenOutGivenExactBptIn(
                 amp,
                 balances,
                 tokenIndex,
@@ -115,7 +115,7 @@ contract StableMathMock {
         uint256 swapFee
     ) external pure returns (uint256) {
         return
-            StableMath._calcBptInGivenExactTokensOut(
+            StableMath.computeBptInGivenExactTokensOut(
                 amp,
                 balances,
                 amountsOut,


### PR DESCRIPTION
# Description

While reviewing the rounding direction, noticed we still had some old "_calc" holdovers from before we standardized on "compute".

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

