### PR TITLE
Mutation testing fix

### DIFF
--- a/pkg/vault/test/foundry/mutation/vault/VaultAdmin.t.sol
+++ b/pkg/vault/test/foundry/mutation/vault/VaultAdmin.t.sol
@@ -20,8 +20,6 @@ contract VaultAdminMutationTest is BaseVaultTest {
     */
     using ArrayHelpers for *;
 
-    IVaultAdmin internal vaultAdmin = IVaultAdmin(address(vaultExtension));
-
     function setUp() public virtual override {
         BaseVaultTest.setUp();
     }

--- a/pkg/vault/test/foundry/mutation/vault/VaultExtension.t.sol
+++ b/pkg/vault/test/foundry/mutation/vault/VaultExtension.t.sol
@@ -125,8 +125,8 @@ contract VaultExtensionMutationTest is BaseVaultTest {
             [x] onlyVault
     */
     function testAllowanceWhenNotVault() public {
-        vm.expectRevert();
-        vaultExtension.allowance(address(dai), address(0), address(1));
+        vm.expectRevert(IVaultErrors.NotVaultDelegateCall.selector);
+        vaultExtension.allowance(address(dai), address(1), address(2));
     }
 
     /*

--- a/pkg/vault/test/foundry/utils/BaseVaultTest.sol
+++ b/pkg/vault/test/foundry/utils/BaseVaultTest.sol
@@ -8,6 +8,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import { IVaultAdmin } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultAdmin.sol";
+import { IVaultExtension } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultExtension.sol";
 import { IVaultMock } from "@balancer-labs/v3-interfaces/contracts/test/IVaultMock.sol";
 import { IRateProvider } from "@balancer-labs/v3-interfaces/contracts/vault/IRateProvider.sol";
 import { IBasePool } from "@balancer-labs/v3-interfaces/contracts/vault/IBasePool.sol";
@@ -20,7 +21,6 @@ import { BaseTest } from "@balancer-labs/v3-solidity-utils/test/foundry/utils/Ba
 
 import { RateProviderMock } from "../../../contracts/test/RateProviderMock.sol";
 import { VaultMock } from "../../../contracts/test/VaultMock.sol";
-import { VaultExtensionMock } from "../../../contracts/test/VaultExtensionMock.sol";
 import { Router } from "../../../contracts/Router.sol";
 import { BatchRouter } from "../../../contracts/BatchRouter.sol";
 import { VaultStorage } from "../../../contracts/VaultStorage.sol";
@@ -49,7 +49,9 @@ abstract contract BaseVaultTest is VaultStorage, BaseTest, Permit2Helpers {
     // Vault mock.
     IVaultMock internal vault;
     // Vault extension mock.
-    VaultExtensionMock internal vaultExtension;
+    IVaultExtension internal vaultExtension;
+    // Vault admin mock.
+    IVaultAdmin internal vaultAdmin;
     // Router mock.
     RouterMock internal router;
     // Batch router
@@ -90,6 +92,10 @@ abstract contract BaseVaultTest is VaultStorage, BaseTest, Permit2Helpers {
 
         vault = IVaultMock(address(VaultMockDeployer.deploy()));
         vm.label(address(vault), "vault");
+        vaultExtension = IVaultExtension(vault.getVaultExtension());
+        vm.label(address(vaultExtension), "vaultExtension");
+        vaultAdmin = IVaultAdmin(vault.getVaultAdmin());
+        vm.label(address(vaultAdmin), "vaultAxtension");
         authorizer = BasicAuthorizerMock(address(vault.getAuthorizer()));
         vm.label(address(authorizer), "authorizer");
         factoryMock = PoolFactoryMock(address(vault.getPoolFactoryMock()));


### PR DESCRIPTION
The cause of the failures in #594 is that the admin / extension are not properly initialized in the base vault test. This is why `expectRevert` was behaving weird: it didn't work, but the test reverted anyways because the references to the admin and the extension were dangling.

PTAL @JosepBove; can you please wrap it up?