### PR TITLE
Support empty permit2 batches

### DIFF
--- a/pkg/vault/contracts/Router.sol
+++ b/pkg/vault/contracts/Router.sol
@@ -1156,8 +1156,13 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
                 s
             );
         }
-        // Use Permit2 for tokens that are swapped and added into the Vault.
-        _permit2.permit(msg.sender, permit2Batch, permit2Signature);
+
+        // Only call permit2 if there's something to do.
+        if (permit2Batch.details.length > 0) {
+            // Use Permit2 for tokens that are swapped and added into the Vault.
+            _permit2.permit(msg.sender, permit2Batch, permit2Signature);
+        }
+
         // Execute all the required operations once permissions have been granted.
         return multicall(multicallData);
     }

--- a/pkg/vault/test/foundry/Permit2.t.sol
+++ b/pkg/vault/test/foundry/Permit2.t.sol
@@ -134,4 +134,27 @@ contract Permit2Test is BaseVaultTest {
         // Allowance is spent
         assertEq(amount, 0, "USDC allowance is not spent");
     }
+
+    function testEmptyBatchAndCall() public {
+        IRouter.PermitApproval[] memory permitBatch = new IRouter.PermitApproval[](0);
+        bytes[] memory permitSignatures = new bytes[](0);
+        IAllowanceTransfer.PermitBatch memory permit2Batch;
+        bytes[] memory multicallData = new bytes[](1);
+
+        uint256[] memory amountsIn = [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray();
+        bptAmountOut = defaultAmount * 2;
+
+        multicallData[0] = abi.encodeWithSelector(
+            IRouter.addLiquidityUnbalanced.selector,
+            address(pool),
+            amountsIn,
+            bptAmountOut,
+            false,
+            bytes("")
+        );
+
+        vm.expectCall(address(router), multicallData[0]);
+        vm.prank(alice);
+        router.permitBatchAndCall(permitBatch, permitSignatures, permit2Batch, "", multicallData);
+    }
 }


### PR DESCRIPTION
# Description

There's no reason to call [permit2](https://etherscan.deth.net/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) (see `AllowanceTransfer#L43`) if there's nothing to do in the permit2 batch. Therefore we can just skip the call.

This allows the SDK to just call `permitBatchAndCall` even if there's nothing to do on the permit2 side.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A