### PR TITLE
Draft: move token out of token config.

### DIFF
--- a/pkg/interfaces/contracts/test/IVaultMainMock.sol
+++ b/pkg/interfaces/contracts/test/IVaultMainMock.sol
@@ -101,27 +101,27 @@ interface IVaultMainMock {
 
     // Convenience functions for constructing TokenConfig arrays
 
-    function buildTokenConfig(IERC20[] memory tokens) external view returns (TokenConfig[] memory tokenConfig);
+    function buildTokenConfig(IERC20[] memory tokens) external view returns (TokenConfigRegistration[] memory tokenConfig);
 
     /// @dev Infers TokenType (STANDARD or WITH_RATE) from the presence or absence of the rate provider.
     function buildTokenConfig(
         IERC20[] memory tokens,
         IRateProvider[] memory rateProviders
-    ) external view returns (TokenConfig[] memory tokenConfig);
+    ) external view returns (TokenConfigRegistration[] memory tokenConfig);
 
     /// @dev Infers TokenType (STANDARD or WITH_RATE) from the presence or absence of the rate provider.
     function buildTokenConfig(
         IERC20[] memory tokens,
         IRateProvider[] memory rateProviders,
         bool[] memory yieldFeeFlags
-    ) external view returns (TokenConfig[] memory tokenConfig);
+    ) external view returns (TokenConfigRegistration[] memory tokenConfig);
 
     function buildTokenConfig(
         IERC20[] memory tokens,
         TokenType[] memory tokenTypes,
         IRateProvider[] memory rateProviders,
         bool[] memory yieldFeeFlags
-    ) external view returns (TokenConfig[] memory tokenConfig);
+    ) external view returns (TokenConfigRegistration[] memory tokenConfig);
 
     function accountDelta(IERC20 token, int256 delta) external;
 

--- a/pkg/interfaces/contracts/vault/IHooks.sol
+++ b/pkg/interfaces/contracts/vault/IHooks.sol
@@ -27,7 +27,7 @@ interface IHooks {
     function onRegister(
         address factory,
         address pool,
-        TokenConfig[] memory tokenConfig,
+        TokenConfigRegistration[] memory tokenConfig,
         LiquidityManagement calldata liquidityManagement
     ) external returns (bool);
 

--- a/pkg/interfaces/contracts/vault/IVaultEvents.sol
+++ b/pkg/interfaces/contracts/vault/IVaultEvents.sol
@@ -26,7 +26,7 @@ interface IVaultEvents {
     event PoolRegistered(
         address indexed pool,
         address indexed factory,
-        TokenConfig[] tokenConfig,
+        TokenConfigRegistration[] tokenConfig,
         uint256 swapFeePercentage,
         uint256 pauseWindowEndTime,
         PoolRoleAccounts roleAccounts,

--- a/pkg/interfaces/contracts/vault/IVaultExtension.sol
+++ b/pkg/interfaces/contracts/vault/IVaultExtension.sol
@@ -66,7 +66,7 @@ interface IVaultExtension {
      * authorizer.
      *
      * @param pool The address of the pool being registered
-     * @param tokenConfig An array of descriptors for the tokens the pool will manage
+     * @param tokenConfigRegistration An array of descriptors for the tokens the pool will manage
      * @param swapFeePercentage The initial static swap fee percentage of the pool
      * @param pauseWindowEndTime The timestamp after which it is no longer possible to pause the pool
      * @param roleAccounts Addresses the Vault will allow to change certain pool settings
@@ -75,7 +75,7 @@ interface IVaultExtension {
      */
     function registerPool(
         address pool,
-        TokenConfig[] memory tokenConfig,
+        TokenConfigRegistration[] memory tokenConfigRegistration,
         uint256 swapFeePercentage,
         uint256 pauseWindowEndTime,
         PoolRoleAccounts calldata roleAccounts,
@@ -130,6 +130,7 @@ interface IVaultExtension {
 
     /**
      * @notice Gets the raw data for a pool: tokens, raw balances, scaling factors.
+     * @return tokens Pool tokens
      * @return tokenConfig Pool's token configuration
      * @return balancesRaw Corresponding raw balances of the tokens
      * @return scalingFactors Corresponding scalingFactors of the tokens
@@ -139,7 +140,7 @@ interface IVaultExtension {
     )
         external
         view
-        returns (TokenConfig[] memory tokenConfig, uint256[] memory balancesRaw, uint256[] memory scalingFactors);
+        returns (IERC20[] memory tokens, TokenConfig[] memory tokenConfig, uint256[] memory balancesRaw, uint256[] memory scalingFactors);
 
     /**
      * @notice Gets the configuration parameters of a pool.

--- a/pkg/interfaces/contracts/vault/VaultTypes.sol
+++ b/pkg/interfaces/contracts/vault/VaultTypes.sol
@@ -117,15 +117,20 @@ enum TokenType {
  * @param paysYieldFees Flag indicating whether yield fees should be charged on this token
  */
 struct TokenConfig {
-    IERC20 token;
     TokenType tokenType;
     IRateProvider rateProvider;
     bool paysYieldFees;
 }
 
+struct TokenConfigRegistration {
+    IERC20 token;
+    TokenConfig config;
+}
+
 struct PoolData {
     PoolConfig poolConfig;
     TokenConfig[] tokenConfig;
+    IERC20[] tokens;
     uint256[] balancesRaw;
     uint256[] balancesLiveScaled18;
     uint256[] tokenRates;

--- a/pkg/pool-weighted/contracts/WeightedPool8020Factory.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool8020Factory.sol
@@ -45,8 +45,8 @@ contract WeightedPool8020Factory is IPoolVersion, BasePoolFactory, Version {
      * @param swapFeePercentage Initial swap fee percentage
      */
     function create(
-        TokenConfig memory highWeightTokenConfig,
-        TokenConfig memory lowWeightTokenConfig,
+        TokenConfigRegistration memory highWeightTokenConfig,
+        TokenConfigRegistration memory lowWeightTokenConfig,
         PoolRoleAccounts memory roleAccounts,
         uint256 swapFeePercentage
     ) external returns (address pool) {
@@ -57,7 +57,7 @@ contract WeightedPool8020Factory is IPoolVersion, BasePoolFactory, Version {
         IERC20 highWeightToken = highWeightTokenConfig.token;
         IERC20 lowWeightToken = lowWeightTokenConfig.token;
 
-        TokenConfig[] memory tokenConfig = new TokenConfig[](2);
+        TokenConfigRegistration[] memory tokenConfig = new TokenConfigRegistration[](2);
         uint256[] memory weights = new uint256[](2);
 
         // Tokens must be sorted.

--- a/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
@@ -52,7 +52,7 @@ contract WeightedPoolFactory is IPoolVersion, BasePoolFactory, Version {
     function create(
         string memory name,
         string memory symbol,
-        TokenConfig[] memory tokens,
+        TokenConfigRegistration[] memory tokens,
         uint256[] memory normalizedWeights,
         PoolRoleAccounts memory roleAccounts,
         uint256 swapFeePercentage,

--- a/pkg/solidity-utils/contracts/test/InputHelpersMock.sol
+++ b/pkg/solidity-utils/contracts/test/InputHelpersMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.24;
 
-import { TokenConfig } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+import { TokenConfigRegistration } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
 import "../helpers/InputHelpers.sol";
 
@@ -15,7 +15,7 @@ contract InputHelpersMock {
         InputHelpers.ensureSortedTokens(tokens);
     }
 
-    function sortTokenConfig(TokenConfig[] memory tokenConfig) public pure returns (TokenConfig[] memory) {
+    function sortTokenConfig(TokenConfigRegistration[] memory tokenConfig) public pure returns (TokenConfigRegistration[] memory) {
         for (uint256 i = 0; i < tokenConfig.length - 1; ++i) {
             for (uint256 j = 0; j < tokenConfig.length - i - 1; j++) {
                 if (tokenConfig[j].token > tokenConfig[j + 1].token) {

--- a/pkg/vault/contracts/BasePoolHooks.sol
+++ b/pkg/vault/contracts/BasePoolHooks.sol
@@ -28,7 +28,7 @@ abstract contract BasePoolHooks is IHooks, VaultGuard {
     function onRegister(
         address,
         address,
-        TokenConfig[] memory,
+        TokenConfigRegistration[] memory,
         LiquidityManagement calldata
     ) external virtual onlyVault returns (bool) {
         // By default, deny all factories. This method must be overwritten by the hook contract

--- a/pkg/vault/contracts/Vault.sol
+++ b/pkg/vault/contracts/Vault.sol
@@ -625,7 +625,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
 
             {
                 // stack-too-deep (forge)
-                IERC20 token = poolData.tokenConfig[i].token;
+                IERC20 token = poolData.tokens[i];
 
                 // 2) Check limits for raw amounts
                 if (amountInRaw > params.maxAmountsIn[i]) {
@@ -826,7 +826,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
 
             {
                 // stack-too-deep
-                IERC20 token = poolData.tokenConfig[i].token;
+                IERC20 token = poolData.tokens[i];
                 // 2) Check limits for raw amounts
                 if (amountOutRaw < params.minAmountsOut[i]) {
                     revert AmountOutBelowMin(token, amountOutRaw, params.minAmountsOut[i]);

--- a/pkg/vault/contracts/VaultCommon.sol
+++ b/pkg/vault/contracts/VaultCommon.sol
@@ -323,7 +323,7 @@ abstract contract VaultCommon is IVaultEvents, IVaultErrors, VaultStorage, Reent
 
         for (uint256 i = 0; i < numTokens; ++i) {
             bytes32 packedBalances = poolTokenBalances.unchecked_valueAt(i);
-            IERC20 token = poolData.tokenConfig[i].token;
+            IERC20 token = poolData.tokens[i];
             uint256 storedBalanceRaw = packedBalances.getBalanceRaw();
 
             // poolData has balances updated with yield fees now.

--- a/pkg/vault/contracts/factories/BasePoolFactory.sol
+++ b/pkg/vault/contracts/factories/BasePoolFactory.sol
@@ -96,7 +96,7 @@ abstract contract BasePoolFactory is IBasePoolFactory, SingletonAuthentication, 
 
     function _registerPoolWithVault(
         address pool,
-        TokenConfig[] memory tokens,
+        TokenConfigRegistration[] memory tokens,
         uint256 swapFeePercentage,
         PoolRoleAccounts memory roleAccounts,
         address poolHooksContract,

--- a/pkg/vault/contracts/lib/PoolDataLib.sol
+++ b/pkg/vault/contracts/lib/PoolDataLib.sol
@@ -38,6 +38,7 @@ library PoolDataLib {
         poolData.balancesLiveScaled18 = new uint256[](numTokens);
         poolData.decimalScalingFactors = PoolConfigLib.getDecimalScalingFactors(poolData.poolConfig, numTokens);
         poolData.tokenRates = new uint256[](numTokens);
+        poolData.tokens = new IERC20[](numTokens);
 
         bool poolSubjectToYieldFees = poolData.poolConfig.isPoolInitialized &&
             poolData.poolConfig.aggregateProtocolYieldFeePercentage > 0 &&
@@ -46,6 +47,7 @@ library PoolDataLib {
         for (uint256 i = 0; i < numTokens; ++i) {
             (IERC20 token, bytes32 packedBalance) = poolTokenBalances.unchecked_at(i);
             poolData.tokenConfig[i] = poolTokenConfig[token];
+            poolData.tokens[i] = token;
             updateTokenRate(poolData, i);
             updateRawAndLiveBalance(poolData, i, packedBalance.getBalanceRaw(), roundingDirection);
 

--- a/pkg/vault/contracts/test/PoolFactoryMock.sol
+++ b/pkg/vault/contracts/test/PoolFactoryMock.sol
@@ -21,7 +21,7 @@ contract PoolFactoryMock is FactoryWidePauseWindow {
         _vault = vault;
     }
 
-    function registerTestPool(address pool, TokenConfig[] memory tokenConfig) external {
+    function registerTestPool(address pool, TokenConfigRegistration[] memory tokenConfig) external {
         PoolRoleAccounts memory roleAccounts;
 
         _vault.registerPool(
@@ -39,7 +39,7 @@ contract PoolFactoryMock is FactoryWidePauseWindow {
         );
     }
 
-    function registerTestPool(address pool, TokenConfig[] memory tokenConfig, address poolHooksContract) external {
+    function registerTestPool(address pool, TokenConfigRegistration[] memory tokenConfig, address poolHooksContract) external {
         PoolRoleAccounts memory roleAccounts;
 
         _vault.registerPool(
@@ -59,7 +59,7 @@ contract PoolFactoryMock is FactoryWidePauseWindow {
 
     function registerTestPool(
         address pool,
-        TokenConfig[] memory tokenConfig,
+        TokenConfigRegistration[] memory tokenConfig,
         address poolHooksContract,
         address poolCreator
     ) external {
@@ -83,7 +83,7 @@ contract PoolFactoryMock is FactoryWidePauseWindow {
 
     function registerGeneralTestPool(
         address pool,
-        TokenConfig[] memory tokenConfig,
+        TokenConfigRegistration[] memory tokenConfig,
         uint256 swapFee,
         uint256 pauseWindowDuration,
         PoolRoleAccounts memory roleAccounts,
@@ -106,7 +106,7 @@ contract PoolFactoryMock is FactoryWidePauseWindow {
 
     function registerPool(
         address pool,
-        TokenConfig[] memory tokenConfig,
+        TokenConfigRegistration[] memory tokenConfig,
         PoolRoleAccounts memory roleAccounts,
         address poolHooksContract,
         LiquidityManagement calldata liquidityManagement
@@ -124,7 +124,7 @@ contract PoolFactoryMock is FactoryWidePauseWindow {
 
     function registerPoolWithSwapFee(
         address pool,
-        TokenConfig[] memory tokenConfig,
+        TokenConfigRegistration[] memory tokenConfig,
         uint256 swapFeePercentage,
         address poolHooksContract,
         LiquidityManagement calldata liquidityManagement
@@ -145,7 +145,7 @@ contract PoolFactoryMock is FactoryWidePauseWindow {
     // For tests; otherwise can't get the exact event arguments.
     function registerPoolAtTimestamp(
         address pool,
-        TokenConfig[] memory tokenConfig,
+        TokenConfigRegistration[] memory tokenConfig,
         uint256 timestamp,
         PoolRoleAccounts memory roleAccounts,
         address poolHooksContract,

--- a/pkg/vault/contracts/test/PoolHooksMock.sol
+++ b/pkg/vault/contracts/test/PoolHooksMock.sol
@@ -63,7 +63,7 @@ contract PoolHooksMock is BasePoolHooks {
     function onRegister(
         address factory,
         address,
-        TokenConfig[] memory,
+        TokenConfigRegistration[] memory,
         LiquidityManagement calldata
     ) external view override returns (bool) {
         return _allowedFactories[factory];
@@ -130,7 +130,7 @@ contract PoolHooksMock is BasePoolHooks {
         uint256 amountCalculatedScaled18
     ) external view override returns (bool success) {
         // check that actual pool balances match
-        (TokenConfig[] memory tokenConfig, uint256[] memory balancesRaw, uint256[] memory scalingFactors) = _vault
+        (IERC20[] memory tokens, TokenConfig[] memory tokenConfig, uint256[] memory balancesRaw, uint256[] memory scalingFactors) = _vault
             .getPoolTokenInfo(_pool);
 
         uint256[] memory currentLiveBalances = IVaultMock(address(_vault)).getCurrentLiveBalances(_pool);
@@ -138,7 +138,7 @@ contract PoolHooksMock is BasePoolHooks {
         uint256[] memory rates = _vault.getPoolTokenRates(_pool);
 
         for (uint256 i = 0; i < tokenConfig.length; ++i) {
-            if (tokenConfig[i].token == params.tokenIn) {
+            if (tokens[i] == params.tokenIn) {
                 if (params.tokenInBalanceScaled18 != currentLiveBalances[i]) {
                     return false;
                 }
@@ -149,7 +149,7 @@ contract PoolHooksMock is BasePoolHooks {
                 if (expectedTokenInBalanceRaw != balancesRaw[i]) {
                     return false;
                 }
-            } else if (tokenConfig[i].token == params.tokenOut) {
+            } else if (tokens[i] == params.tokenOut) {
                 if (params.tokenOutBalanceScaled18 != currentLiveBalances[i]) {
                     return false;
                 }

--- a/pkg/vault/contracts/test/VaultMock.sol
+++ b/pkg/vault/contracts/test/VaultMock.sol
@@ -123,7 +123,7 @@ contract VaultMock is IVaultMainMock, Vault {
     }
 
     function manualRegisterPoolPassThruTokens(address pool, IERC20[] memory tokens) external {
-        TokenConfig[] memory tokenConfig = new TokenConfig[](tokens.length);
+        TokenConfigRegistration[] memory tokenConfig = new TokenConfigRegistration[](tokens.length);
         PoolRoleAccounts memory roleAccounts;
         for (uint256 i = 0; i < tokens.length; ++i) {
             tokenConfig[i].token = tokens[i];
@@ -242,8 +242,8 @@ contract VaultMock is IVaultMainMock, Vault {
         return (poolData.tokenConfig, poolData.balancesRaw, poolData.decimalScalingFactors, poolData.poolConfig);
     }
 
-    function buildTokenConfig(IERC20[] memory tokens) public view returns (TokenConfig[] memory tokenConfig) {
-        tokenConfig = new TokenConfig[](tokens.length);
+    function buildTokenConfig(IERC20[] memory tokens) public view returns (TokenConfigRegistration[] memory tokenConfig) {
+        tokenConfig = new TokenConfigRegistration[](tokens.length);
         for (uint256 i = 0; i < tokens.length; ++i) {
             tokenConfig[i].token = tokens[i];
         }
@@ -254,12 +254,12 @@ contract VaultMock is IVaultMainMock, Vault {
     function buildTokenConfig(
         IERC20[] memory tokens,
         IRateProvider[] memory rateProviders
-    ) public view returns (TokenConfig[] memory tokenConfig) {
-        tokenConfig = new TokenConfig[](tokens.length);
+    ) public view returns (TokenConfigRegistration[] memory tokenConfig) {
+        tokenConfig = new TokenConfigRegistration[](tokens.length);
         for (uint256 i = 0; i < tokens.length; ++i) {
             tokenConfig[i].token = tokens[i];
-            tokenConfig[i].rateProvider = rateProviders[i];
-            tokenConfig[i].tokenType = rateProviders[i] == IRateProvider(address(0))
+            tokenConfig[i].config.rateProvider = rateProviders[i];
+            tokenConfig[i].config.tokenType = rateProviders[i] == IRateProvider(address(0))
                 ? TokenType.STANDARD
                 : TokenType.WITH_RATE;
         }
@@ -271,15 +271,15 @@ contract VaultMock is IVaultMainMock, Vault {
         IERC20[] memory tokens,
         IRateProvider[] memory rateProviders,
         bool[] memory yieldFeeFlags
-    ) public view returns (TokenConfig[] memory tokenConfig) {
-        tokenConfig = new TokenConfig[](tokens.length);
+    ) public view returns (TokenConfigRegistration[] memory tokenConfig) {
+        tokenConfig = new TokenConfigRegistration[](tokens.length);
         for (uint256 i = 0; i < tokens.length; ++i) {
             tokenConfig[i].token = tokens[i];
-            tokenConfig[i].rateProvider = rateProviders[i];
-            tokenConfig[i].tokenType = rateProviders[i] == IRateProvider(address(0))
+            tokenConfig[i].config.rateProvider = rateProviders[i];
+            tokenConfig[i].config.tokenType = rateProviders[i] == IRateProvider(address(0))
                 ? TokenType.STANDARD
                 : TokenType.WITH_RATE;
-            tokenConfig[i].paysYieldFees = yieldFeeFlags[i];
+            tokenConfig[i].config.paysYieldFees = yieldFeeFlags[i];
         }
 
         tokenConfig = _inputHelpersMock.sortTokenConfig(tokenConfig);
@@ -290,13 +290,13 @@ contract VaultMock is IVaultMainMock, Vault {
         TokenType[] memory tokenTypes,
         IRateProvider[] memory rateProviders,
         bool[] memory yieldFeeFlags
-    ) public view returns (TokenConfig[] memory tokenConfig) {
-        tokenConfig = new TokenConfig[](tokens.length);
+    ) public view returns (TokenConfigRegistration[] memory tokenConfig) {
+        tokenConfig = new TokenConfigRegistration[](tokens.length);
         for (uint256 i = 0; i < tokens.length; ++i) {
             tokenConfig[i].token = tokens[i];
-            tokenConfig[i].tokenType = tokenTypes[i];
-            tokenConfig[i].rateProvider = rateProviders[i];
-            tokenConfig[i].paysYieldFees = yieldFeeFlags[i];
+            tokenConfig[i].config.tokenType = tokenTypes[i];
+            tokenConfig[i].config.rateProvider = rateProviders[i];
+            tokenConfig[i].config.paysYieldFees = yieldFeeFlags[i];
         }
 
         tokenConfig = _inputHelpersMock.sortTokenConfig(tokenConfig);

--- a/pvt/helpers/src/models/tokens/tokenConfig.ts
+++ b/pvt/helpers/src/models/tokens/tokenConfig.ts
@@ -1,17 +1,19 @@
-import { TokenConfigStruct } from '@balancer-labs/v3-interfaces/typechain-types/contracts/vault/IVault';
+import { TokenConfigRegistrationStruct } from '@balancer-labs/v3-interfaces/typechain-types/contracts/vault/IVault';
 import { TokenType } from '@balancer-labs/v3-helpers/src/models/types/types';
 import { ZERO_ADDRESS } from '@balancer-labs/v3-helpers/src/constants';
 
-export function buildTokenConfig(tokens: string[], withRate?: boolean): TokenConfigStruct[] {
-  const result: TokenConfigStruct[] = [];
+export function buildTokenConfig(tokens: string[], withRate?: boolean): TokenConfigRegistrationStruct[] {
+  const result: TokenConfigRegistrationStruct[] = [];
   withRate = withRate ?? false;
 
   tokens.map((token, i) => {
     result[i] = {
       token: token,
-      tokenType: withRate ? TokenType.WITH_RATE : TokenType.STANDARD,
-      rateProvider: withRate ? token : ZERO_ADDRESS,
-      paysYieldFees: withRate,
+      config: {
+        tokenType: withRate ? TokenType.WITH_RATE : TokenType.STANDARD,
+        rateProvider: withRate ? token : ZERO_ADDRESS,
+        paysYieldFees: withRate,
+      },
     };
   });
 


### PR DESCRIPTION
# Description

`TokenConfig` holds the address of the token, but inside the vault you need the token address to read it.
When the token config is de-serialized, reading the token address incurs in one extra SLOAD.

The interface to register the pool makes sense, as it packs everything that is needed (token address + config). But it's probably not worth storing the token address with the token config.

Half-baked idea, but the gas costs go down (try out hardhat benchmark).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
