### PR TITLE
Extraneous field in struct

### DIFF
--- a/pkg/interfaces/contracts/vault/IHooks.sol
+++ b/pkg/interfaces/contracts/vault/IHooks.sol
@@ -41,7 +41,6 @@ interface IHooks {
         bool shouldCallAfterAddLiquidity;
         bool shouldCallBeforeRemoveLiquidity;
         bool shouldCallAfterRemoveLiquidity;
-        address hooksContract;
     }
 
     /**


### PR DESCRIPTION
# Description

HookFlags shouldn't still have the address field, right? (That's in HooksConfig.)

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
