### PR TITLE
Router: bytecode size fix

### DIFF
--- a/pkg/vault/contracts/RouterCommon.sol
+++ b/pkg/vault/contracts/RouterCommon.sol
@@ -50,15 +50,17 @@ contract RouterCommon is IRouterCommon, VaultGuard {
     IPermit2 internal immutable _permit2;
 
     modifier saveSender() {
-        {
-            address sender = _getSenderSlot().tload();
-
-            // NOTE: This is a one-time operation. The sender can't be changed within the transaction.
-            if (sender == address(0)) {
-                _getSenderSlot().tstore(msg.sender);
-            }
-        }
+        _saveSender();
         _;
+    }
+
+    function _saveSender() internal {
+        address sender = _getSenderSlot().tload();
+
+        // NOTE: This is a one-time operation. The sender can't be changed within the transaction.
+        if (sender == address(0)) {
+            _getSenderSlot().tstore(msg.sender);
+        }
     }
 
     constructor(IVault vault, IWETH weth, IPermit2 permit2) VaultGuard(vault) {


### PR DESCRIPTION
# Description

Save bytecode size by putting `saveSender` modifier code inside an internal function. Saves ~1kb.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A