### PR TITLE
Change max yield fee to 50%

### DIFF
--- a/pkg/vault/contracts/ProtocolFeeCollector.sol
+++ b/pkg/vault/contracts/ProtocolFeeCollector.sol
@@ -45,7 +45,7 @@ contract ProtocolFeeCollector is IProtocolFeeCollector, SingletonAuthentication,
     uint256 internal constant _MAX_PROTOCOL_SWAP_FEE_PERCENTAGE = 50e16; // 50%
 
     // Maximum protocol yield fee percentage.
-    uint256 internal constant _MAX_PROTOCOL_YIELD_FEE_PERCENTAGE = 20e16; // 20%
+    uint256 internal constant _MAX_PROTOCOL_YIELD_FEE_PERCENTAGE = 50e16; // 50%
 
     // Global protocol swap fee.
     uint256 private _globalProtocolSwapFeePercentage;

--- a/pkg/vault/test/foundry/ProtocolFeeCollector.t.sol
+++ b/pkg/vault/test/foundry/ProtocolFeeCollector.t.sol
@@ -25,8 +25,8 @@ contract ProtocolFeeCollectorTest is BaseVaultTest {
     uint256 internal constant MAX_PROTOCOL_SWAP_FEE = 50e16;
 
     uint256 internal constant LOW_PROTOCOL_YIELD_FEE = 10e16;
-    uint256 internal constant CUSTOM_PROTOCOL_YIELD_FEE = 15e16;
-    uint256 internal constant MAX_PROTOCOL_YIELD_FEE = 20e16;
+    uint256 internal constant CUSTOM_PROTOCOL_YIELD_FEE = 40e16;
+    uint256 internal constant MAX_PROTOCOL_YIELD_FEE = 50e16;
 
     uint256 internal constant POOL_CREATOR_FEE = 50e16;
 

--- a/pkg/vault/test/foundry/YieldFees.t.sol
+++ b/pkg/vault/test/foundry/YieldFees.t.sol
@@ -204,14 +204,14 @@ contract YieldFeesTest is BaseVaultTest {
         uint256 lastLiveBalance,
         uint256 yieldFeePercentage
     ) public {
-        uint256 _MAX_PROTOCOL_YIELD_FEE_PERCENTAGE = 20e16; // 20%
+        uint256 MAX_PROTOCOL_YIELD_FEE_PERCENTAGE = 50e16; // 50%
 
         balanceRaw = bound(balanceRaw, 0, 2 ** 120);
         decimals = uint8(bound(uint256(decimals), 2, 18));
         tokenRate = bound(tokenRate, 0, 100_000e18);
         uint256 decimalScalingFactor = getDecimalScalingFactor(decimals);
         lastLiveBalance = bound(lastLiveBalance, 0, 2 ** 128);
-        yieldFeePercentage = bound(yieldFeePercentage, 0, _MAX_PROTOCOL_YIELD_FEE_PERCENTAGE);
+        yieldFeePercentage = bound(yieldFeePercentage, 0, MAX_PROTOCOL_YIELD_FEE_PERCENTAGE);
 
         PoolData memory poolData = _simplePoolData(balanceRaw, decimalScalingFactor, tokenRate);
         uint256 liveBalance = poolData.balancesLiveScaled18[0];


### PR DESCRIPTION
# Description

This came up in discussions. As far as I know, the 20% is a historical number that came from discussions with Integrations / Maxis at least a year ago about what a reasonable yield fee would be, and has no firm data behind it. In any case this is only a max; we can still set it to 20% or whatever to start with.

As a reminder, the idea behind maximum fees (which we had in V2) was to give some assurances to LPs - and also guard against a compromised governance just setting it to 100%.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
