### PR TITLE
Fix pool creator fee

### DIFF
--- a/pkg/vault/contracts/Vault.sol
+++ b/pkg/vault/contracts/Vault.sol
@@ -964,7 +964,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
             }
 
             if (poolData.poolConfig.poolCreatorFeePercentage > 0) {
-                creatorSwapFeeAmountScaled18 = (swapFeeAmountScaled18 - protocolSwapFeeAmountRaw).mulUp(
+                creatorSwapFeeAmountScaled18 = (swapFeeAmountScaled18 - protocolSwapFeeAmountScaled18).mulUp(
                     poolData.poolConfig.poolCreatorFeePercentage
                 );
                 creatorSwapFeeAmountRaw = creatorSwapFeeAmountScaled18.toRawUndoRateRoundDown(

--- a/pkg/vault/test/foundry/unit/VaultUnitSwap.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultUnitSwap.t.sol
@@ -280,9 +280,10 @@ contract VaultUnitSwapTest is BaseTest {
 
         // check fees
         assertEq(vars.swapFeeAmountScaled18, fee, "Unexpected swapFeeAmountScaled18");
+        uint256 protocolSwapFeeAmountScaled18 = vars.swapFeeAmountScaled18.mulUp(vaultState.protocolSwapFeePercentage);
         assertEq(
             vars.protocolSwapFeeAmountRaw,
-            vars.swapFeeAmountScaled18.mulUp(vaultState.protocolSwapFeePercentage).toRawUndoRateRoundDown(
+            protocolSwapFeeAmountScaled18.toRawUndoRateRoundDown(
                 poolData.decimalScalingFactors[vars.indexOut],
                 poolData.tokenRates[vars.indexOut]
             ),
@@ -290,7 +291,7 @@ contract VaultUnitSwapTest is BaseTest {
         );
         assertEq(
             vars.creatorSwapFeeAmountRaw,
-            (vars.swapFeeAmountScaled18 - vars.protocolSwapFeeAmountRaw)
+            (vars.swapFeeAmountScaled18 - protocolSwapFeeAmountScaled18)
                 .mulUp(poolData.poolConfig.poolCreatorFeePercentage)
                 .toRawUndoRateRoundDown(
                     poolData.decimalScalingFactors[vars.indexOut],


### PR DESCRIPTION
# Description

In the current implementation, the pool creator fee is taken from the difference between the total swap fee and the protocol swap fee. Both quantities need to be scaled18 for the math to make sense.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A