### PR TITLE
Remove unnecessary abi encoding

### DIFF
--- a/pkg/pool-weighted/test/foundry/WeightedPool.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedPool.t.sol
@@ -298,7 +298,7 @@ contract WeightedPoolTest is BaseVaultTest {
         authorizer.grantRole(vault.getActionId(IVaultAdmin.setStaticSwapFeePercentage.selector), alice);
         vm.prank(alice);
 
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.SwapFeePercentageTooLow.selector));
+        vm.expectRevert(IVaultErrors.SwapFeePercentageTooLow.selector);
         vault.setStaticSwapFeePercentage(address(pool), MIN_SWAP_FEE - 1);
     }
 }

--- a/pkg/solidity-utils/test/foundry/FixedPoint.t.sol
+++ b/pkg/solidity-utils/test/foundry/FixedPoint.t.sol
@@ -110,7 +110,7 @@ contract FixedPointTest is Test {
         unchecked {
             if (b == 0) {
                 // This check is required because Yul's `div` doesn't revert on b==0
-                vm.expectRevert(abi.encodeWithSelector(FixedPoint.ZeroDivision.selector));
+                vm.expectRevert(FixedPoint.ZeroDivision.selector);
                 FixedPoint.divUp(a, b);
             } else if (a != 0 && (a * FixedPoint.ONE) / FixedPoint.ONE != a) {
                 vm.expectRevert(stdError.arithmeticError);

--- a/pkg/solidity-utils/test/foundry/RevertCodec.t.sol
+++ b/pkg/solidity-utils/test/foundry/RevertCodec.t.sol
@@ -10,7 +10,7 @@ contract RevertCodecTest is Test {
     error TestCustomError(uint256 code);
 
     function testcatchEncodedResultNoSelector() public {
-        vm.expectRevert(abi.encodeWithSelector(RevertCodec.ErrorSelectorNotFound.selector));
+        vm.expectRevert(RevertCodec.ErrorSelectorNotFound.selector);
         RevertCodec.catchEncodedResult("");
     }
 
@@ -29,7 +29,7 @@ contract RevertCodecTest is Test {
     }
 
     function testParseSelectorNoData() public {
-        vm.expectRevert(abi.encodeWithSelector(RevertCodec.ErrorSelectorNotFound.selector));
+        vm.expectRevert(RevertCodec.ErrorSelectorNotFound.selector);
         RevertCodec.parseSelector("");
     }
 

--- a/pkg/vault/test/foundry/BatchRouter.t.sol
+++ b/pkg/vault/test/foundry/BatchRouter.t.sol
@@ -17,14 +17,14 @@ contract BatchRouter is BaseVaultTest {
     function testSwapDeadlineExactIn() public {
         IBatchRouter.SwapPathExactAmountIn[] memory paths;
 
-        vm.expectRevert(abi.encodeWithSelector(RouterCommon.SwapDeadline.selector));
+        vm.expectRevert(RouterCommon.SwapDeadline.selector);
         batchRouter.swapExactIn(paths, block.timestamp - 1, false, bytes(""));
     }
 
     function testSwapDeadlineExactOut() public {
         IBatchRouter.SwapPathExactAmountOut[] memory paths;
 
-        vm.expectRevert(abi.encodeWithSelector(RouterCommon.SwapDeadline.selector));
+        vm.expectRevert(RouterCommon.SwapDeadline.selector);
         batchRouter.swapExactOut(paths, block.timestamp - 1, false, bytes(""));
     }
 }

--- a/pkg/vault/test/foundry/BufferVaultPrimitive.t.sol
+++ b/pkg/vault/test/foundry/BufferVaultPrimitive.t.sol
@@ -520,7 +520,7 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
     function testDisableVaultBufferAuthentication() public {
         vm.prank(alice);
         // Should revert, since alice has no rights to disable buffer
-        vm.expectRevert(abi.encodeWithSelector(IAuthentication.SenderNotAllowed.selector));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         IVaultAdmin(address(vault)).pauseVaultBuffers();
 
         vm.prank(admin);
@@ -529,7 +529,7 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
 
         vm.prank(alice);
         // Should revert, since alice has no rights to enable buffer
-        vm.expectRevert(abi.encodeWithSelector(IAuthentication.SenderNotAllowed.selector));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         IVaultAdmin(address(vault)).unpauseVaultBuffers();
 
         vm.prank(admin);
@@ -555,10 +555,10 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
         // wrap/unwrap, add and remove liquidity should fail, since vault buffers are disabled
         vm.startPrank(lp);
 
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.VaultBuffersArePaused.selector));
+        vm.expectRevert(IVaultErrors.VaultBuffersArePaused.selector);
         batchRouter.swapExactIn(paths, MAX_UINT256, false, bytes(""));
 
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.VaultBuffersArePaused.selector));
+        vm.expectRevert(IVaultErrors.VaultBuffersArePaused.selector);
         router.addLiquidityToBuffer(IERC4626(address(waDAI)), _wrapAmount, _wrapAmount, address(lp));
 
         // remove liquidity is supposed to pass even with buffers paused, so revert is not expected

--- a/pkg/vault/test/foundry/Hooks.t.sol
+++ b/pkg/vault/test/foundry/Hooks.t.sol
@@ -154,7 +154,7 @@ contract HooksTest is BaseVaultTest {
         // should fail
         PoolHooksMock(poolHooksContract).setFailOnComputeDynamicSwapFeeHook(true);
         vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.DynamicSwapFeeHookFailed.selector));
+        vm.expectRevert(IVaultErrors.DynamicSwapFeeHookFailed.selector);
         router.swapSingleTokenExactIn(
             address(pool),
             usdc,
@@ -203,7 +203,7 @@ contract HooksTest is BaseVaultTest {
         // should fail
         PoolHooksMock(poolHooksContract).setFailOnBeforeSwapHook(true);
         vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.BeforeSwapHookFailed.selector));
+        vm.expectRevert(IVaultErrors.BeforeSwapHookFailed.selector);
         router.swapSingleTokenExactIn(
             address(pool),
             usdc,
@@ -267,7 +267,7 @@ contract HooksTest is BaseVaultTest {
         // should fail
         PoolHooksMock(poolHooksContract).setFailOnAfterSwapHook(true);
         vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.AfterSwapHookFailed.selector));
+        vm.expectRevert(IVaultErrors.AfterSwapHookFailed.selector);
         router.swapSingleTokenExactIn(
             address(pool),
             usdc,

--- a/pkg/vault/test/foundry/Initializer.t.sol
+++ b/pkg/vault/test/foundry/Initializer.t.sol
@@ -82,7 +82,7 @@ contract InitializerTest is BaseVaultTest {
     function testOnBeforeInitializeHookRevert() public {
         PoolHooksMock(poolHooksContract).setFailOnBeforeInitializeHook(true);
         vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.BeforeInitializeHookFailed.selector));
+        vm.expectRevert(IVaultErrors.BeforeInitializeHookFailed.selector);
         router.initialize(
             address(pool),
             standardPoolTokens,
@@ -117,7 +117,7 @@ contract InitializerTest is BaseVaultTest {
     function testOnAfterInitializeHookRevert() public {
         PoolHooksMock(poolHooksContract).setFailOnAfterInitializeHook(true);
         vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.AfterInitializeHookFailed.selector));
+        vm.expectRevert(IVaultErrors.AfterInitializeHookFailed.selector);
         router.initialize(
             address(pool),
             standardPoolTokens,

--- a/pkg/vault/test/foundry/PoolPause.t.sol
+++ b/pkg/vault/test/foundry/PoolPause.t.sol
@@ -137,18 +137,18 @@ contract PoolPauseTest is BaseVaultTest {
 
     function testCannotPauseIfNotManager() public {
         vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(IAuthentication.SenderNotAllowed.selector));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         vault.pausePool(address(pool));
 
         vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(IAuthentication.SenderNotAllowed.selector));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         vault.unpausePool(address(pool));
     }
 
     function testGovernancePause() public {
         // Nice try, Bob!
         vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(IAuthentication.SenderNotAllowed.selector));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         vault.pausePool(address(unmanagedPool));
 
         // Reluctantly authorize Bob

--- a/pkg/vault/test/foundry/PoolSwapManager.t.sol
+++ b/pkg/vault/test/foundry/PoolSwapManager.t.sol
@@ -100,7 +100,7 @@ contract PoolSwapManagerTest is BaseVaultTest {
         require(vault.getStaticSwapFeeManager(address(pool)) == address(admin), "Wrong swap fee manager");
 
         vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(IAuthentication.SenderNotAllowed.selector));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         vault.setStaticSwapFeePercentage(address(pool), NEW_SWAP_FEE);
     }
 
@@ -108,7 +108,7 @@ contract PoolSwapManagerTest is BaseVaultTest {
         require(vault.getStaticSwapFeePercentage(address(unmanagedPool)) == 0, "initial swap fee non-zero");
 
         vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(IAuthentication.SenderNotAllowed.selector));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         vault.setStaticSwapFeePercentage(address(unmanagedPool), NEW_SWAP_FEE);
 
         bytes32 setSwapFeeRole = vault.getActionId(IVaultAdmin.setStaticSwapFeePercentage.selector);
@@ -121,7 +121,7 @@ contract PoolSwapManagerTest is BaseVaultTest {
 
         // Granting speciic permission to bob on unmanagedPool doesn't grant it on otherPool
         vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(IAuthentication.SenderNotAllowed.selector));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         vault.setStaticSwapFeePercentage(address(otherPool), NEW_SWAP_FEE);
     }
 
@@ -130,14 +130,14 @@ contract PoolSwapManagerTest is BaseVaultTest {
         require(vault.getStaticSwapFeePercentage(address(pool)) == 0, "initial swap fee non-zero");
 
         vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(IAuthentication.SenderNotAllowed.selector));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         vault.setStaticSwapFeePercentage(address(pool), NEW_SWAP_FEE);
 
         bytes32 setSwapFeeRole = vault.getActionId(IVaultAdmin.setStaticSwapFeePercentage.selector);
         authorizer.grantRole(setSwapFeeRole, bob);
 
         vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(IAuthentication.SenderNotAllowed.selector));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         vault.setStaticSwapFeePercentage(address(pool), NEW_SWAP_FEE);
     }
 }

--- a/pkg/vault/test/foundry/RecoveryMode.t.sol
+++ b/pkg/vault/test/foundry/RecoveryMode.t.sol
@@ -65,7 +65,7 @@ contract RecoveryModeTest is BaseVaultTest {
         // When Vault is not paused, `enableRecoveryMode` is permissioned.
         require(vault.isVaultPaused() == false, "Vault should not be paused initially");
 
-        vm.expectRevert(abi.encodeWithSelector(IAuthentication.SenderNotAllowed.selector));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         vm.prank(lp);
         vault.enableRecoveryMode(pool);
 
@@ -89,7 +89,7 @@ contract RecoveryModeTest is BaseVaultTest {
         // Also ensure Vault is not paused.
         require(vault.isVaultPaused() == false, "Vault should not be paused initially");
 
-        vm.expectRevert(abi.encodeWithSelector(IAuthentication.SenderNotAllowed.selector));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         vm.prank(lp);
         vault.enableRecoveryMode(pool);
 
@@ -124,7 +124,7 @@ contract RecoveryModeTest is BaseVaultTest {
 
         // Recovery Mode is permissioned even though the Vault's pause bit is set, because it's no longer pausable.
         assertFalse(vault.isVaultPaused(), "Vault should unpause itself after buffer expiration");
-        vm.expectRevert(abi.encodeWithSelector(IAuthentication.SenderNotAllowed.selector));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         vm.prank(lp);
         vault.enableRecoveryMode(pool);
 
@@ -157,7 +157,7 @@ contract RecoveryModeTest is BaseVaultTest {
 
         // Recovery Mode is permissioned even though the Pool's pause bit is set, because it's no longer pausable.
         assertFalse(vault.isPoolPaused(pool), "Pool should unpause itself after buffer expiration");
-        vm.expectRevert(abi.encodeWithSelector(IAuthentication.SenderNotAllowed.selector));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         vm.prank(lp);
         vault.enableRecoveryMode(pool);
 

--- a/pkg/vault/test/foundry/Router.t.sol
+++ b/pkg/vault/test/foundry/Router.t.sol
@@ -129,12 +129,12 @@ contract RouterTest is BaseVaultTest {
 
     function testQuerySwap() public {
         vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(EVMCallModeHelpers.NotStaticCall.selector));
+        vm.expectRevert(EVMCallModeHelpers.NotStaticCall.selector);
         router.querySwapSingleTokenExactIn(address(pool), usdc, dai, usdcAmountIn, bytes(""));
     }
 
     function testDisableQueries() public {
-        vm.expectRevert(abi.encodeWithSelector(IAuthentication.SenderNotAllowed.selector));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
 
         vault.disableQuery();
 
@@ -146,7 +146,7 @@ contract RouterTest is BaseVaultTest {
         vm.prank(alice);
         vault.disableQuery();
 
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.QueriesDisabled.selector));
+        vm.expectRevert(IVaultErrors.QueriesDisabled.selector);
 
         vm.prank(address(0), address(0));
         router.querySwapSingleTokenExactIn(address(pool), usdc, dai, usdcAmountIn, bytes(""));
@@ -198,7 +198,7 @@ contract RouterTest is BaseVaultTest {
         checkAddLiquidityPreConditions();
 
         // Caller does not have enough ETH, even if they hold weth.
-        vm.expectRevert(abi.encodeWithSelector(RouterCommon.InsufficientEth.selector));
+        vm.expectRevert(RouterCommon.InsufficientEth.selector);
         vm.prank(alice);
         router.initialize(address(wethPoolNoInit), wethDaiTokens, wethDaiAmountsIn, initBpt, true, bytes(""));
     }
@@ -269,7 +269,7 @@ contract RouterTest is BaseVaultTest {
         checkAddLiquidityPreConditions();
 
         // Caller does not have enough ETH, even if they hold weth.
-        vm.expectRevert(abi.encodeWithSelector(RouterCommon.InsufficientEth.selector));
+        vm.expectRevert(RouterCommon.InsufficientEth.selector);
         vm.prank(alice);
         router.addLiquidityCustom(address(wethPool), wethDaiAmountsIn, bptAmountOut, true, bytes(""));
     }
@@ -501,7 +501,7 @@ contract RouterTest is BaseVaultTest {
         assertEq(amountsGiven[usdcIdx], 4321);
         assertEq(tokenIndex, usdcIdx);
 
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.TokenNotRegistered.selector));
+        vm.expectRevert(IVaultErrors.TokenNotRegistered.selector);
         router.getSingleInputArrayAndTokenIndex(address(pool), weth, daiAmountIn);
     }
 

--- a/pkg/vault/test/foundry/VaultDefaultHandlers.t.sol
+++ b/pkg/vault/test/foundry/VaultDefaultHandlers.t.sol
@@ -19,13 +19,13 @@ contract VaultDefaultHandlers is BaseVaultTest {
 
     function testReceive() public {
         vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.CannotReceiveEth.selector));
+        vm.expectRevert(IVaultErrors.CannotReceiveEth.selector);
         payable(address(vault)).transfer(1);
     }
 
     function testDefaultHandlerWithEth() public {
         vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.CannotReceiveEth.selector));
+        vm.expectRevert(IVaultErrors.CannotReceiveEth.selector);
         VaultExtensionMock(payable(address(vault))).mockExtensionHash{ value: 1 }("");
     }
 
@@ -44,7 +44,7 @@ contract VaultDefaultHandlers is BaseVaultTest {
         assertTrue(IVault(address(vault)).isPoolRegistered(pool));
 
         IVault vaultExtension = IVault(vault.getVaultExtension());
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.NotVaultDelegateCall.selector));
+        vm.expectRevert(IVaultErrors.NotVaultDelegateCall.selector);
         vaultExtension.isPoolRegistered(pool);
     }
 }

--- a/pkg/vault/test/foundry/VaultFactory.t.sol
+++ b/pkg/vault/test/foundry/VaultFactory.t.sol
@@ -46,7 +46,7 @@ contract VaultFactoryTest is Test {
 
     function testCreateNotAuthorized() public {
         vm.prank(deployer);
-        vm.expectRevert(abi.encodeWithSelector(IAuthentication.SenderNotAllowed.selector));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         factory.create(bytes32(0), address(0));
     }
 
@@ -56,7 +56,7 @@ contract VaultFactoryTest is Test {
 
         address vaultAddress = factory.getDeploymentAddress(salt);
         vm.prank(deployer);
-        vm.expectRevert(abi.encodeWithSelector(VaultFactory.VaultAddressMismatch.selector));
+        vm.expectRevert(VaultFactory.VaultAddressMismatch.selector);
         factory.create(bytes32(uint256(salt) + 1), vaultAddress);
     }
 
@@ -67,7 +67,7 @@ contract VaultFactoryTest is Test {
         address vaultAddress = factory.getDeploymentAddress(salt);
         vm.startPrank(deployer);
         factory.create(salt, vaultAddress);
-        vm.expectRevert(abi.encodeWithSelector(VaultFactory.VaultAlreadyCreated.selector));
+        vm.expectRevert(VaultFactory.VaultAlreadyCreated.selector);
         factory.create(salt, vaultAddress);
     }
 }

--- a/pkg/vault/test/foundry/VaultLiquidity.t.sol
+++ b/pkg/vault/test/foundry/VaultLiquidity.t.sol
@@ -67,7 +67,7 @@ contract VaultLiquidityTest is BaseVaultTest {
         vault.manualSetPoolConfig(pool, poolConfig);
 
         vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.DoesNotSupportUnbalancedLiquidity.selector));
+        vm.expectRevert(IVaultErrors.DoesNotSupportUnbalancedLiquidity.selector);
         router.addLiquidityUnbalanced(
             address(pool),
             [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray(),
@@ -108,7 +108,7 @@ contract VaultLiquidityTest is BaseVaultTest {
         vault.manualSetPoolConfig(pool, poolConfig);
 
         vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.DoesNotSupportUnbalancedLiquidity.selector));
+        vm.expectRevert(IVaultErrors.DoesNotSupportUnbalancedLiquidity.selector);
         router.addLiquiditySingleTokenExactOut(address(pool), dai, defaultAmount, defaultAmount, false, bytes(""));
     }
 
@@ -137,7 +137,7 @@ contract VaultLiquidityTest is BaseVaultTest {
         vault.manualSetPoolConfig(pool, poolConfig);
 
         vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.DoesNotSupportAddLiquidityCustom.selector));
+        vm.expectRevert(IVaultErrors.DoesNotSupportAddLiquidityCustom.selector);
         router.addLiquidityCustom(
             address(pool),
             [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray(),
@@ -243,7 +243,7 @@ contract VaultLiquidityTest is BaseVaultTest {
         poolConfig.liquidityManagement.disableUnbalancedLiquidity = true;
         vault.manualSetPoolConfig(pool, poolConfig);
 
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.DoesNotSupportUnbalancedLiquidity.selector));
+        vm.expectRevert(IVaultErrors.DoesNotSupportUnbalancedLiquidity.selector);
         vm.startPrank(alice);
         router.removeLiquiditySingleTokenExactIn(
             address(pool),
@@ -281,7 +281,7 @@ contract VaultLiquidityTest is BaseVaultTest {
         poolConfig.liquidityManagement.disableUnbalancedLiquidity = true;
         vault.manualSetPoolConfig(pool, poolConfig);
 
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.DoesNotSupportUnbalancedLiquidity.selector));
+        vm.expectRevert(IVaultErrors.DoesNotSupportUnbalancedLiquidity.selector);
         vm.startPrank(alice);
         router.removeLiquiditySingleTokenExactOut(
             address(pool),
@@ -317,7 +317,7 @@ contract VaultLiquidityTest is BaseVaultTest {
         poolConfig.liquidityManagement.enableRemoveLiquidityCustom = false;
         vault.manualSetPoolConfig(pool, poolConfig);
 
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.DoesNotSupportRemoveLiquidityCustom.selector));
+        vm.expectRevert(IVaultErrors.DoesNotSupportRemoveLiquidityCustom.selector);
         vm.startPrank(alice);
         router.removeLiquidityCustom(
             address(pool),

--- a/pkg/vault/test/foundry/VaultSwap.t.sol
+++ b/pkg/vault/test/foundry/VaultSwap.t.sol
@@ -93,7 +93,7 @@ contract VaultSwapTest is BaseVaultTest {
 
     function testSwapDeadlineExactIn() public {
         vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(RouterCommon.SwapDeadline.selector));
+        vm.expectRevert(RouterCommon.SwapDeadline.selector);
         router.swapSingleTokenExactIn(
             address(pool),
             usdc,
@@ -123,7 +123,7 @@ contract VaultSwapTest is BaseVaultTest {
 
     function testSwapDeadlineExactOut() public {
         vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(RouterCommon.SwapDeadline.selector));
+        vm.expectRevert(RouterCommon.SwapDeadline.selector);
         router.swapSingleTokenExactOut(
             address(pool),
             usdc,

--- a/pkg/vault/test/foundry/VaultTokens.t.sol
+++ b/pkg/vault/test/foundry/VaultTokens.t.sol
@@ -81,7 +81,7 @@ contract VaultTokenTest is BaseVaultTest {
         tokenConfig[0].rateProvider = IRateProvider(waDAI);
         tokenConfig[usdcIdx].token = IERC20(usdc);
 
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.InvalidTokenConfiguration.selector));
+        vm.expectRevert(IVaultErrors.InvalidTokenConfiguration.selector);
         _registerPool(tokenConfig);
     }
 
@@ -95,7 +95,7 @@ contract VaultTokenTest is BaseVaultTest {
         tokenConfig[ethIdx].tokenType = TokenType.WITH_RATE;
         tokenConfig[localUsdcIdx].token = IERC20(usdc);
 
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.InvalidTokenConfiguration.selector));
+        vm.expectRevert(IVaultErrors.InvalidTokenConfiguration.selector);
         _registerPool(tokenConfig);
     }
 

--- a/pkg/vault/test/foundry/unit/PoolAndVaultPaused.t.sol
+++ b/pkg/vault/test/foundry/unit/PoolAndVaultPaused.t.sol
@@ -74,7 +74,7 @@ contract PoolAndVaultPausedTest is BaseVaultTest {
         vm.warp(_vaultBufferPeriodEndTimeTest - 1);
         vault.manualSetVaultPaused(true);
 
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.VaultPaused.selector));
+        vm.expectRevert(IVaultErrors.VaultPaused.selector);
         vault.ensureUnpausedAndGetVaultState(address(pool));
     }
 
@@ -116,7 +116,7 @@ contract PoolAndVaultPausedTest is BaseVaultTest {
         vault.manualSetVaultPaused(true);
         vault.manualSetPoolPaused(address(pool), false);
 
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.VaultPaused.selector));
+        vm.expectRevert(IVaultErrors.VaultPaused.selector);
         vault.ensureUnpausedAndGetVaultState(address(pool));
     }
 


### PR DESCRIPTION
# Description

Little one to simplify expectReverts that don't need abi encoding. Doesn't hurt anything, but was being done inconsistently.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
