### PR TITLE
remove saveUser from Buffer methods in router

### DIFF
--- a/pkg/vault/contracts/Router.sol
+++ b/pkg/vault/contracts/Router.sol
@@ -410,7 +410,7 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
     function removeLiquidityRecovery(
         address pool,
         uint256 exactBptAmountIn
-    ) external saveSender returns (uint256[] memory amountsOut) {
+    ) external returns (uint256[] memory amountsOut) {
         amountsOut = abi.decode(
             _vault.unlock(
                 abi.encodeWithSelector(Router.removeLiquidityRecoveryHook.selector, pool, msg.sender, exactBptAmountIn)
@@ -1058,7 +1058,7 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
     function queryRemoveLiquidityRecovery(
         address pool,
         uint256 exactBptAmountIn
-    ) external saveSender returns (uint256[] memory amountsOut) {
+    ) external returns (uint256[] memory amountsOut) {
         return
             abi.decode(
                 _vault.quote(


### PR DESCRIPTION
# Description

Remove `saveUser` from unnecessary methods in Router.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
