### PR TITLE
Add real test where a hook reads the sender and changes the result

### DIFF
--- a/pkg/vault/contracts/RouterCommon.sol
+++ b/pkg/vault/contracts/RouterCommon.sol
@@ -164,6 +164,7 @@ contract RouterCommon is IRouterSender {
         result = Address.functionDelegateCall(address(this), data);
     }
 
+    // solhint-disable no-inline-assembly
     function _getSenderSlot() internal pure returns (StorageSlot.AddressSlotType) {
         StorageSlot.AddressSlotType slot;
 

--- a/pkg/vault/contracts/test/PoolMock.sol
+++ b/pkg/vault/contracts/test/PoolMock.sol
@@ -11,6 +11,7 @@ import { IPoolLiquidity } from "@balancer-labs/v3-interfaces/contracts/vault/IPo
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import { IVaultMock } from "@balancer-labs/v3-interfaces/contracts/test/IVaultMock.sol";
 import { IRateProvider } from "@balancer-labs/v3-interfaces/contracts/vault/IRateProvider.sol";
+import { IRouterSender } from "@balancer-labs/v3-interfaces/contracts/vault/IRouterSender.sol";
 import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
 import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
@@ -49,6 +50,7 @@ contract PoolMock is IBasePool, IPoolHooks, IPoolLiquidity, BalancerPoolToken {
     RateProviderMock _rateProvider;
     uint256 private _newTokenRate;
     uint256 private _dynamicSwapFee;
+    address private _specialSender;
 
     // Amounts in are multiplied by the multiplier, amounts out are divided by it
     uint256 private _multiplier = FixedPoint.ONE;
@@ -79,6 +81,10 @@ contract PoolMock is IBasePool, IPoolHooks, IPoolLiquidity, BalancerPoolToken {
         // inv = x + y
         uint256 invariant = computeInvariant(balances);
         return (balances[tokenInIndex] + invariant.mulDown(invariantRatio)) - invariant;
+    }
+
+    function setSpecialSender(address sender) external {
+        _specialSender = sender;
     }
 
     function setSwapReentrancyHookActive(bool _swapReentrancyHookActive) external {
@@ -186,8 +192,18 @@ contract PoolMock is IBasePool, IPoolHooks, IPoolLiquidity, BalancerPoolToken {
         return !failOnAfterInitialize;
     }
 
-    function onComputeDynamicSwapFee(IBasePool.PoolSwapParams calldata) external view returns (bool, uint256) {
-        return (!failComputeDynamicSwapFeeHook, _dynamicSwapFee);
+    function onComputeDynamicSwapFee(IBasePool.PoolSwapParams calldata params) external view returns (bool, uint256) {
+        uint256 finalSwapFee = _dynamicSwapFee;
+
+        if (_specialSender != address(0)) {
+            // Check the sender
+            address swapper = IRouterSender(params.router).getSender();
+            if (swapper == _specialSender) {
+                finalSwapFee = 0;
+            }
+        }
+
+        return (!failComputeDynamicSwapFeeHook, finalSwapFee);
     }
 
     function onBeforeSwap(IBasePool.PoolSwapParams calldata) external override returns (bool success) {

--- a/pkg/vault/test/foundry/DynamicFeePoolTest.t.sol
+++ b/pkg/vault/test/foundry/DynamicFeePoolTest.t.sol
@@ -7,6 +7,7 @@ import "forge-std/Test.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import { IRouter } from "@balancer-labs/v3-interfaces/contracts/vault/IRouter.sol";
 import { IVaultAdmin } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultAdmin.sol";
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 import { IRateProvider } from "@balancer-labs/v3-interfaces/contracts/vault/IRateProvider.sol";
@@ -16,6 +17,7 @@ import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
 import { BasePoolMath } from "@balancer-labs/v3-solidity-utils/contracts/math/BasePoolMath.sol";
 import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/ArrayHelpers.sol";
+import { RouterCommon } from "@balancer-labs/v3-vault/contracts/RouterCommon.sol";
 
 import { PoolMock } from "../../contracts/test/PoolMock.sol";
 import { PoolConfigBits, PoolConfigLib } from "../../contracts/lib/PoolConfigLib.sol";
@@ -114,6 +116,78 @@ contract DynamicFeePoolTest is BaseVaultTest {
             false,
             bytes("")
         );
+    }
+
+    function testSwapCallsComputeFeeWithSender() public {
+        IBasePool.PoolSwapParams memory poolSwapParams = IBasePool.PoolSwapParams({
+            kind: SwapKind.EXACT_IN,
+            amountGivenScaled18: defaultAmount,
+            balancesScaled18: [poolInitAmount, poolInitAmount].toMemoryArray(),
+            indexIn: daiIdx,
+            indexOut: usdcIdx,
+            router: address(router),
+            userData: bytes("")
+        });
+
+        vm.expectCall(
+            address(pool),
+            abi.encodeWithSelector(PoolMock.onComputeDynamicSwapFee.selector, poolSwapParams),
+            1 // callCount
+        );
+
+        vm.expectCall(
+            address(pool),
+            abi.encodeWithSelector(PoolMock.onSwap.selector, poolSwapParams),
+            1 // callCount
+        );
+
+        // Set a 100% fee, and bob as 0 swap fee sender.
+        PoolMock(pool).setDynamicSwapFeePercentage(FixedPoint.ONE);
+        PoolMock(pool).setSpecialSender(bob);
+
+        uint256 aliceBalanceBefore = usdc.balanceOf(alice);
+
+        vm.prank(alice);
+        router.callAndSaveSender(
+            abi.encodeWithSelector(
+                IRouter.swapSingleTokenExactIn.selector,
+                address(pool),
+                dai,
+                usdc,
+                defaultAmount,
+                0,
+                MAX_UINT256,
+                false,
+                bytes("")
+            )
+        );
+
+        uint256 aliceBalanceAfter = usdc.balanceOf(alice);
+        // 100% fee; should get nothing
+        assertEq(aliceBalanceAfter - aliceBalanceBefore, 0);
+
+        // Now set Alice as the special 0-fee sender
+        PoolMock(pool).setSpecialSender(alice);
+        aliceBalanceBefore = aliceBalanceAfter;
+
+        vm.prank(alice);
+        router.callAndSaveSender(
+            abi.encodeWithSelector(
+                IRouter.swapSingleTokenExactIn.selector,
+                address(pool),
+                dai,
+                usdc,
+                defaultAmount,
+                0,
+                MAX_UINT256,
+                false,
+                bytes("")
+            )
+        );
+
+        aliceBalanceAfter = usdc.balanceOf(alice);
+        // No fee; should get full swap amount
+        assertEq(aliceBalanceAfter - aliceBalanceBefore, defaultAmount);
     }
 
     function testExternalComputeFee() public {


### PR DESCRIPTION
# Description

This PR adds a "real life" test of the `callAndSaveSender` functionality. The first use case for this was dynamic fee computation, where a pool would give a discount to a certain user (or class of users). Here, we set such a "special sender" in the mock, and the compute dynamic fee function gives that special sender a 0 fee.

Merge into #563.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
