### PR TITLE
Fix hooks config alternative approach

### DIFF
--- a/pkg/interfaces/contracts/vault/IHooks.sol
+++ b/pkg/interfaces/contracts/vault/IHooks.sol
@@ -31,11 +31,24 @@ interface IHooks {
         LiquidityManagement calldata liquidityManagement
     ) external returns (bool);
 
+    struct HookFlags {
+        bool shouldCallBeforeInitialize;
+        bool shouldCallAfterInitialize;
+        bool shouldCallComputeDynamicSwapFee;
+        bool shouldCallBeforeSwap;
+        bool shouldCallAfterSwap;
+        bool shouldCallBeforeAddLiquidity;
+        bool shouldCallAfterAddLiquidity;
+        bool shouldCallBeforeRemoveLiquidity;
+        bool shouldCallAfterRemoveLiquidity;
+        address hooksContract;
+    }
+
     /**
      * @notice Returns flags informing which hooks are implemented in the contract.
-     * @return hooksConfig Flags indicating which hooks the contract supports and the address of the hook contract
+     * @return hookFlags Flags indicating which hooks the contract supports
      */
-    function getHooksConfig() external returns (HooksConfig memory hooksConfig);
+    function getHookFlags() external returns (HookFlags memory hookFlags);
 
     /***************************************************************************
                                    Initialize

--- a/pkg/vault/contracts/BasePoolHooks.sol
+++ b/pkg/vault/contracts/BasePoolHooks.sol
@@ -36,7 +36,7 @@ abstract contract BasePoolHooks is IHooks, VaultGuard {
     }
 
     /// @inheritdoc IHooks
-    function getHooksConfig() external virtual returns (HooksConfig memory);
+    function getHookFlags() external virtual returns (HookFlags memory);
 
     /// @inheritdoc IHooks
     function onBeforeInitialize(uint256[] memory, bytes memory) external virtual onlyVault returns (bool) {

--- a/pkg/vault/contracts/VaultExtension.sol
+++ b/pkg/vault/contracts/VaultExtension.sol
@@ -194,8 +194,19 @@ contract VaultExtension is IVaultExtension, VaultCommon, Proxy {
 
             // Gets the default HooksConfig from the hook contract and saves in the vault state
             // Storing into hooksConfig first avoids stack-too-deep
-            hooksConfig = IHooks(params.poolHooksContract).getHooksConfig();
-            _hooksConfig[pool] = hooksConfig;
+            IHooks.HookFlags memory hookFlags = IHooks(params.poolHooksContract).getHookFlags();
+            _hooksConfig[pool] = HooksConfig({
+                shouldCallBeforeInitialize: hookFlags.shouldCallBeforeInitialize,
+                shouldCallAfterInitialize: hookFlags.shouldCallAfterInitialize,
+                shouldCallComputeDynamicSwapFee: hookFlags.shouldCallComputeDynamicSwapFee,
+                shouldCallBeforeSwap: hookFlags.shouldCallBeforeSwap,
+                shouldCallAfterSwap: hookFlags.shouldCallAfterSwap,
+                shouldCallBeforeAddLiquidity: hookFlags.shouldCallBeforeAddLiquidity,
+                shouldCallAfterAddLiquidity: hookFlags.shouldCallAfterAddLiquidity,
+                shouldCallBeforeRemoveLiquidity: hookFlags.shouldCallBeforeRemoveLiquidity,
+                shouldCallAfterRemoveLiquidity: hookFlags.shouldCallAfterRemoveLiquidity,
+                hooksContract: params.poolHooksContract
+            });
         }
 
         uint256 numTokens = params.tokenConfig.length;

--- a/pkg/vault/contracts/test/PoolHooksMock.sol
+++ b/pkg/vault/contracts/test/PoolHooksMock.sol
@@ -54,7 +54,7 @@ contract PoolHooksMock is BasePoolHooks {
 
     mapping(address => bool) private _allowedFactories;
 
-    HooksConfig private _hooksConfig;
+    HookFlags private _hookFlags;
 
     constructor(IVault vault) BasePoolHooks(vault) {
         // solhint-disable-previous-line no-empty-blocks
@@ -69,13 +69,12 @@ contract PoolHooksMock is BasePoolHooks {
         return _allowedFactories[factory];
     }
 
-    function getHooksConfig() external view override returns (HooksConfig memory) {
-        return _hooksConfig;
+    function getHookFlags() external view override returns (HookFlags memory) {
+        return _hookFlags;
     }
 
-    function setHooksConfig(HooksConfig memory hooksConfig) external {
-        _hooksConfig = hooksConfig;
-        _hooksConfig.hooksContract = address(this);
+    function setHookFlags(HookFlags memory hookFlags) external {
+        _hookFlags = hookFlags;
     }
 
     function onBeforeInitialize(uint256[] memory, bytes memory) external override returns (bool) {

--- a/pkg/vault/test/foundry/DynamicFeePoolTest.t.sol
+++ b/pkg/vault/test/foundry/DynamicFeePoolTest.t.sol
@@ -7,6 +7,7 @@ import "forge-std/Test.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import { IHooks } from "@balancer-labs/v3-interfaces/contracts/vault/IHooks.sol";
 import { IRouter } from "@balancer-labs/v3-interfaces/contracts/vault/IRouter.sol";
 import { IVaultAdmin } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultAdmin.sol";
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
@@ -55,9 +56,9 @@ contract DynamicFeePoolTest is BaseVaultTest {
         vm.label(address(newPool), label);
         PoolRoleAccounts memory roleAccounts;
 
-        HooksConfig memory hooksConfig;
-        hooksConfig.shouldCallComputeDynamicSwapFee = true;
-        PoolHooksMock(poolHooksContract).setHooksConfig(hooksConfig);
+        IHooks.HookFlags memory hookFlags;
+        hookFlags.shouldCallComputeDynamicSwapFee = true;
+        PoolHooksMock(poolHooksContract).setHookFlags(hookFlags);
 
         factoryMock.registerPool(
             address(newPool),

--- a/pkg/vault/test/foundry/Hooks.t.sol
+++ b/pkg/vault/test/foundry/Hooks.t.sol
@@ -49,8 +49,8 @@ contract HooksTest is BaseVaultTest {
     }
 
     function createHook() internal override returns (address) {
-        HooksConfig memory hooksConfig;
-        return _createHook(hooksConfig);
+        IHooks.HookFlags memory hookFlags;
+        return _createHook(hookFlags);
     }
 
     // onRegister

--- a/pkg/vault/test/foundry/utils/BaseVaultTest.sol
+++ b/pkg/vault/test/foundry/utils/BaseVaultTest.sol
@@ -185,17 +185,16 @@ abstract contract BaseVaultTest is VaultStorage, BaseTest, Permit2Helpers {
 
     function createHook() internal virtual returns (address) {
         // Sets all flags as false
-        HooksConfig memory hooksConfig;
-        return _createHook(hooksConfig);
+        IHooks.HookFlags memory hookFlags;
+        return _createHook(hookFlags);
     }
 
-    function _createHook(HooksConfig memory hooksConfig) internal virtual returns (address) {
+    function _createHook(IHooks.HookFlags memory hookFlags) internal virtual returns (address) {
         PoolHooksMock newHook = new PoolHooksMock(IVault(address(vault)));
-        hooksConfig.hooksContract = address(newHook);
         // Allow pools built with factoryMock to use the poolHooksMock
         newHook.allowFactory(address(factoryMock));
         // Configure pool hook flags
-        newHook.setHooksConfig(hooksConfig);
+        newHook.setHookFlags(hookFlags);
         vm.label(address(newHook), "pool hooks");
         return address(newHook);
     }


### PR DESCRIPTION
# Description

Alternative approach to #621. We create a second struct in IHooks that is all flags without the address. On pool register, we map to the flags struct into the config struct, avoiding the nested struct gas overhead.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
