### PR TITLE
Resolve ambiguous PoolConfigLib error messages

### DIFF
--- a/pkg/vault/test/foundry/unit/PoolConfigLib.t.sol
+++ b/pkg/vault/test/foundry/unit/PoolConfigLib.t.sol
@@ -761,7 +761,11 @@ contract PoolConfigLibTest is Test {
             )
         );
 
-        assertEq(PoolConfigLib.toTokenDecimalDiffs(tokenDecimalDiffs), value, "tokenDecimalDiffs mismatch (testToTokenDecimalDiffs)");
+        assertEq(
+            PoolConfigLib.toTokenDecimalDiffs(tokenDecimalDiffs),
+            value,
+            "tokenDecimalDiffs mismatch (testToTokenDecimalDiffs)"
+        );
     }
 
     function testGetDecimalScalingFactors() public {


### PR DESCRIPTION
# Description

Noticed while debugging other things that the error messages in the PoolConfigLib forge tests were ambiguous. Didn't want to fix it in a PR that might be discarded, so split it out into this one.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
