### PR TITLE
Fix pragma version in test files

### DIFF
--- a/pkg/vault/test/foundry/unit/PoolAndVaultPaused.t.sol
+++ b/pkg/vault/test/foundry/unit/PoolAndVaultPaused.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 

--- a/pkg/vault/test/foundry/unit/PoolConfigLib.t.sol
+++ b/pkg/vault/test/foundry/unit/PoolConfigLib.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 import { PoolConfig, PoolConfigBits, PoolConfigLib } from "@balancer-labs/v3-vault/contracts/lib/PoolConfigLib.sol";

--- a/pkg/vault/test/foundry/unit/VaultCommonBasicFunctions.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultCommonBasicFunctions.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 

--- a/pkg/vault/test/foundry/unit/VaultCommonModifiers.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultCommonModifiers.t.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.24;
 
 import "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 

--- a/pkg/vault/test/foundry/unit/VaultUnit.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultUnit.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 

--- a/pkg/vault/test/foundry/unit/VaultUnitSwap.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultUnitSwap.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 


### PR DESCRIPTION
# Description

Our current pragma version is 0.8.24, but some test files were adopting 0.8.4.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge
