### PR TITLE
Remove unnecessary address(pool)

### DIFF
--- a/pkg/vault/test/foundry/BalancerPoolTokenTest.t.sol
+++ b/pkg/vault/test/foundry/BalancerPoolTokenTest.t.sol
@@ -61,17 +61,17 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     function testBurn() public {
         uint256 burnAmount = defaultAmount - MINIMUM_TOTAL_SUPPLY;
 
-        vault.mintERC20(address(pool), user, defaultAmount);
+        vault.mintERC20(pool, user, defaultAmount);
 
         vm.expectEmit();
         emit IERC20.Transfer(user, address(0), burnAmount);
-        vault.burnERC20(address(pool), user, burnAmount);
+        vault.burnERC20(pool, user, burnAmount);
 
         assertEq(poolToken.balanceOf(user), MINIMUM_TOTAL_SUPPLY, "balance mismatch");
     }
 
     function testApprove() public {
-        vault.mintERC20(address(pool), address(this), defaultAmount);
+        vault.mintERC20(pool, address(this), defaultAmount);
 
         vm.expectEmit();
         emit IERC20.Approval(address(this), user, defaultAmount);
@@ -81,7 +81,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     function testTransfer() public {
-        vault.mintERC20(address(pool), address(this), defaultAmount);
+        vault.mintERC20(pool, address(this), defaultAmount);
 
         vm.expectEmit();
         emit IERC20.Transfer(address(this), user, defaultAmount);
@@ -95,7 +95,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     function testTransferFrom() public {
         address from = address(0xABCD);
 
-        vault.mintERC20(address(pool), address(from), defaultAmount);
+        vault.mintERC20(pool, address(from), defaultAmount);
 
         vm.prank(from);
         poolToken.approve(address(this), defaultAmount);

--- a/pkg/vault/test/foundry/DynamicFeePoolTest.t.sol
+++ b/pkg/vault/test/foundry/DynamicFeePoolTest.t.sol
@@ -102,14 +102,14 @@ contract DynamicFeePoolTest is BaseVaultTest {
         );
 
         vm.expectCall(
-            address(pool),
+            pool,
             abi.encodeWithSelector(PoolMock.onSwap.selector, poolSwapParams),
             1 // callCount
         );
 
         vm.prank(alice);
         // Perform a swap in the pool
-        router.swapSingleTokenExactIn(address(pool), dai, usdc, defaultAmount, 0, MAX_UINT256, false, bytes(""));
+        router.swapSingleTokenExactIn(pool, dai, usdc, defaultAmount, 0, MAX_UINT256, false, bytes(""));
     }
 
     function testSwapCallsComputeFeeWithSender() public {
@@ -130,7 +130,7 @@ contract DynamicFeePoolTest is BaseVaultTest {
         );
 
         vm.expectCall(
-            address(pool),
+            pool,
             abi.encodeWithSelector(PoolMock.onSwap.selector, poolSwapParams),
             1 // callCount
         );
@@ -142,7 +142,7 @@ contract DynamicFeePoolTest is BaseVaultTest {
         uint256 aliceBalanceBefore = usdc.balanceOf(alice);
 
         vm.prank(alice);
-        router.swapSingleTokenExactIn(address(pool), dai, usdc, defaultAmount, 0, MAX_UINT256, false, bytes(""));
+        router.swapSingleTokenExactIn(pool, dai, usdc, defaultAmount, 0, MAX_UINT256, false, bytes(""));
 
         uint256 aliceBalanceAfter = usdc.balanceOf(alice);
         // 100% fee; should get nothing
@@ -153,7 +153,7 @@ contract DynamicFeePoolTest is BaseVaultTest {
         aliceBalanceBefore = aliceBalanceAfter;
 
         vm.prank(alice);
-        router.swapSingleTokenExactIn(address(pool), dai, usdc, defaultAmount, 0, MAX_UINT256, false, bytes(""));
+        router.swapSingleTokenExactIn(pool, dai, usdc, defaultAmount, 0, MAX_UINT256, false, bytes(""));
 
         aliceBalanceAfter = usdc.balanceOf(alice);
         // No fee; should get full swap amount
@@ -163,7 +163,7 @@ contract DynamicFeePoolTest is BaseVaultTest {
     function testExternalComputeFee() public {
         authorizer.grantRole(vault.getActionId(IVaultAdmin.setStaticSwapFeePercentage.selector), alice);
         vm.prank(alice);
-        vault.setStaticSwapFeePercentage(address(pool), 10e16);
+        vault.setStaticSwapFeePercentage(pool, 10e16);
         uint256[] memory balances;
 
         vm.expectCall(
@@ -189,7 +189,7 @@ contract DynamicFeePoolTest is BaseVaultTest {
 
         PoolHooksMock(poolHooksContract).setDynamicSwapFeePercentage(dynamicSwapFeePercentage);
 
-        (bool success, uint256 actualDynamicSwapFee) = vault.computeDynamicSwapFee(address(pool), swapParams);
+        (bool success, uint256 actualDynamicSwapFee) = vault.computeDynamicSwapFee(pool, swapParams);
 
         assertTrue(success, "computeDynamicSwapFee returned false");
         assertEq(actualDynamicSwapFee, dynamicSwapFeePercentage, "Wrong dynamicSwapFeePercentage");
@@ -201,7 +201,7 @@ contract DynamicFeePoolTest is BaseVaultTest {
 
         vm.prank(alice);
         uint256 swapAmountOut = router.swapSingleTokenExactIn(
-            address(pool),
+            pool,
             dai,
             usdc,
             defaultAmount,

--- a/pkg/vault/test/foundry/GetBptRate.t.sol
+++ b/pkg/vault/test/foundry/GetBptRate.t.sol
@@ -76,19 +76,19 @@ contract GetBptRateTest is BaseVaultTest {
             .toMemoryArray();
         uint256 weightedInvariant = WeightedMath.computeInvariant(weights, liveBalances);
         uint256 expectedRate = weightedInvariant.divDown(totalSupply);
-        uint256 actualRate = vault.getBptRate(address(pool));
+        uint256 actualRate = vault.getBptRate(pool);
         assertEq(actualRate, expectedRate, "Wrong rate");
 
         uint256[] memory amountsIn = [defaultAmount, 0].toMemoryArray();
         vm.prank(bob);
-        uint256 addLiquidityBptAmountOut = router.addLiquidityUnbalanced(address(pool), amountsIn, 0, false, bytes(""));
+        uint256 addLiquidityBptAmountOut = router.addLiquidityUnbalanced(pool, amountsIn, 0, false, bytes(""));
 
         totalSupply += addLiquidityBptAmountOut;
         liveBalances = [2 * defaultAmount.mulDown(daiMockRate), defaultAmount.mulDown(usdcMockRate)].toMemoryArray();
         weightedInvariant = WeightedMath.computeInvariant(weights, liveBalances);
 
         expectedRate = weightedInvariant.divDown(totalSupply);
-        actualRate = vault.getBptRate(address(pool));
+        actualRate = vault.getBptRate(pool);
         assertEq(actualRate, expectedRate, "Wrong rate after addLiquidity");
     }
 }

--- a/pkg/vault/test/foundry/Hooks.t.sol
+++ b/pkg/vault/test/foundry/Hooks.t.sol
@@ -35,7 +35,7 @@ contract HooksTest is BaseVaultTest {
         BaseVaultTest.setUp();
 
         // Sets the pool address in the hook, so we can check balances of the pool inside the hook
-        PoolHooksMock(poolHooksContract).setPool(address(pool));
+        PoolHooksMock(poolHooksContract).setPool(pool);
 
         (daiIdx, usdcIdx) = getSortedIndexes(address(dai), address(usdc));
 
@@ -121,9 +121,9 @@ contract HooksTest is BaseVaultTest {
     // dynamic fee
 
     function testOnComputeDynamicSwapFeeHook() public {
-        HooksConfig memory hooksConfig = vault.getHooksConfig(address(pool));
+        HooksConfig memory hooksConfig = vault.getHooksConfig(pool);
         hooksConfig.shouldCallComputeDynamicSwapFee = true;
-        vault.setHooksConfig(address(pool), hooksConfig);
+        vault.setHooksConfig(pool, hooksConfig);
 
         vm.prank(bob);
         vm.expectCall(
@@ -143,20 +143,20 @@ contract HooksTest is BaseVaultTest {
             )
         );
         snapStart("swapWithOnComputeDynamicSwapFeeHook");
-        router.swapSingleTokenExactIn(address(pool), usdc, dai, defaultAmount, 0, MAX_UINT256, false, bytes(""));
+        router.swapSingleTokenExactIn(pool, usdc, dai, defaultAmount, 0, MAX_UINT256, false, bytes(""));
         snapEnd();
     }
 
     function testOnComputeDynamicSwapFeeHookReturningStaticFee() public {
         uint256 staticSwapFeePercentage = 10e16;
 
-        HooksConfig memory hooksConfig = vault.getHooksConfig(address(pool));
+        HooksConfig memory hooksConfig = vault.getHooksConfig(pool);
         hooksConfig.shouldCallComputeDynamicSwapFee = true;
-        vault.setHooksConfig(address(pool), hooksConfig);
+        vault.setHooksConfig(pool, hooksConfig);
 
         authorizer.grantRole(vault.getActionId(IVaultAdmin.setStaticSwapFeePercentage.selector), alice);
         vm.prank(alice);
-        vault.setStaticSwapFeePercentage(address(pool), staticSwapFeePercentage);
+        vault.setStaticSwapFeePercentage(pool, staticSwapFeePercentage);
 
         vm.prank(bob);
         vm.expectCall(
@@ -175,36 +175,27 @@ contract HooksTest is BaseVaultTest {
                 staticSwapFeePercentage
             )
         );
-        router.swapSingleTokenExactIn(address(pool), usdc, dai, defaultAmount, 0, MAX_UINT256, false, bytes(""));
+        router.swapSingleTokenExactIn(pool, usdc, dai, defaultAmount, 0, MAX_UINT256, false, bytes(""));
     }
 
     function testOnComputeDynamicSwapFeeHookRevert() public {
-        HooksConfig memory hooksConfig = vault.getHooksConfig(address(pool));
+        HooksConfig memory hooksConfig = vault.getHooksConfig(pool);
         hooksConfig.shouldCallComputeDynamicSwapFee = true;
-        vault.setHooksConfig(address(pool), hooksConfig);
+        vault.setHooksConfig(pool, hooksConfig);
 
         // should fail
         PoolHooksMock(poolHooksContract).setFailOnComputeDynamicSwapFeeHook(true);
         vm.prank(bob);
         vm.expectRevert(IVaultErrors.DynamicSwapFeeHookFailed.selector);
-        router.swapSingleTokenExactIn(
-            address(pool),
-            usdc,
-            dai,
-            defaultAmount,
-            defaultAmount,
-            MAX_UINT256,
-            false,
-            bytes("")
-        );
+        router.swapSingleTokenExactIn(pool, usdc, dai, defaultAmount, defaultAmount, MAX_UINT256, false, bytes(""));
     }
 
     // before swap
 
     function testOnBeforeSwapHook() public {
-        HooksConfig memory hooksConfig = vault.getHooksConfig(address(pool));
+        HooksConfig memory hooksConfig = vault.getHooksConfig(pool);
         hooksConfig.shouldCallBeforeSwap = true;
-        vault.setHooksConfig(address(pool), hooksConfig);
+        vault.setHooksConfig(pool, hooksConfig);
 
         vm.prank(bob);
         vm.expectCall(
@@ -223,37 +214,28 @@ contract HooksTest is BaseVaultTest {
             )
         );
         snapStart("swapWithOnBeforeSwapHook");
-        router.swapSingleTokenExactIn(address(pool), usdc, dai, defaultAmount, 0, MAX_UINT256, false, bytes(""));
+        router.swapSingleTokenExactIn(pool, usdc, dai, defaultAmount, 0, MAX_UINT256, false, bytes(""));
         snapEnd();
     }
 
     function testOnBeforeSwapHookRevert() public {
-        HooksConfig memory hooksConfig = vault.getHooksConfig(address(pool));
+        HooksConfig memory hooksConfig = vault.getHooksConfig(pool);
         hooksConfig.shouldCallBeforeSwap = true;
-        vault.setHooksConfig(address(pool), hooksConfig);
+        vault.setHooksConfig(pool, hooksConfig);
 
         // should fail
         PoolHooksMock(poolHooksContract).setFailOnBeforeSwapHook(true);
         vm.prank(bob);
         vm.expectRevert(IVaultErrors.BeforeSwapHookFailed.selector);
-        router.swapSingleTokenExactIn(
-            address(pool),
-            usdc,
-            dai,
-            defaultAmount,
-            defaultAmount,
-            MAX_UINT256,
-            false,
-            bytes("")
-        );
+        router.swapSingleTokenExactIn(pool, usdc, dai, defaultAmount, defaultAmount, MAX_UINT256, false, bytes(""));
     }
 
     // after swap
 
     function testOnAfterSwapHook() public {
-        HooksConfig memory hooksConfig = vault.getHooksConfig(address(pool));
+        HooksConfig memory hooksConfig = vault.getHooksConfig(pool);
         hooksConfig.shouldCallAfterSwap = true;
-        vault.setHooksConfig(address(pool), hooksConfig);
+        vault.setHooksConfig(pool, hooksConfig);
 
         setSwapFeePercentage(swapFeePercentage);
         vault.manualSetAggregateProtocolSwapFeePercentage(
@@ -287,29 +269,20 @@ contract HooksTest is BaseVaultTest {
         );
 
         snapStart("swapWithOnAfterSwapHook");
-        router.swapSingleTokenExactIn(address(pool), usdc, dai, defaultAmount, 0, MAX_UINT256, false, bytes(""));
+        router.swapSingleTokenExactIn(pool, usdc, dai, defaultAmount, 0, MAX_UINT256, false, bytes(""));
         snapEnd();
     }
 
     function testOnAfterSwapHookRevert() public {
-        HooksConfig memory hooksConfig = vault.getHooksConfig(address(pool));
+        HooksConfig memory hooksConfig = vault.getHooksConfig(pool);
         hooksConfig.shouldCallAfterSwap = true;
-        vault.setHooksConfig(address(pool), hooksConfig);
+        vault.setHooksConfig(pool, hooksConfig);
 
         // should fail
         PoolHooksMock(poolHooksContract).setFailOnAfterSwapHook(true);
         vm.prank(bob);
         vm.expectRevert(IVaultErrors.AfterSwapHookFailed.selector);
-        router.swapSingleTokenExactIn(
-            address(pool),
-            usdc,
-            dai,
-            defaultAmount,
-            defaultAmount,
-            MAX_UINT256,
-            false,
-            bytes("")
-        );
+        router.swapSingleTokenExactIn(pool, usdc, dai, defaultAmount, defaultAmount, MAX_UINT256, false, bytes(""));
     }
 
     // Before add
@@ -320,7 +293,7 @@ contract HooksTest is BaseVaultTest {
         vm.prank(bob);
         // Doesn't fail, does not call hooks
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [defaultAmount, defaultAmount].toMemoryArray(),
             bptAmount,
             false,
@@ -329,9 +302,9 @@ contract HooksTest is BaseVaultTest {
     }
 
     function testOnBeforeAddLiquidityHook() public {
-        HooksConfig memory hooksConfig = vault.getHooksConfig(address(pool));
+        HooksConfig memory hooksConfig = vault.getHooksConfig(pool);
         hooksConfig.shouldCallBeforeAddLiquidity = true;
-        vault.setHooksConfig(address(pool), hooksConfig);
+        vault.setHooksConfig(pool, hooksConfig);
 
         vm.prank(bob);
         vm.expectCall(
@@ -348,7 +321,7 @@ contract HooksTest is BaseVaultTest {
         );
         snapStart("addLiquidityWithOnBeforeHook");
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [defaultAmount, defaultAmount].toMemoryArray(),
             bptAmountRoundDown,
             false,
@@ -364,7 +337,7 @@ contract HooksTest is BaseVaultTest {
 
         vm.prank(alice);
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [defaultAmount, defaultAmount].toMemoryArray(),
             bptAmount,
             false,
@@ -373,7 +346,7 @@ contract HooksTest is BaseVaultTest {
 
         vm.prank(alice);
         router.removeLiquidityProportional(
-            address(pool),
+            pool,
             bptAmount,
             [defaultAmountRoundDown, defaultAmountRoundDown].toMemoryArray(),
             false,
@@ -382,13 +355,13 @@ contract HooksTest is BaseVaultTest {
     }
 
     function testOnBeforeRemoveLiquidityHook() public {
-        HooksConfig memory hooksConfig = vault.getHooksConfig(address(pool));
+        HooksConfig memory hooksConfig = vault.getHooksConfig(pool);
         hooksConfig.shouldCallBeforeRemoveLiquidity = true;
-        vault.setHooksConfig(address(pool), hooksConfig);
+        vault.setHooksConfig(pool, hooksConfig);
 
         vm.prank(alice);
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [defaultAmount, defaultAmount].toMemoryArray(),
             bptAmount,
             false,
@@ -410,7 +383,7 @@ contract HooksTest is BaseVaultTest {
         vm.prank(alice);
         snapStart("removeLiquidityWithOnBeforeHook");
         router.removeLiquidityProportional(
-            address(pool),
+            pool,
             bptAmount,
             [defaultAmountRoundDown, defaultAmountRoundDown].toMemoryArray(),
             false,
@@ -427,7 +400,7 @@ contract HooksTest is BaseVaultTest {
         vm.prank(bob);
         // Doesn't fail, does not call hooks
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [defaultAmount, defaultAmount].toMemoryArray(),
             bptAmount,
             false,
@@ -436,9 +409,9 @@ contract HooksTest is BaseVaultTest {
     }
 
     function testOnAfterAddLiquidityHook() public {
-        HooksConfig memory hooksConfig = vault.getHooksConfig(address(pool));
+        HooksConfig memory hooksConfig = vault.getHooksConfig(pool);
         hooksConfig.shouldCallAfterAddLiquidity = true;
-        vault.setHooksConfig(address(pool), hooksConfig);
+        vault.setHooksConfig(pool, hooksConfig);
 
         vm.prank(bob);
         vm.expectCall(
@@ -454,7 +427,7 @@ contract HooksTest is BaseVaultTest {
         );
         snapStart("addLiquidityWithOnAfterHook");
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [defaultAmount, defaultAmount].toMemoryArray(),
             bptAmountRoundDown,
             false,
@@ -470,7 +443,7 @@ contract HooksTest is BaseVaultTest {
 
         vm.prank(alice);
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [defaultAmount, defaultAmount].toMemoryArray(),
             bptAmount,
             false,
@@ -479,7 +452,7 @@ contract HooksTest is BaseVaultTest {
 
         vm.prank(alice);
         router.removeLiquidityProportional(
-            address(pool),
+            pool,
             bptAmount,
             [defaultAmountRoundDown, defaultAmountRoundDown].toMemoryArray(),
             false,
@@ -488,13 +461,13 @@ contract HooksTest is BaseVaultTest {
     }
 
     function testOnAfterRemoveLiquidityHook() public {
-        HooksConfig memory hooksConfig = vault.getHooksConfig(address(pool));
+        HooksConfig memory hooksConfig = vault.getHooksConfig(pool);
         hooksConfig.shouldCallAfterRemoveLiquidity = true;
-        vault.setHooksConfig(address(pool), hooksConfig);
+        vault.setHooksConfig(pool, hooksConfig);
 
         vm.prank(alice);
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [defaultAmount, defaultAmount].toMemoryArray(),
             bptAmount,
             false,
@@ -516,7 +489,7 @@ contract HooksTest is BaseVaultTest {
         vm.prank(alice);
         snapStart("removeLiquidityWithOnAfterHook");
         router.removeLiquidityProportional(
-            address(pool),
+            pool,
             bptAmount,
             [defaultAmountRoundDown, defaultAmountRoundDown].toMemoryArray(),
             false,

--- a/pkg/vault/test/foundry/HooksAlteringBalances.t.sol
+++ b/pkg/vault/test/foundry/HooksAlteringBalances.t.sol
@@ -30,12 +30,12 @@ contract HooksAlteringBalancesTest is BaseVaultTest {
 
         _swapAmount = poolInitAmount / 100;
 
-        HooksConfig memory config = vault.getHooksConfig(address(pool));
+        HooksConfig memory config = vault.getHooksConfig(pool);
         config.shouldCallBeforeSwap = true;
-        vault.setHooksConfig(address(pool), config);
+        vault.setHooksConfig(pool, config);
 
         // Sets the pool address in the hook, so we can change pool balances inside the hook
-        PoolHooksMock(poolHooksContract).setPool(address(pool));
+        PoolHooksMock(poolHooksContract).setPool(pool);
 
         (daiIdx, usdcIdx) = getSortedIndexes(address(dai), address(usdc));
     }
@@ -81,7 +81,7 @@ contract HooksAlteringBalancesTest is BaseVaultTest {
         );
 
         vm.expectCall(
-            address(pool),
+            pool,
             abi.encodeWithSelector(
                 IBasePool.onSwap.selector,
                 IBasePool.PoolSwapParams({
@@ -96,13 +96,13 @@ contract HooksAlteringBalancesTest is BaseVaultTest {
             )
         );
 
-        router.swapSingleTokenExactIn(address(pool), dai, usdc, _swapAmount, 0, MAX_UINT256, false, bytes(""));
+        router.swapSingleTokenExactIn(pool, dai, usdc, _swapAmount, 0, MAX_UINT256, false, bytes(""));
     }
 
     function testOnBeforeAddLiquidityHookAltersBalances() public {
-        HooksConfig memory config = vault.getHooksConfig(address(pool));
+        HooksConfig memory config = vault.getHooksConfig(pool);
         config.shouldCallBeforeAddLiquidity = true;
-        vault.setHooksConfig(address(pool), config);
+        vault.setHooksConfig(pool, config);
 
         uint256[] memory originalBalances = [poolInitAmount, poolInitAmount].toMemoryArray();
         // newBalances are raw and scaled18, because rate is 1 and decimals are 18
@@ -128,7 +128,7 @@ contract HooksAlteringBalancesTest is BaseVaultTest {
         );
 
         vm.expectCall(
-            address(pool),
+            pool,
             abi.encodeWithSelector(
                 IPoolLiquidity.onAddLiquidityCustom.selector,
                 router,
@@ -139,19 +139,19 @@ contract HooksAlteringBalancesTest is BaseVaultTest {
             )
         );
 
-        router.addLiquidityCustom(address(pool), amountsIn, bptAmountRoundDown, false, bytes(""));
+        router.addLiquidityCustom(pool, amountsIn, bptAmountRoundDown, false, bytes(""));
     }
 
     function testOnBeforeRemoveLiquidityHookAlterBalance() public {
-        HooksConfig memory config = vault.getHooksConfig(address(pool));
+        HooksConfig memory config = vault.getHooksConfig(pool);
         config.shouldCallBeforeRemoveLiquidity = true;
-        vault.setHooksConfig(address(pool), config);
+        vault.setHooksConfig(pool, config);
 
         uint256[] memory amountsOut = [defaultAmount, defaultAmount].toMemoryArray();
 
         vm.prank(alice);
         // Add liquidity to have BPTs to remove liquidity later
-        router.addLiquidityUnbalanced(address(pool), amountsOut, 0, false, bytes(""));
+        router.addLiquidityUnbalanced(pool, amountsOut, 0, false, bytes(""));
 
         uint256 balanceAfterLiquidity = poolInitAmount + defaultAmount;
 
@@ -179,7 +179,7 @@ contract HooksAlteringBalancesTest is BaseVaultTest {
 
         // removeLiquidityCustom passes the minAmountsOut to the callback, so we can check that they are updated.
         vm.expectCall(
-            address(pool),
+            pool,
             abi.encodeWithSelector(
                 IPoolLiquidity.onRemoveLiquidityCustom.selector,
                 router,
@@ -190,6 +190,6 @@ contract HooksAlteringBalancesTest is BaseVaultTest {
             )
         );
         vm.prank(alice);
-        router.removeLiquidityCustom(address(pool), bptAmount, amountsOut, false, bytes(""));
+        router.removeLiquidityCustom(pool, bptAmount, amountsOut, false, bytes(""));
     }
 }

--- a/pkg/vault/test/foundry/HooksAlteringRates.t.sol
+++ b/pkg/vault/test/foundry/HooksAlteringRates.t.sol
@@ -28,9 +28,9 @@ contract HooksAlteringRatesTest is BaseVaultTest {
     function setUp() public virtual override {
         BaseVaultTest.setUp();
 
-        HooksConfig memory config = vault.getHooksConfig(address(pool));
+        HooksConfig memory config = vault.getHooksConfig(pool);
         config.shouldCallBeforeSwap = true;
-        vault.setHooksConfig(address(pool), config);
+        vault.setHooksConfig(pool, config);
 
         (daiIdx, usdcIdx) = getSortedIndexes(address(dai), address(usdc));
     }
@@ -67,7 +67,7 @@ contract HooksAlteringRatesTest is BaseVaultTest {
         // Check that the swap gets balances and amount given that reflect the updated rate
         vm.prank(bob);
         vm.expectCall(
-            address(pool),
+            pool,
             abi.encodeWithSelector(
                 IBasePool.onSwap.selector,
                 IBasePool.PoolSwapParams({
@@ -82,7 +82,7 @@ contract HooksAlteringRatesTest is BaseVaultTest {
             )
         );
 
-        router.swapSingleTokenExactIn(address(pool), dai, usdc, defaultAmount, 0, MAX_UINT256, false, bytes(""));
+        router.swapSingleTokenExactIn(pool, dai, usdc, defaultAmount, 0, MAX_UINT256, false, bytes(""));
     }
 
     function testOnBeforeInitializeHookAltersRate() public {
@@ -133,10 +133,10 @@ contract HooksAlteringRatesTest is BaseVaultTest {
     }
 
     function testOnBeforeAddLiquidityHookAltersRate() public {
-        HooksConfig memory config = vault.getHooksConfig(address(pool));
+        HooksConfig memory config = vault.getHooksConfig(pool);
         config.shouldCallBeforeAddLiquidity = true;
         config.shouldCallAfterAddLiquidity = true;
-        vault.setHooksConfig(address(pool), config);
+        vault.setHooksConfig(pool, config);
 
         // Change rate of first token
         PoolHooksMock(poolHooksContract).setChangeTokenRateOnBeforeAddLiquidityHook(true, rateProvider, 0.5e18);
@@ -169,7 +169,7 @@ contract HooksAlteringRatesTest is BaseVaultTest {
         );
 
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [defaultAmount, defaultAmount].toMemoryArray(),
             bptAmountRoundDown,
             false,
@@ -178,9 +178,9 @@ contract HooksAlteringRatesTest is BaseVaultTest {
     }
 
     function testOnBeforeRemoveLiquidityHookAlterRate() public {
-        HooksConfig memory config = vault.getHooksConfig(address(pool));
+        HooksConfig memory config = vault.getHooksConfig(pool);
         config.shouldCallBeforeRemoveLiquidity = true;
-        vault.setHooksConfig(address(pool), config);
+        vault.setHooksConfig(pool, config);
 
         // Change rate of first token
         PoolHooksMock(poolHooksContract).setChangeTokenRateOnBeforeRemoveLiquidityHook(true, rateProvider, 0.5e18);
@@ -189,7 +189,7 @@ contract HooksAlteringRatesTest is BaseVaultTest {
 
         vm.prank(alice);
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [defaultAmount, defaultAmount].toMemoryArray(),
             bptAmount,
             false,
@@ -207,7 +207,7 @@ contract HooksAlteringRatesTest is BaseVaultTest {
 
         // removeLiquidityCustom passes the minAmountsOut to the callback, so we can check that they are updated.
         vm.expectCall(
-            address(pool),
+            pool,
             abi.encodeWithSelector(
                 IPoolLiquidity.onRemoveLiquidityCustom.selector,
                 router,
@@ -219,7 +219,7 @@ contract HooksAlteringRatesTest is BaseVaultTest {
         );
         vm.prank(alice);
         router.removeLiquidityCustom(
-            address(pool),
+            pool,
             bptAmount,
             [defaultAmountRoundDown, defaultAmountRoundDown].toMemoryArray(),
             false,

--- a/pkg/vault/test/foundry/Initializer.t.sol
+++ b/pkg/vault/test/foundry/Initializer.t.sol
@@ -29,10 +29,10 @@ contract InitializerTest is BaseVaultTest {
     function setUp() public virtual override {
         BaseVaultTest.setUp();
 
-        HooksConfig memory config = vault.getHooksConfig(address(pool));
+        HooksConfig memory config = vault.getHooksConfig(pool);
         config.shouldCallBeforeInitialize = true;
         config.shouldCallAfterInitialize = true;
-        vault.setHooksConfig(address(pool), config);
+        vault.setHooksConfig(pool, config);
 
         standardPoolTokens = InputHelpers.sortTokens([address(dai), address(usdc)].toMemoryArray().asIERC20());
     }
@@ -40,17 +40,17 @@ contract InitializerTest is BaseVaultTest {
     function initPool() internal override {}
 
     function testNoRevertWithZeroConfig() public {
-        HooksConfig memory config = vault.getHooksConfig(address(pool));
+        HooksConfig memory config = vault.getHooksConfig(pool);
         config.shouldCallBeforeInitialize = false;
         config.shouldCallAfterInitialize = false;
-        vault.setHooksConfig(address(pool), config);
+        vault.setHooksConfig(pool, config);
 
         PoolHooksMock(poolHooksContract).setFailOnBeforeInitializeHook(true);
         PoolHooksMock(poolHooksContract).setFailOnAfterInitializeHook(true);
 
         vm.prank(bob);
         router.initialize(
-            address(pool),
+            pool,
             standardPoolTokens,
             [defaultAmount, defaultAmount].toMemoryArray(),
             0,
@@ -70,7 +70,7 @@ contract InitializerTest is BaseVaultTest {
             )
         );
         router.initialize(
-            address(pool),
+            pool,
             standardPoolTokens,
             [defaultAmount, defaultAmount].toMemoryArray(),
             0,
@@ -84,7 +84,7 @@ contract InitializerTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectRevert(IVaultErrors.BeforeInitializeHookFailed.selector);
         router.initialize(
-            address(pool),
+            pool,
             standardPoolTokens,
             [defaultAmount, defaultAmount].toMemoryArray(),
             0,
@@ -105,7 +105,7 @@ contract InitializerTest is BaseVaultTest {
             )
         );
         router.initialize(
-            address(pool),
+            pool,
             standardPoolTokens,
             [defaultAmount, defaultAmount].toMemoryArray(),
             0,
@@ -119,7 +119,7 @@ contract InitializerTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectRevert(IVaultErrors.AfterInitializeHookFailed.selector);
         router.initialize(
-            address(pool),
+            pool,
             standardPoolTokens,
             [defaultAmount, defaultAmount].toMemoryArray(),
             0,

--- a/pkg/vault/test/foundry/Permit2.t.sol
+++ b/pkg/vault/test/foundry/Permit2.t.sol
@@ -38,16 +38,7 @@ contract Permit2Test is BaseVaultTest {
         assertEq(amount, 0);
 
         vm.expectRevert(abi.encodeWithSelector(IAllowanceTransfer.AllowanceExpired.selector, 0));
-        router.swapSingleTokenExactIn(
-            address(pool),
-            usdc,
-            dai,
-            defaultAmount,
-            defaultAmount,
-            MAX_UINT256,
-            false,
-            bytes("")
-        );
+        router.swapSingleTokenExactIn(pool, usdc, dai, defaultAmount, defaultAmount, MAX_UINT256, false, bytes(""));
     }
 
     function testPermitBatchAndCall() public {
@@ -73,7 +64,7 @@ contract Permit2Test is BaseVaultTest {
 
         bytes[] memory permitSignatures = new bytes[](1);
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
-            IEIP712(address(pool)),
+            IEIP712(pool),
             alice,
             address(router),
             bptAmountOut,
@@ -103,7 +94,7 @@ contract Permit2Test is BaseVaultTest {
         bytes[] memory multicallData = new bytes[](2);
         multicallData[0] = abi.encodeWithSelector(
             IRouter.addLiquidityUnbalanced.selector,
-            address(pool),
+            pool,
             amountsIn,
             bptAmountOut,
             false,
@@ -113,7 +104,7 @@ contract Permit2Test is BaseVaultTest {
         uint256[] memory minAmountsOut = [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray();
         multicallData[1] = abi.encodeWithSelector(
             IRouter.removeLiquidityProportional.selector,
-            address(pool),
+            pool,
             bptAmountOut,
             minAmountsOut,
             false,
@@ -146,7 +137,7 @@ contract Permit2Test is BaseVaultTest {
 
         multicallData[0] = abi.encodeWithSelector(
             IRouter.addLiquidityUnbalanced.selector,
-            address(pool),
+            pool,
             amountsIn,
             bptAmountOut,
             false,

--- a/pkg/vault/test/foundry/PoolData.t.sol
+++ b/pkg/vault/test/foundry/PoolData.t.sol
@@ -58,13 +58,13 @@ contract PoolDataTest is BaseVaultTest {
         // `loadPoolDataUpdatingBalancesAndYieldFees` and `getRawBalances` are functions in VaultMock.
 
         PoolData memory data = vault.loadPoolDataUpdatingBalancesAndYieldFees(
-            address(pool),
+            pool,
             roundUp ? Rounding.ROUND_UP : Rounding.ROUND_DOWN
         );
 
         // Compute decimal scaling factors from the tokens, in the mock.
         uint256[] memory expectedScalingFactors = PoolMock(pool).getDecimalScalingFactors();
-        uint256[] memory expectedRawBalances = vault.getRawBalances(address(pool));
+        uint256[] memory expectedRawBalances = vault.getRawBalances(pool);
         uint256[] memory expectedRates = new uint256[](2);
         expectedRates[0] = daiRate;
         expectedRates[1] = wstETHRate;

--- a/pkg/vault/test/foundry/PoolPause.t.sol
+++ b/pkg/vault/test/foundry/PoolPause.t.sol
@@ -43,7 +43,7 @@ contract PoolPauseTest is BaseVaultTest {
         pool = address(new PoolMock(IVault(address(vault)), "ERC20 Pool", "ERC20POOL"));
 
         factoryMock.registerGeneralTestPool(
-            address(pool),
+            pool,
             tokenConfig,
             0,
             365 days,
@@ -116,7 +116,7 @@ contract PoolPauseTest is BaseVaultTest {
     }
 
     function testHasPauseManager() public {
-        (, , , address pauseManager) = vault.getPoolPausedState(address(pool));
+        (, , , address pauseManager) = vault.getPoolPausedState(pool);
         assertEq(pauseManager, admin, "Pause manager is not admin");
 
         (, , , pauseManager) = vault.getPoolPausedState(address(unmanagedPool));
@@ -125,28 +125,28 @@ contract PoolPauseTest is BaseVaultTest {
 
     function testPauseManagerCanPause() public {
         // Pool is not paused
-        require(vault.isPoolPaused(address(pool)) == false, "Vault is already paused");
+        require(vault.isPoolPaused(pool) == false, "Vault is already paused");
 
         // pause manager can pause and unpause
         vm.prank(admin);
-        vault.pausePool(address(pool));
+        vault.pausePool(pool);
 
-        assertTrue(vault.isPoolPaused(address(pool)), "Vault not paused");
+        assertTrue(vault.isPoolPaused(pool), "Vault not paused");
 
         vm.prank(admin);
-        vault.unpausePool(address(pool));
+        vault.unpausePool(pool);
 
-        assertFalse(vault.isPoolPaused(address(pool)), "Vault is still paused after unpause");
+        assertFalse(vault.isPoolPaused(pool), "Vault is still paused after unpause");
     }
 
     function testCannotPauseIfNotManager() public {
         vm.prank(bob);
         vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
-        vault.pausePool(address(pool));
+        vault.pausePool(pool);
 
         vm.prank(alice);
         vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
-        vault.unpausePool(address(pool));
+        vault.unpausePool(pool);
     }
 
     function testGovernancePause() public {

--- a/pkg/vault/test/foundry/PoolSwapManager.t.sol
+++ b/pkg/vault/test/foundry/PoolSwapManager.t.sol
@@ -42,7 +42,7 @@ contract PoolSwapManagerTest is BaseVaultTest {
 
         // Make admin the swap fee manager.
         factoryMock.registerGeneralTestPool(
-            address(pool),
+            pool,
             tokenConfig,
             0,
             365 days,
@@ -82,7 +82,7 @@ contract PoolSwapManagerTest is BaseVaultTest {
     }
 
     function testHasSwapFeeManager() public {
-        address swapFeeManager = vault.getPoolRoleAccounts(address(pool)).swapFeeManager;
+        address swapFeeManager = vault.getPoolRoleAccounts(pool).swapFeeManager;
         assertEq(swapFeeManager, admin, "swapFeeManager is not admin");
 
         swapFeeManager = vault.getPoolRoleAccounts(address(unmanagedPool)).swapFeeManager;
@@ -90,21 +90,21 @@ contract PoolSwapManagerTest is BaseVaultTest {
     }
 
     function testSwapFeeManagerCanSetFees() public {
-        require(vault.getStaticSwapFeePercentage(address(pool)) == 0, "initial swap fee non-zero");
+        require(vault.getStaticSwapFeePercentage(pool) == 0, "initial swap fee non-zero");
 
         // swap fee manager can set the static swap fee.
         vm.prank(admin);
-        vault.setStaticSwapFeePercentage(address(pool), NEW_SWAP_FEE);
+        vault.setStaticSwapFeePercentage(pool, NEW_SWAP_FEE);
 
-        assertEq(vault.getStaticSwapFeePercentage(address(pool)), NEW_SWAP_FEE, "Wrong swap fee");
+        assertEq(vault.getStaticSwapFeePercentage(pool), NEW_SWAP_FEE, "Wrong swap fee");
     }
 
     function testCannotSetSwapFeePercentageIfNotManager() public {
-        require(vault.getPoolRoleAccounts(address(pool)).swapFeeManager == address(admin), "Wrong swap fee manager");
+        require(vault.getPoolRoleAccounts(pool).swapFeeManager == address(admin), "Wrong swap fee manager");
 
         vm.prank(bob);
         vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
-        vault.setStaticSwapFeePercentage(address(pool), NEW_SWAP_FEE);
+        vault.setStaticSwapFeePercentage(pool, NEW_SWAP_FEE);
     }
 
     function testGovernanceCanSetSwapFeeIfNoManager() public {
@@ -130,17 +130,17 @@ contract PoolSwapManagerTest is BaseVaultTest {
 
     // It is onlyOwner, so governance cannot override
     function testGovernanceCannotSetSwapFeeWithManager() public {
-        require(vault.getStaticSwapFeePercentage(address(pool)) == 0, "initial swap fee non-zero");
+        require(vault.getStaticSwapFeePercentage(pool) == 0, "initial swap fee non-zero");
 
         vm.prank(bob);
         vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
-        vault.setStaticSwapFeePercentage(address(pool), NEW_SWAP_FEE);
+        vault.setStaticSwapFeePercentage(pool, NEW_SWAP_FEE);
 
         bytes32 setSwapFeeRole = vault.getActionId(IVaultAdmin.setStaticSwapFeePercentage.selector);
         authorizer.grantRole(setSwapFeeRole, bob);
 
         vm.prank(bob);
         vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
-        vault.setStaticSwapFeePercentage(address(pool), NEW_SWAP_FEE);
+        vault.setStaticSwapFeePercentage(pool, NEW_SWAP_FEE);
     }
 }

--- a/pkg/vault/test/foundry/ProtocolFeeController.t.sol
+++ b/pkg/vault/test/foundry/ProtocolFeeController.t.sol
@@ -571,12 +571,7 @@ contract ProtocolFeeControllerTest is BaseVaultTest {
 
         vm.expectCall(
             address(feeController),
-            abi.encodeWithSelector(
-                IProtocolFeeController.receiveProtocolFees.selector,
-                address(pool),
-                swapAmounts,
-                yieldAmounts
-            )
+            abi.encodeWithSelector(IProtocolFeeController.receiveProtocolFees.selector, pool, swapAmounts, yieldAmounts)
         );
         // Move them to the fee controller.
         vault.collectProtocolFees(pool);

--- a/pkg/vault/test/foundry/ProtocolFeeExemption.t.sol
+++ b/pkg/vault/test/foundry/ProtocolFeeExemption.t.sol
@@ -63,7 +63,7 @@ contract ProtocolFeeExemptionTest is BaseVaultTest {
         tokenConfig[usdcIdx].token = IERC20(usdc);
 
         pool = address(new PoolMock(IVault(address(vault)), "Non-Exempt Pool", "NOTEXEMPT"));
-        factoryMock.registerGeneralTestPool(address(pool), tokenConfig, 0, 365 days, false, roleAccounts, address(0));
+        factoryMock.registerGeneralTestPool(pool, tokenConfig, 0, 365 days, false, roleAccounts, address(0));
 
         PoolConfig memory poolConfig = vault.getPoolConfig(pool);
 
@@ -77,7 +77,7 @@ contract ProtocolFeeExemptionTest is BaseVaultTest {
         tokenConfig[usdcIdx].token = IERC20(usdc);
 
         pool = address(new PoolMock(IVault(address(vault)), "Exempt Pool", "EXEMPT"));
-        factoryMock.registerGeneralTestPool(address(pool), tokenConfig, 0, 365 days, true, roleAccounts, address(0));
+        factoryMock.registerGeneralTestPool(pool, tokenConfig, 0, 365 days, true, roleAccounts, address(0));
 
         PoolConfig memory poolConfig = vault.getPoolConfig(pool);
 

--- a/pkg/vault/test/foundry/RecoveryMode.t.sol
+++ b/pkg/vault/test/foundry/RecoveryMode.t.sol
@@ -24,22 +24,22 @@ contract RecoveryModeTest is BaseVaultTest {
         uint256[] memory amountsIn = [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray();
 
         vm.prank(alice);
-        uint256 bptAmountOut = router.addLiquidityUnbalanced(address(pool), amountsIn, defaultAmount, false, bytes(""));
+        uint256 bptAmountOut = router.addLiquidityUnbalanced(pool, amountsIn, defaultAmount, false, bytes(""));
 
         // Raw and live should be in sync
         assertRawAndLiveBalanceRelationship(true);
 
         // Put pool in recovery mode
-        vault.manualEnableRecoveryMode(address(pool));
+        vault.manualEnableRecoveryMode(pool);
 
         // Do a recovery withdrawal
         vm.prank(alice);
-        router.removeLiquidityRecovery(address(pool), bptAmountOut / 2);
+        router.removeLiquidityRecovery(pool, bptAmountOut / 2);
 
         // Raw and live should be out of sync
         assertRawAndLiveBalanceRelationship(false);
 
-        vault.manualDisableRecoveryMode(address(pool));
+        vault.manualDisableRecoveryMode(pool);
 
         // Raw and live should be back in sync
         assertRawAndLiveBalanceRelationship(true);

--- a/pkg/vault/test/foundry/Router.t.sol
+++ b/pkg/vault/test/foundry/Router.t.sol
@@ -105,7 +105,7 @@ contract RouterTest is BaseVaultTest {
     }
 
     function initPool() internal override {
-        (TokenConfig[] memory tokenConfig, , ) = vault.getPoolTokenInfo(address(pool));
+        (TokenConfig[] memory tokenConfig, , ) = vault.getPoolTokenInfo(pool);
         vm.prank(lp);
         IERC20[] memory tokens = new IERC20[](tokenConfig.length);
 
@@ -113,7 +113,7 @@ contract RouterTest is BaseVaultTest {
             tokens[i] = tokenConfig[i].token;
         }
 
-        router.initialize(address(pool), tokens, [poolInitAmount, poolInitAmount].toMemoryArray(), 0, false, "");
+        router.initialize(pool, tokens, [poolInitAmount, poolInitAmount].toMemoryArray(), 0, false, "");
 
         vm.prank(lp);
         bool wethIsEth = true;
@@ -130,7 +130,7 @@ contract RouterTest is BaseVaultTest {
     function testQuerySwap() public {
         vm.prank(bob);
         vm.expectRevert(EVMCallModeHelpers.NotStaticCall.selector);
-        router.querySwapSingleTokenExactIn(address(pool), usdc, dai, usdcAmountIn, bytes(""));
+        router.querySwapSingleTokenExactIn(pool, usdc, dai, usdcAmountIn, bytes(""));
     }
 
     function testDisableQueries() public {
@@ -149,7 +149,7 @@ contract RouterTest is BaseVaultTest {
         vm.expectRevert(IVaultErrors.QueriesDisabled.selector);
 
         vm.prank(address(0), address(0));
-        router.querySwapSingleTokenExactIn(address(pool), usdc, dai, usdcAmountIn, bytes(""));
+        router.querySwapSingleTokenExactIn(pool, usdc, dai, usdcAmountIn, bytes(""));
     }
 
     function testInitializeBelowMinimum() public {
@@ -485,24 +485,20 @@ contract RouterTest is BaseVaultTest {
     }
 
     function testGetSingleInputArray() public {
-        (uint256[] memory amountsGiven, uint256 tokenIndex) = router.getSingleInputArrayAndTokenIndex(
-            address(pool),
-            dai,
-            1234
-        );
+        (uint256[] memory amountsGiven, uint256 tokenIndex) = router.getSingleInputArrayAndTokenIndex(pool, dai, 1234);
         assertEq(amountsGiven.length, 2);
         assertEq(amountsGiven[daiIdx], 1234);
         assertEq(amountsGiven[usdcIdx], 0);
         assertEq(tokenIndex, daiIdx);
 
-        (amountsGiven, tokenIndex) = router.getSingleInputArrayAndTokenIndex(address(pool), usdc, 4321);
+        (amountsGiven, tokenIndex) = router.getSingleInputArrayAndTokenIndex(pool, usdc, 4321);
         assertEq(amountsGiven.length, 2);
         assertEq(amountsGiven[daiIdx], 0);
         assertEq(amountsGiven[usdcIdx], 4321);
         assertEq(tokenIndex, usdcIdx);
 
         vm.expectRevert(IVaultErrors.TokenNotRegistered.selector);
-        router.getSingleInputArrayAndTokenIndex(address(pool), weth, daiAmountIn);
+        router.getSingleInputArrayAndTokenIndex(pool, weth, daiAmountIn);
     }
 
     function checkRemoveLiquidityPreConditions() internal view {

--- a/pkg/vault/test/foundry/VaultLiquidity.t.sol
+++ b/pkg/vault/test/foundry/VaultLiquidity.t.sol
@@ -33,7 +33,7 @@ contract VaultLiquidityTest is BaseVaultTest {
 
         vm.prank(alice);
         snapStart("vaultAddLiquidityProportional");
-        amountsIn = router.addLiquidityProportional(address(pool), amountsIn, bptAmountOut, false, bytes(""));
+        amountsIn = router.addLiquidityProportional(pool, amountsIn, bptAmountOut, false, bytes(""));
         snapEnd();
 
         // should mint correct amount of BPT tokens
@@ -49,7 +49,7 @@ contract VaultLiquidityTest is BaseVaultTest {
 
         vm.prank(alice);
         snapStart("vaultAddLiquidityUnbalanced");
-        bptAmountOut = router.addLiquidityUnbalanced(address(pool), amountsIn, defaultAmount, false, bytes(""));
+        bptAmountOut = router.addLiquidityUnbalanced(pool, amountsIn, defaultAmount, false, bytes(""));
         snapEnd();
 
         // should mint correct amount of BPT tokens
@@ -69,7 +69,7 @@ contract VaultLiquidityTest is BaseVaultTest {
         vm.prank(alice);
         vm.expectRevert(IVaultErrors.DoesNotSupportUnbalancedLiquidity.selector);
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray(),
             defaultAmount,
             false,
@@ -82,7 +82,7 @@ contract VaultLiquidityTest is BaseVaultTest {
         vm.prank(alice);
         snapStart("vaultAddLiquiditySingleTokenExactOut");
         uint256 amountIn = router.addLiquiditySingleTokenExactOut(
-            address(pool),
+            pool,
             dai,
             defaultAmount,
             bptAmountOut,
@@ -109,13 +109,13 @@ contract VaultLiquidityTest is BaseVaultTest {
 
         vm.prank(alice);
         vm.expectRevert(IVaultErrors.DoesNotSupportUnbalancedLiquidity.selector);
-        router.addLiquiditySingleTokenExactOut(address(pool), dai, defaultAmount, defaultAmount, false, bytes(""));
+        router.addLiquiditySingleTokenExactOut(pool, dai, defaultAmount, defaultAmount, false, bytes(""));
     }
 
     function addLiquidityCustom() public returns (uint256[] memory amountsIn, uint256 bptAmountOut) {
         vm.prank(alice);
         (amountsIn, bptAmountOut, ) = router.addLiquidityCustom(
-            address(pool),
+            pool,
             [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray(),
             defaultAmount,
             false,
@@ -139,7 +139,7 @@ contract VaultLiquidityTest is BaseVaultTest {
         vm.prank(alice);
         vm.expectRevert(IVaultErrors.DoesNotSupportAddLiquidityCustom.selector);
         router.addLiquidityCustom(
-            address(pool),
+            pool,
             [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray(),
             defaultAmount,
             false,
@@ -150,9 +150,9 @@ contract VaultLiquidityTest is BaseVaultTest {
     function testAddLiquidityNotInitialized() public {
         pool = createPool();
 
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolNotInitialized.selector, address(pool)));
+        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolNotInitialized.selector, pool));
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray(),
             defaultAmount,
             false,
@@ -166,7 +166,7 @@ contract VaultLiquidityTest is BaseVaultTest {
         );
         vm.prank(alice);
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray(),
             2 * defaultAmount + 1,
             false,
@@ -185,7 +185,7 @@ contract VaultLiquidityTest is BaseVaultTest {
             )
         );
         vm.prank(alice);
-        router.addLiquiditySingleTokenExactOut(address(pool), dai, defaultAmount - 1, bptAmountOut, false, bytes(""));
+        router.addLiquiditySingleTokenExactOut(pool, dai, defaultAmount - 1, bptAmountOut, false, bytes(""));
     }
 
     /// Remove
@@ -195,7 +195,7 @@ contract VaultLiquidityTest is BaseVaultTest {
 
         snapStart("vaultRemoveLiquidityProportional");
         amountsOut = router.removeLiquidityProportional(
-            address(pool),
+            pool,
             bptAmountIn,
             [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray(),
             false,
@@ -217,7 +217,7 @@ contract VaultLiquidityTest is BaseVaultTest {
 
         snapStart("vaultRemoveLiquiditySingleTokenExactIn");
         uint256 amountOut = router.removeLiquiditySingleTokenExactIn(
-            address(pool),
+            pool,
             bptAmountIn,
             dai,
             defaultAmount,
@@ -245,14 +245,7 @@ contract VaultLiquidityTest is BaseVaultTest {
 
         vm.expectRevert(IVaultErrors.DoesNotSupportUnbalancedLiquidity.selector);
         vm.startPrank(alice);
-        router.removeLiquiditySingleTokenExactIn(
-            address(pool),
-            defaultAmount * 2,
-            dai,
-            defaultAmount,
-            false,
-            bytes("")
-        );
+        router.removeLiquiditySingleTokenExactIn(pool, defaultAmount * 2, dai, defaultAmount, false, bytes(""));
     }
 
     function removeLiquiditySingleTokenExactOut() public returns (uint256[] memory amountsOut, uint256 bptAmountIn) {
@@ -261,7 +254,7 @@ contract VaultLiquidityTest is BaseVaultTest {
 
         snapStart("vaultRemoveLiquiditySingleTokenExactOut");
         bptAmountIn = router.removeLiquiditySingleTokenExactOut(
-            address(pool),
+            pool,
             2 * defaultAmount,
             dai,
             uint256(2 * defaultAmount),
@@ -283,19 +276,12 @@ contract VaultLiquidityTest is BaseVaultTest {
 
         vm.expectRevert(IVaultErrors.DoesNotSupportUnbalancedLiquidity.selector);
         vm.startPrank(alice);
-        router.removeLiquiditySingleTokenExactOut(
-            address(pool),
-            defaultAmount * 2,
-            dai,
-            defaultAmount * 2,
-            false,
-            bytes("")
-        );
+        router.removeLiquiditySingleTokenExactOut(pool, defaultAmount * 2, dai, defaultAmount * 2, false, bytes(""));
     }
 
     function removeLiquidityCustom() public returns (uint256[] memory amountsOut, uint256 bptAmountIn) {
         (bptAmountIn, amountsOut, ) = router.removeLiquidityCustom(
-            address(pool),
+            pool,
             defaultAmount * 2,
             [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray(),
             false,
@@ -320,7 +306,7 @@ contract VaultLiquidityTest is BaseVaultTest {
         vm.expectRevert(IVaultErrors.DoesNotSupportRemoveLiquidityCustom.selector);
         vm.startPrank(alice);
         router.removeLiquidityCustom(
-            address(pool),
+            pool,
             defaultAmount * 2,
             [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray(),
             false,
@@ -333,9 +319,9 @@ contract VaultLiquidityTest is BaseVaultTest {
 
         pool = createPool();
 
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolNotInitialized.selector, address(pool)));
+        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolNotInitialized.selector, pool));
         router.removeLiquidityProportional(
-            address(pool),
+            pool,
             defaultAmount,
             [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray(),
             false,
@@ -357,7 +343,7 @@ contract VaultLiquidityTest is BaseVaultTest {
             )
         );
         vm.startPrank(alice);
-        router.removeLiquidityProportional(address(pool), 2 * defaultAmount, amountsOut, false, bytes(""));
+        router.removeLiquidityProportional(pool, 2 * defaultAmount, amountsOut, false, bytes(""));
     }
 
     function testRemoveLiquidityBptInAboveMax() public {
@@ -366,7 +352,7 @@ contract VaultLiquidityTest is BaseVaultTest {
         );
         vm.startPrank(alice);
         router.removeLiquiditySingleTokenExactOut(
-            address(pool),
+            pool,
             defaultAmount / 2 - 1, // Exit with only one token, so the expected BPT amount in is 1/2 of the total.
             dai,
             uint256(defaultAmount),
@@ -427,7 +413,7 @@ contract VaultLiquidityTest is BaseVaultTest {
         vm.startPrank(alice);
 
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray(),
             defaultAmount,
             false,

--- a/pkg/vault/test/foundry/VaultLiquidityFees.t.sol
+++ b/pkg/vault/test/foundry/VaultLiquidityFees.t.sol
@@ -40,7 +40,7 @@ contract VaultLiquidityWithFeesTest is BaseVaultTest {
         assertTrue(protocolSwapFeePercentage > 0);
         assertTrue(poolCreatorFeePercentage > 0);
 
-        PoolConfig memory config = vault.getPoolConfig(address(pool));
+        PoolConfig memory config = vault.getPoolConfig(pool);
 
         assertEq(config.getStaticSwapFeePercentage(), swapFeePercentage);
         assertEq(
@@ -77,7 +77,7 @@ contract VaultLiquidityWithFeesTest is BaseVaultTest {
 
         vm.prank(alice);
         snapStart("routerAddLiquidityUnbalancedWithCreatorFee");
-        bptAmountOut = router.addLiquidityUnbalanced(address(pool), amountsIn, expectedBptAmountOut, false, bytes(""));
+        bptAmountOut = router.addLiquidityUnbalanced(pool, amountsIn, expectedBptAmountOut, false, bytes(""));
         snapEnd();
         // should mint correct amount of BPT tokens
         assertEq(bptAmountOut, expectedBptAmountOut, "Invalid amount of BPT");
@@ -110,7 +110,7 @@ contract VaultLiquidityWithFeesTest is BaseVaultTest {
         vm.prank(alice);
         snapStart("routerAddLiquiditySingleTokenExactOutWithCreatorFee");
         uint256 amountIn = router.addLiquiditySingleTokenExactOut(
-            address(pool),
+            pool,
             dai,
             // amount + (amount / ( 100% - swapFee%)) / 2 + 1
             defaultAmount + (defaultAmount / 99) / 2 + 1,
@@ -154,7 +154,7 @@ contract VaultLiquidityWithFeesTest is BaseVaultTest {
 
         snapStart("routerRemoveLiquiditySingleTokenExactInWithCreatorFee");
         uint256 amountOut = router.removeLiquiditySingleTokenExactIn(
-            address(pool),
+            pool,
             bptAmountIn,
             dai,
             defaultAmount,
@@ -198,7 +198,7 @@ contract VaultLiquidityWithFeesTest is BaseVaultTest {
 
         snapStart("routerRemoveLiquiditySingleTokenExactOutWithCreatorFee");
         bptAmountIn = router.removeLiquiditySingleTokenExactOut(
-            address(pool),
+            pool,
             2 * defaultAmount,
             dai,
             uint256(defaultAmount),
@@ -288,7 +288,7 @@ contract VaultLiquidityWithFeesTest is BaseVaultTest {
         vm.startPrank(alice);
 
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray(),
             defaultAmount,
             false,

--- a/pkg/vault/test/foundry/VaultLiquidityRate.t.sol
+++ b/pkg/vault/test/foundry/VaultLiquidityRate.t.sol
@@ -57,8 +57,8 @@ contract VaultLiquidityWithRatesTest is BaseVaultTest {
         rateProvider.mockRate(mockRate);
         initPool();
 
-        uint256[] memory rawBalances = vault.getRawBalances(address(pool));
-        uint256[] memory liveBalances = vault.getLastLiveBalances(address(pool));
+        uint256[] memory rawBalances = vault.getRawBalances(pool);
+        uint256[] memory liveBalances = vault.getLastLiveBalances(pool);
 
         assertEq(FixedPoint.mulDown(rawBalances[wstethIdx], mockRate), liveBalances[wstethIdx]);
         assertEq(rawBalances[daiIdx], liveBalances[daiIdx]);
@@ -71,7 +71,7 @@ contract VaultLiquidityWithRatesTest is BaseVaultTest {
 
         vm.startPrank(alice);
         vm.expectCall(
-            address(pool),
+            pool,
             abi.encodeWithSelector(
                 IBasePool.computeBalance.selector,
                 expectedBalances, // liveBalancesScaled18
@@ -80,7 +80,7 @@ contract VaultLiquidityWithRatesTest is BaseVaultTest {
             )
         );
 
-        router.addLiquiditySingleTokenExactOut(address(pool), wsteth, defaultAmount, defaultAmount, false, bytes(""));
+        router.addLiquiditySingleTokenExactOut(pool, wsteth, defaultAmount, defaultAmount, false, bytes(""));
     }
 
     function testAddLiquidityCustomWithRate() public {
@@ -97,7 +97,7 @@ contract VaultLiquidityWithRatesTest is BaseVaultTest {
 
         vm.startPrank(alice);
         vm.expectCall(
-            address(pool),
+            pool,
             abi.encodeWithSelector(
                 IPoolLiquidity.onAddLiquidityCustom.selector,
                 router,
@@ -109,7 +109,7 @@ contract VaultLiquidityWithRatesTest is BaseVaultTest {
         );
 
         router.addLiquidityCustom(
-            address(pool),
+            pool,
             [defaultAmount, defaultAmount].toMemoryArray(),
             defaultAmount,
             false,
@@ -121,7 +121,7 @@ contract VaultLiquidityWithRatesTest is BaseVaultTest {
         vm.startPrank(alice);
 
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [defaultAmount, defaultAmount].toMemoryArray(),
             defaultAmount,
             false,
@@ -130,7 +130,7 @@ contract VaultLiquidityWithRatesTest is BaseVaultTest {
 
         // TODO: Find a way to test rates inside the Vault
         router.removeLiquidityProportional(
-            address(pool),
+            pool,
             defaultAmount * 2,
             [defaultAmount, defaultAmount].toMemoryArray(),
             false,
@@ -144,18 +144,18 @@ contract VaultLiquidityWithRatesTest is BaseVaultTest {
         vm.startPrank(alice);
 
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [defaultAmount, defaultAmount].toMemoryArray(),
             defaultAmount,
             false,
             bytes("")
         );
 
-        PoolData memory balances = vault.loadPoolDataUpdatingBalancesAndYieldFees(address(pool), Rounding.ROUND_DOWN);
+        PoolData memory balances = vault.loadPoolDataUpdatingBalancesAndYieldFees(pool, Rounding.ROUND_DOWN);
         uint256 bptAmountIn = defaultAmount * 2;
 
         vm.expectCall(
-            address(pool),
+            pool,
             abi.encodeWithSelector(
                 IBasePool.computeBalance.selector,
                 [balances.balancesLiveScaled18[daiIdx], balances.balancesLiveScaled18[wstethIdx]].toMemoryArray(),
@@ -164,28 +164,28 @@ contract VaultLiquidityWithRatesTest is BaseVaultTest {
             )
         );
 
-        router.removeLiquiditySingleTokenExactIn(address(pool), bptAmountIn, wsteth, defaultAmount, false, bytes(""));
+        router.removeLiquiditySingleTokenExactIn(pool, bptAmountIn, wsteth, defaultAmount, false, bytes(""));
     }
 
     function testRemoveLiquidityCustomWithRate() public {
         vm.startPrank(alice);
 
         router.addLiquidityUnbalanced(
-            address(pool),
+            pool,
             [defaultAmount, defaultAmount].toMemoryArray(),
             defaultAmount,
             false,
             bytes("")
         );
 
-        PoolData memory balances = vault.loadPoolDataUpdatingBalancesAndYieldFees(address(pool), Rounding.ROUND_DOWN);
+        PoolData memory balances = vault.loadPoolDataUpdatingBalancesAndYieldFees(pool, Rounding.ROUND_DOWN);
         uint256[] memory expectedAmountsOutRaw = new uint256[](2);
 
         expectedAmountsOutRaw[wstethIdx] = FixedPoint.mulDown(defaultAmount, mockRate);
         expectedAmountsOutRaw[daiIdx] = defaultAmount;
 
         vm.expectCall(
-            address(pool),
+            pool,
             abi.encodeWithSelector(
                 IPoolLiquidity.onRemoveLiquidityCustom.selector,
                 router,
@@ -197,7 +197,7 @@ contract VaultLiquidityWithRatesTest is BaseVaultTest {
         );
 
         router.removeLiquidityCustom(
-            address(pool),
+            pool,
             defaultAmount,
             [defaultAmount, defaultAmount].toMemoryArray(),
             false,

--- a/pkg/vault/test/foundry/VaultSwap.t.sol
+++ b/pkg/vault/test/foundry/VaultSwap.t.sol
@@ -45,21 +45,12 @@ contract VaultSwapTest is BaseVaultTest {
     /// Swap
 
     function testCannotSwapWhenPaused() public {
-        vault.manualPausePool(address(pool));
+        vault.manualPausePool(pool);
 
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolPaused.selector, address(pool)));
+        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolPaused.selector, pool));
 
         vm.prank(bob);
-        router.swapSingleTokenExactIn(
-            address(pool),
-            usdc,
-            dai,
-            defaultAmount,
-            defaultAmount,
-            MAX_UINT256,
-            false,
-            bytes("")
-        );
+        router.swapSingleTokenExactIn(pool, usdc, dai, defaultAmount, defaultAmount, MAX_UINT256, false, bytes(""));
     }
 
     function testSwapNotInitialized() public {
@@ -79,23 +70,14 @@ contract VaultSwapTest is BaseVaultTest {
     function testSwapLimitExactIn() public {
         vm.prank(alice);
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.SwapLimit.selector, defaultAmount - 1, defaultAmount));
-        router.swapSingleTokenExactIn(
-            address(pool),
-            usdc,
-            dai,
-            defaultAmount - 1,
-            defaultAmount,
-            MAX_UINT256,
-            false,
-            bytes("")
-        );
+        router.swapSingleTokenExactIn(pool, usdc, dai, defaultAmount - 1, defaultAmount, MAX_UINT256, false, bytes(""));
     }
 
     function testSwapDeadlineExactIn() public {
         vm.prank(alice);
         vm.expectRevert(RouterCommon.SwapDeadline.selector);
         router.swapSingleTokenExactIn(
-            address(pool),
+            pool,
             usdc,
             dai,
             defaultAmount,
@@ -110,7 +92,7 @@ contract VaultSwapTest is BaseVaultTest {
         vm.prank(alice);
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.SwapLimit.selector, defaultAmount, defaultAmount - 1));
         router.swapSingleTokenExactOut(
-            address(pool),
+            pool,
             usdc,
             dai,
             defaultAmount,
@@ -125,7 +107,7 @@ contract VaultSwapTest is BaseVaultTest {
         vm.prank(alice);
         vm.expectRevert(RouterCommon.SwapDeadline.selector);
         router.swapSingleTokenExactOut(
-            address(pool),
+            pool,
             usdc,
             dai,
             defaultAmount,
@@ -143,16 +125,7 @@ contract VaultSwapTest is BaseVaultTest {
     function swapSingleTokenExactIn() public returns (uint256 fee, uint256 protocolFee) {
         vm.prank(alice);
         snapStart("vaultSwapSingleTokenExactIn");
-        router.swapSingleTokenExactIn(
-            address(pool),
-            usdc,
-            dai,
-            defaultAmount,
-            defaultAmount,
-            MAX_UINT256,
-            false,
-            bytes("")
-        );
+        router.swapSingleTokenExactIn(pool, usdc, dai, defaultAmount, defaultAmount, MAX_UINT256, false, bytes(""));
         snapEnd();
         return (0, 0);
     }
@@ -164,16 +137,7 @@ contract VaultSwapTest is BaseVaultTest {
     function swapSingleTokenExactOut() public returns (uint256 fee, uint256 protocolFee) {
         vm.prank(alice);
         snapStart("vaultSwapSingleTokenExactOut");
-        router.swapSingleTokenExactOut(
-            address(pool),
-            usdc,
-            dai,
-            defaultAmount,
-            defaultAmount,
-            MAX_UINT256,
-            false,
-            bytes("")
-        );
+        router.swapSingleTokenExactOut(pool, usdc, dai, defaultAmount, defaultAmount, MAX_UINT256, false, bytes(""));
         snapEnd();
         return (0, 0);
     }
@@ -187,7 +151,7 @@ contract VaultSwapTest is BaseVaultTest {
 
         vm.expectEmit();
         emit IVaultEvents.Swap(
-            address(pool),
+            pool,
             usdc,
             dai,
             defaultAmount,
@@ -199,7 +163,7 @@ contract VaultSwapTest is BaseVaultTest {
 
         vm.prank(alice);
         router.swapSingleTokenExactIn(
-            address(pool),
+            pool,
             usdc,
             dai,
             defaultAmount,
@@ -215,7 +179,7 @@ contract VaultSwapTest is BaseVaultTest {
 
         vm.expectEmit();
         emit IVaultEvents.Swap(
-            address(pool),
+            pool,
             usdc,
             dai,
             defaultAmount + swapFee,
@@ -227,7 +191,7 @@ contract VaultSwapTest is BaseVaultTest {
 
         vm.prank(alice);
         router.swapSingleTokenExactOut(
-            address(pool),
+            pool,
             usdc,
             dai,
             defaultAmount,
@@ -244,7 +208,7 @@ contract VaultSwapTest is BaseVaultTest {
         vm.prank(alice);
         snapStart("vaultSwapSingleTokenExactInWithFee");
         router.swapSingleTokenExactIn(
-            address(pool),
+            pool,
             usdc,
             dai,
             defaultAmount,
@@ -282,7 +246,7 @@ contract VaultSwapTest is BaseVaultTest {
         vm.prank(alice);
         snapStart("vaultSwapSingleTokenExactInWithProtocolFee");
         router.swapSingleTokenExactIn(
-            address(pool),
+            pool,
             usdc,
             dai,
             defaultAmount,
@@ -305,7 +269,7 @@ contract VaultSwapTest is BaseVaultTest {
 
         vm.prank(alice);
         router.swapSingleTokenExactOut(
-            address(pool),
+            pool,
             usdc, // tokenIn
             dai, // tokenOut
             defaultAmount, // exactAmountOut
@@ -343,7 +307,7 @@ contract VaultSwapTest is BaseVaultTest {
 
         vm.prank(alice);
         router.swapSingleTokenExactOut(
-            address(pool),
+            pool,
             usdc, // tokenIn
             dai, // tokenOut
             defaultAmount, // exactAmountOut
@@ -366,7 +330,7 @@ contract VaultSwapTest is BaseVaultTest {
 
         vm.prank(alice);
         router.swapSingleTokenExactIn(
-            address(pool),
+            pool,
             usdc,
             dai,
             defaultAmount / 2,
@@ -378,7 +342,7 @@ contract VaultSwapTest is BaseVaultTest {
 
         vm.prank(alice);
         router.swapSingleTokenExactIn(
-            address(pool),
+            pool,
             usdc,
             dai,
             defaultAmount / 2,
@@ -399,7 +363,7 @@ contract VaultSwapTest is BaseVaultTest {
 
         vm.prank(bob);
         router.swapSingleTokenExactIn(
-            address(pool),
+            pool,
             usdc,
             dai,
             defaultAmount,
@@ -431,7 +395,7 @@ contract VaultSwapTest is BaseVaultTest {
         // do second swap
         SwapParams memory params = SwapParams({
             kind: SwapKind.EXACT_IN,
-            pool: address(pool),
+            pool: pool,
             tokenIn: dai,
             tokenOut: usdc,
             amountGivenRaw: defaultAmount,
@@ -444,7 +408,7 @@ contract VaultSwapTest is BaseVaultTest {
     function startSwap() public {
         SwapParams memory params = SwapParams({
             kind: SwapKind.EXACT_IN,
-            pool: address(pool),
+            pool: pool,
             tokenIn: usdc,
             tokenOut: dai,
             amountGivenRaw: defaultAmount,
@@ -456,9 +420,9 @@ contract VaultSwapTest is BaseVaultTest {
 
     function testReentrancySwap() public {
         // Enable before swap
-        HooksConfig memory config = vault.getHooksConfig(address(pool));
+        HooksConfig memory config = vault.getHooksConfig(pool);
         config.shouldCallBeforeSwap = true;
-        vault.setHooksConfig(address(pool), config);
+        vault.setHooksConfig(pool, config);
 
         // Enable reentrancy hook
         PoolHooksMock(poolHooksContract).setSwapReentrancyHookActive(true);
@@ -470,11 +434,11 @@ contract VaultSwapTest is BaseVaultTest {
         uint256 usdcBeforeSwap = usdc.balanceOf(address(this));
         uint256 daiBeforeSwap = dai.balanceOf(address(this));
 
-        (, uint256[] memory balancesRawBefore, ) = vault.getPoolTokenInfo(address(pool));
+        (, uint256[] memory balancesRawBefore, ) = vault.getPoolTokenInfo(pool);
 
         vault.unlock(abi.encode(this.startSwap.selector));
 
-        (, uint256[] memory balancesRawAfter, ) = vault.getPoolTokenInfo(address(pool));
+        (, uint256[] memory balancesRawAfter, ) = vault.getPoolTokenInfo(pool);
 
         // Pool balances should not change
         for (uint256 i = 0; i < balancesRawAfter.length; ++i) {
@@ -510,7 +474,7 @@ contract VaultSwapTest is BaseVaultTest {
         assertEq(dai.balanceOf(alice), daiBeforeSwap + defaultAmount - daiFee, "Swap: User's DAI balance is wrong");
 
         // Tokens are adjusted in the pool
-        (, uint256[] memory balances, ) = vault.getPoolTokenInfo(address(pool));
+        (, uint256[] memory balances, ) = vault.getPoolTokenInfo(pool);
         assertEq(balances[daiIdx], daiFee - daiProtocolFee, "Swap: Pool's [0] balance is wrong");
         assertEq(balances[usdcIdx], 2 * defaultAmount + usdcFee - usdcProtocolFee, "Swap: Pool's [1] balance is wrong");
 

--- a/pkg/vault/test/foundry/VaultSwapRate.t.sol
+++ b/pkg/vault/test/foundry/VaultSwapRate.t.sol
@@ -62,7 +62,7 @@ contract VaultSwapWithRatesTest is BaseVaultTest {
     }
 
     function testInitialRateProviderState() public {
-        (TokenConfig[] memory tokenConfig, , ) = vault.getPoolTokenInfo(address(pool));
+        (TokenConfig[] memory tokenConfig, , ) = vault.getPoolTokenInfo(pool);
 
         assertEq(address(tokenConfig[wstethIdx].rateProvider), address(rateProvider), "Wrong rate provider");
         assertEq(address(tokenConfig[daiIdx].rateProvider), address(0), "Rate provider should be 0");
@@ -77,7 +77,7 @@ contract VaultSwapWithRatesTest is BaseVaultTest {
         expectedBalances[daiIdx] = defaultAmount;
 
         vm.expectCall(
-            address(pool),
+            pool,
             abi.encodeWithSelector(
                 IBasePool.onSwap.selector,
                 IBasePool.PoolSwapParams({
@@ -94,7 +94,7 @@ contract VaultSwapWithRatesTest is BaseVaultTest {
 
         vm.prank(bob);
         router.swapSingleTokenExactIn(
-            address(pool),
+            pool,
             dai,
             wsteth,
             defaultAmount,
@@ -114,7 +114,7 @@ contract VaultSwapWithRatesTest is BaseVaultTest {
         expectedBalances[daiIdx] = defaultAmount;
 
         vm.expectCall(
-            address(pool),
+            pool,
             abi.encodeWithSelector(
                 IBasePool.onSwap.selector,
                 IBasePool.PoolSwapParams({
@@ -131,7 +131,7 @@ contract VaultSwapWithRatesTest is BaseVaultTest {
 
         vm.prank(bob);
         router.swapSingleTokenExactOut(
-            address(pool),
+            pool,
             dai,
             wsteth,
             rateAdjustedAmountGiven,

--- a/pkg/vault/test/foundry/YieldFees.t.sol
+++ b/pkg/vault/test/foundry/YieldFees.t.sol
@@ -317,12 +317,12 @@ contract YieldFeesTest is BaseVaultTest {
         bool roundUp
     ) internal returns (uint256[] memory liveBalances) {
         PoolData memory data = vault.loadPoolDataUpdatingBalancesAndYieldFees(
-            address(pool),
+            pool,
             roundUp ? Rounding.ROUND_UP : Rounding.ROUND_DOWN
         );
 
         uint256[] memory expectedScalingFactors = PoolMock(pool).getDecimalScalingFactors();
-        uint256[] memory expectedRawBalances = vault.getRawBalances(address(pool));
+        uint256[] memory expectedRawBalances = vault.getRawBalances(pool);
         uint256[] memory expectedRates = new uint256[](2);
 
         expectedRates[wstethIdx] = wstethRate;

--- a/pkg/vault/test/foundry/mutation/router/Router.t.sol
+++ b/pkg/vault/test/foundry/mutation/router/Router.t.sol
@@ -55,7 +55,7 @@ contract RouterMutationTest is BaseVaultTest {
     function testInitializeHookWhenNotVault() public {
         IRouter.InitializeHookParams memory hookParams = IRouter.InitializeHookParams(
             msg.sender,
-            address(pool),
+            pool,
             tokens,
             amountsIn,
             0,
@@ -75,7 +75,7 @@ contract RouterMutationTest is BaseVaultTest {
     function testAddLiquidityHookWhenNotVault() public {
         IRouter.AddLiquidityHookParams memory hookParams = IRouter.AddLiquidityHookParams(
             msg.sender,
-            address(pool),
+            pool,
             amountsIn,
             0,
             AddLiquidityKind.PROPORTIONAL,
@@ -95,7 +95,7 @@ contract RouterMutationTest is BaseVaultTest {
     */
     function testRemoveLiquidityRecoveryHookWhenNotVault() public {
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.SenderIsNotVault.selector, address(this)));
-        router.removeLiquidityRecoveryHook(address(pool), msg.sender, amountsIn[0]);
+        router.removeLiquidityRecoveryHook(pool, msg.sender, amountsIn[0]);
     }
 
     /*
@@ -107,7 +107,7 @@ contract RouterMutationTest is BaseVaultTest {
         IRouter.SwapSingleTokenHookParams memory params = IRouter.SwapSingleTokenHookParams(
             msg.sender,
             SwapKind.EXACT_IN,
-            address(pool),
+            pool,
             IERC20(dai),
             IERC20(usdc),
             amountsIn[0],
@@ -130,7 +130,7 @@ contract RouterMutationTest is BaseVaultTest {
         IRouter.SwapSingleTokenHookParams memory params = IRouter.SwapSingleTokenHookParams(
             msg.sender,
             SwapKind.EXACT_IN,
-            address(pool),
+            pool,
             IERC20(dai),
             IERC20(usdc),
             amountsIn[0],
@@ -152,7 +152,7 @@ contract RouterMutationTest is BaseVaultTest {
     function testQueryAddLiquidityHookWhenNotVault() public {
         IRouter.AddLiquidityHookParams memory hookParams = IRouter.AddLiquidityHookParams(
             msg.sender,
-            address(pool),
+            pool,
             amountsIn,
             0,
             AddLiquidityKind.PROPORTIONAL,
@@ -172,7 +172,7 @@ contract RouterMutationTest is BaseVaultTest {
     function testQueryRemoveLiquidityHookWhenNotVault() public {
         IRouter.RemoveLiquidityHookParams memory params = IRouter.RemoveLiquidityHookParams(
             msg.sender,
-            address(pool),
+            pool,
             amountsIn,
             0,
             RemoveLiquidityKind.SINGLE_TOKEN_EXACT_IN,
@@ -191,6 +191,6 @@ contract RouterMutationTest is BaseVaultTest {
     */
     function testQueryRemoveLiquidityRecoveryHookWhenNoVault() public {
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.SenderIsNotVault.selector, address(this)));
-        router.queryRemoveLiquidityRecoveryHook(address(pool), msg.sender, 10);
+        router.queryRemoveLiquidityRecoveryHook(pool, msg.sender, 10);
     }
 }

--- a/pkg/vault/test/foundry/unit/PoolAndVaultPaused.t.sol
+++ b/pkg/vault/test/foundry/unit/PoolAndVaultPaused.t.sol
@@ -20,7 +20,7 @@ contract PoolAndVaultPausedTest is BaseVaultTest {
 
     function setUp() public virtual override {
         BaseVaultTest.setUp();
-        vault.manualSetPoolPauseWindowEndTime(address(pool), _FIXED_POOL_PAUSE_END_TIME);
+        vault.manualSetPoolPauseWindowEndTime(pool, _FIXED_POOL_PAUSE_END_TIME);
 
         _vaultBufferPeriodEndTimeTest = vault.getBufferPeriodEndTime();
     }
@@ -33,36 +33,36 @@ contract PoolAndVaultPausedTest is BaseVaultTest {
         // sets the time before the pause buffer period
         vm.warp(_FIXED_POOL_PAUSE_END_TIME - 1);
 
-        vault.manualSetPoolPaused(address(pool), true);
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolPaused.selector, address(pool)));
-        vault.ensurePoolNotPaused(address(pool));
+        vault.manualSetPoolPaused(pool, true);
+        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolPaused.selector, pool));
+        vault.ensurePoolNotPaused(pool);
     }
 
     function testPausedPoolAfterBufferPeriod() public {
         // sets the time after the pause buffer period
         vm.warp(_getTimeAfterPoolPauseBufferPeriod());
 
-        vault.manualSetPoolPaused(address(pool), true);
+        vault.manualSetPoolPaused(pool, true);
         // If function does not revert, test passes
-        vault.ensurePoolNotPaused(address(pool));
+        vault.ensurePoolNotPaused(pool);
     }
 
     function testUnpausedPoolBeforeBufferPeriod() public {
         // sets the time before the pause buffer period
         vm.warp(_FIXED_POOL_PAUSE_END_TIME - 1);
 
-        vault.manualSetPoolPaused(address(pool), false);
+        vault.manualSetPoolPaused(pool, false);
         // If function does not revert, test passes
-        vault.ensurePoolNotPaused(address(pool));
+        vault.ensurePoolNotPaused(pool);
     }
 
     function testUnpausedPoolAfterBufferPeriod() public {
         // sets the time after the pause buffer period
         vm.warp(_getTimeAfterPoolPauseBufferPeriod());
 
-        vault.manualSetPoolPaused(address(pool), false);
+        vault.manualSetPoolPaused(pool, false);
         // If function does not revert, test passes
-        vault.ensurePoolNotPaused(address(pool));
+        vault.ensurePoolNotPaused(pool);
     }
 
     /*******************************************************************************
@@ -75,7 +75,7 @@ contract PoolAndVaultPausedTest is BaseVaultTest {
         vault.manualSetVaultPaused(true);
 
         vm.expectRevert(IVaultErrors.VaultPaused.selector);
-        vault.ensureUnpausedAndGetVaultState(address(pool));
+        vault.ensureUnpausedAndGetVaultState(pool);
     }
 
     function testVaultPausedByFlagAfterBufferTime() public {
@@ -84,7 +84,7 @@ contract PoolAndVaultPausedTest is BaseVaultTest {
         vault.manualSetVaultPaused(true);
 
         // Since buffer time has passed, the function should not revert
-        vault.ensureUnpausedAndGetVaultState(address(pool));
+        vault.ensureUnpausedAndGetVaultState(pool);
     }
 
     function testVaultUnpausedButPoolPaused() public {
@@ -92,10 +92,10 @@ contract PoolAndVaultPausedTest is BaseVaultTest {
         vm.warp(_FIXED_POOL_PAUSE_END_TIME - 1);
 
         vault.manualSetVaultPaused(false);
-        vault.manualSetPoolPaused(address(pool), true);
+        vault.manualSetPoolPaused(pool, true);
 
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolPaused.selector, address(pool)));
-        vault.ensureUnpausedAndGetVaultState(address(pool));
+        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolPaused.selector, pool));
+        vault.ensureUnpausedAndGetVaultState(pool);
     }
 
     function testVaultUnpausedButPoolPausedByFlagAfterBufferTime() public {
@@ -103,10 +103,10 @@ contract PoolAndVaultPausedTest is BaseVaultTest {
         vm.warp(_getTimeAfterPoolPauseBufferPeriod());
 
         vault.manualSetVaultPaused(false);
-        vault.manualSetPoolPaused(address(pool), true);
+        vault.manualSetPoolPaused(pool, true);
 
         // Since buffer time has passed, the function should not revert
-        vault.ensureUnpausedAndGetVaultState(address(pool));
+        vault.ensureUnpausedAndGetVaultState(pool);
     }
 
     function testVaultPausedButPoolUnpaused() public {
@@ -114,10 +114,10 @@ contract PoolAndVaultPausedTest is BaseVaultTest {
         vm.warp(_getTimeAfterPoolPauseBufferPeriod());
 
         vault.manualSetVaultPaused(true);
-        vault.manualSetPoolPaused(address(pool), false);
+        vault.manualSetPoolPaused(pool, false);
 
         vm.expectRevert(IVaultErrors.VaultPaused.selector);
-        vault.ensureUnpausedAndGetVaultState(address(pool));
+        vault.ensureUnpausedAndGetVaultState(pool);
     }
 
     function testVaultAndPoolUnpaused() public {
@@ -125,9 +125,9 @@ contract PoolAndVaultPausedTest is BaseVaultTest {
         vm.warp(_getTimeAfterPoolPauseBufferPeriod());
 
         vault.manualSetVaultState(false, true);
-        vault.manualSetPoolPaused(address(pool), false);
+        vault.manualSetPoolPaused(pool, false);
 
-        VaultState memory vaultState = vault.ensureUnpausedAndGetVaultState(address(pool));
+        VaultState memory vaultState = vault.ensureUnpausedAndGetVaultState(pool);
         assertEq(vaultState.isVaultPaused, false, "vaultState.isVaultPaused should be false");
         assertEq(vaultState.isQueryDisabled, true, "vaultState.isQueryDisabled should be true");
     }

--- a/pkg/vault/test/foundry/unit/VaultCommonModifiers.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultCommonModifiers.t.sol
@@ -32,14 +32,14 @@ contract VaultCommonModifiersTest is BaseVaultTest {
     *******************************************************************************/
 
     function testUninitializedPool() public {
-        vault.manualSetInitializedPool(address(pool), false);
-        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolNotInitialized.selector, address(pool)));
-        vault.mockWithInitializedPool(address(pool));
+        vault.manualSetInitializedPool(pool, false);
+        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolNotInitialized.selector, pool));
+        vault.mockWithInitializedPool(pool);
     }
 
     function testInitializedPool() public {
-        vault.manualSetInitializedPool(address(pool), true);
+        vault.manualSetInitializedPool(pool, true);
         // If function does not revert, test passes
-        vault.mockWithInitializedPool(address(pool));
+        vault.mockWithInitializedPool(pool);
     }
 }

--- a/pkg/vault/test/foundry/utils/BaseVaultTest.sol
+++ b/pkg/vault/test/foundry/utils/BaseVaultTest.sol
@@ -114,7 +114,7 @@ abstract contract BaseVaultTest is VaultStorage, BaseTest, Permit2Helpers {
             approveForSender();
             vm.stopPrank();
         }
-        if (address(pool) != address(0)) {
+        if (pool != address(0)) {
             approveForPool(IERC20(pool));
         }
         // Add initial liquidity


### PR DESCRIPTION
# Description

Some tests use address(pool) to get pool address, but the `pool` variable is an address already. 

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

