### PR TITLE
Custom tests for the onlyVault modifiers on the router (mutation testing)

### DIFF
--- a/pkg/vault/test/foundry/mutation/router/Router.t.sol
+++ b/pkg/vault/test/foundry/mutation/router/Router.t.sol
@@ -40,13 +40,6 @@ import {
 contract RouterMutationTest is BaseVaultTest {
     using ArrayHelpers for *;
 
-    // Track the indices for the standard dai/usdc pool.
-    uint256 internal daiIdx;
-    uint256 internal usdcIdx;
-
-    uint256[] internal wethDaiAmountsIn;
-    IERC20[] internal wethDaiTokens;
-
     uint256[] internal amountsIn = [poolInitAmount, poolInitAmount].toMemoryArray();
 
     function setUp() public virtual override {


### PR DESCRIPTION
# Description
Testing all the onlyVault modifiers on the router just in case one of them gets removed by error, this project started from the mutation testing results.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Advances #460, related with #459 
