### PR TITLE
Remove unused storage

### DIFF
--- a/pkg/vault/contracts/VaultStorage.sol
+++ b/pkg/vault/contracts/VaultStorage.sol
@@ -57,9 +57,6 @@ contract VaultStorage {
     // Registry of pool configs.
     mapping(address => PoolConfigBits) internal _poolConfig;
 
-    // Store pool pause managers.
-    mapping(address => address) internal _poolPauseManagers;
-
     // Pool -> (token -> PackedTokenBalance): structure containing the current raw and "last live" scaled balances.
     // Last live balances are used for yield fee computation, and since these have rates applied, they are stored
     // as scaled 18-decimal FP values. Each value takes up half the storage slot (i.e., 128 bits).


### PR DESCRIPTION
# Description

Noticed while working on other stuff that we still have `_poolPauseManagers` in storage, long after replacing them with roles (merge conflict?)

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
