### PR TITLE
Fix: pool config lib test

### DIFF
--- a/pkg/vault/test/foundry/unit/PoolConfigLib.t.sol
+++ b/pkg/vault/test/foundry/unit/PoolConfigLib.t.sol
@@ -27,7 +27,7 @@ contract PoolConfigLibTest is Test {
     mapping(uint256 => bool) usedBits;
 
     // 16 flags + 2 * 24 bit fee + 24 bit token diffs + 32 bit timestamp = 120 total bits used.
-    uint256 private constant CONFIG_MSB = 120;
+    uint256 private constant BITS_IN_USE = 120;
 
     // #region PoolConfigBits
     function testOffsets() public {
@@ -731,7 +731,7 @@ contract PoolConfigLibTest is Test {
     }
 
     function testToAndFromConfigBits__Fuzz(uint256 rawConfigInt) public {
-        rawConfigInt = bound(rawConfigInt, 0, uint256(1 << CONFIG_MSB) - 1);
+        rawConfigInt = bound(rawConfigInt, 0, uint256(1 << BITS_IN_USE) - 1);
         bytes32 rawConfig = bytes32(rawConfigInt);
         PoolConfig memory config = PoolConfigLib.toPoolConfig(PoolConfigBits.wrap(rawConfig));
         bytes32 configBytes32 = PoolConfigBits.unwrap(PoolConfigLib.fromPoolConfig(config));
@@ -740,7 +740,7 @@ contract PoolConfigLibTest is Test {
     }
 
     function testUnusedConfigBits() public {
-        bytes32 unusedBits = bytes32(uint256(type(uint256).max << (CONFIG_MSB + 1)));
+        bytes32 unusedBits = bytes32(uint256(type(uint256).max << (BITS_IN_USE)));
 
         PoolConfig memory config = PoolConfigLib.toPoolConfig(PoolConfigBits.wrap(unusedBits));
         bytes32 configBytes32 = PoolConfigBits.unwrap(PoolConfigLib.fromPoolConfig(config));


### PR DESCRIPTION
# Description

Either `testToAndFromConfigBits__Fuzz` or `testUnusedConfigBits` should fail if the configured amount of bits in use is not the correct one, and there should be no tolerance.

This PR fixes it. 'Bits in use' is actually more accurate.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A