### PR TITLE
Move `permitBatchAndCall` to `RouterCommon`

### DIFF
--- a/pkg/interfaces/contracts/vault/IRouter.sol
+++ b/pkg/interfaces/contracts/vault/IRouter.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.24;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IPermit2 } from "permit2/src/interfaces/IPermit2.sol";
-import { IAllowanceTransfer } from "permit2/src/interfaces/IAllowanceTransfer.sol";
 
 import { AddLiquidityKind, RemoveLiquidityKind, SwapKind } from "./VaultTypes.sol";
 import { IBasePool } from "./IBasePool.sol";
@@ -553,43 +552,4 @@ interface IRouter {
         uint256 exactAmountOut,
         bytes calldata userData
     ) external returns (uint256 amountIn);
-
-    /*******************************************************************************
-                                    Utils
-    *******************************************************************************/
-
-    /**
-     */
-    struct PermitApproval {
-        address token;
-        address owner;
-        address spender;
-        uint256 amount;
-        uint256 nonce;
-        uint256 deadline;
-    }
-
-    /**
-     * @notice Permits multiple allowances and executes a batch of function calls on this contract.
-     * @param permitBatch An array of `PermitApproval` structs, each representing an ERC20 permit request
-     * @param permitSignatures An array of bytes, corresponding to the permit request signature in `permitBatch`
-     * @param permit2Batch A batch of permit2 approvals
-     * @param permit2Signature A permit2 signature for the batch approval
-     * @param multicallData An array of bytes arrays, each representing an encoded function call on this contract
-     * @return results Array of bytes arrays, each representing the return data from each function call executed
-     */
-    function permitBatchAndCall(
-        PermitApproval[] calldata permitBatch,
-        bytes[] calldata permitSignatures,
-        IAllowanceTransfer.PermitBatch calldata permit2Batch,
-        bytes calldata permit2Signature,
-        bytes[] calldata multicallData
-    ) external returns (bytes[] memory results);
-
-    /**
-     * @notice Executes a batch of function calls on this contract.
-     * @param data Encoded function calls to be executed in the batch.
-     * @return results Array of bytes arrays, each representing the return data from each function call executed.
-     */
-    function multicall(bytes[] calldata data) external returns (bytes[] memory results);
 }

--- a/pkg/interfaces/contracts/vault/IRouterCommon.sol
+++ b/pkg/interfaces/contracts/vault/IRouterCommon.sol
@@ -2,10 +2,49 @@
 
 pragma solidity ^0.8.24;
 
+import { IAllowanceTransfer } from "permit2/src/interfaces/IAllowanceTransfer.sol";
+
 interface IRouterCommon {
     /**
      * @notice Get the first sender which initialized the call to Router.
      * @return address The sender address.
      */
     function getSender() external view returns (address);
+
+    /*******************************************************************************
+                                    Utils
+    *******************************************************************************/
+
+    struct PermitApproval {
+        address token;
+        address owner;
+        address spender;
+        uint256 amount;
+        uint256 nonce;
+        uint256 deadline;
+    }
+
+    /**
+     * @notice Permits multiple allowances and executes a batch of function calls on this contract.
+     * @param permitBatch An array of `PermitApproval` structs, each representing an ERC20 permit request
+     * @param permitSignatures An array of bytes, corresponding to the permit request signature in `permitBatch`
+     * @param permit2Batch A batch of permit2 approvals
+     * @param permit2Signature A permit2 signature for the batch approval
+     * @param multicallData An array of bytes arrays, each representing an encoded function call on this contract
+     * @return results Array of bytes arrays, each representing the return data from each function call executed
+     */
+    function permitBatchAndCall(
+        PermitApproval[] calldata permitBatch,
+        bytes[] calldata permitSignatures,
+        IAllowanceTransfer.PermitBatch calldata permit2Batch,
+        bytes calldata permit2Signature,
+        bytes[] calldata multicallData
+    ) external returns (bytes[] memory results);
+
+    /**
+     * @notice Executes a batch of function calls on this contract.
+     * @param data Encoded function calls to be executed in the batch.
+     * @return results Array of bytes arrays, each representing the return data from each function call executed.
+     */
+    function multicall(bytes[] calldata data) external returns (bytes[] memory results);
 }

--- a/pkg/interfaces/contracts/vault/IRouterCommon.sol
+++ b/pkg/interfaces/contracts/vault/IRouterCommon.sol
@@ -12,7 +12,7 @@ interface IRouterCommon {
     function getSender() external view returns (address);
 
     /*******************************************************************************
-                                    Utils
+                                         Utils
     *******************************************************************************/
 
     struct PermitApproval {

--- a/pkg/vault/contracts/RouterCommon.sol
+++ b/pkg/vault/contracts/RouterCommon.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.24;
 
+import { IERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { IPermit2 } from "permit2/src/interfaces/IPermit2.sol";
@@ -12,6 +13,7 @@ import { IRouter } from "@balancer-labs/v3-interfaces/contracts/vault/IRouter.so
 import { IWETH } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/misc/IWETH.sol";
 import { IRouterCommon } from "@balancer-labs/v3-interfaces/contracts/vault/IRouterCommon.sol";
 import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+import { IAllowanceTransfer } from "permit2/src/interfaces/IAllowanceTransfer.sol";
 
 import {
     TransientStorageHelpers
@@ -102,6 +104,80 @@ contract RouterCommon is IRouterCommon, VaultGuard {
         _weth = weth;
         _permit2 = permit2;
         weth.approve(address(vault), type(uint256).max);
+    }
+
+    /*******************************************************************************
+                                    Utils
+    *******************************************************************************/
+
+    struct SignatureParts {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+    }
+
+    /// @inheritdoc IRouterCommon
+    function permitBatchAndCall(
+        PermitApproval[] calldata permitBatch,
+        bytes[] calldata permitSignatures,
+        IAllowanceTransfer.PermitBatch calldata permit2Batch,
+        bytes calldata permit2Signature,
+        bytes[] calldata multicallData
+    ) external virtual saveSender returns (bytes[] memory results) {
+        // Use Permit (ERC-2612) to grant allowances to Permit2 for tokens to swap,
+        // and grant allowances to Vault for BPT tokens.
+        for (uint256 i = 0; i < permitBatch.length; ++i) {
+            bytes memory signature = permitSignatures[i];
+
+            SignatureParts memory signatureParts = _getSignatureParts(signature);
+
+            PermitApproval memory permitApproval = permitBatch[i];
+            IERC20Permit(permitApproval.token).permit(
+                permitApproval.owner,
+                address(this),
+                permitApproval.amount,
+                permitApproval.deadline,
+                signatureParts.v,
+                signatureParts.r,
+                signatureParts.s
+            );
+        }
+
+        // Only call permit2 if there's something to do.
+        if (permit2Batch.details.length > 0) {
+            // Use Permit2 for tokens that are swapped and added into the Vault.
+            _permit2.permit(msg.sender, permit2Batch, permit2Signature);
+        }
+
+        // Execute all the required operations once permissions have been granted.
+        return multicall(multicallData);
+    }
+
+    /// @inheritdoc IRouterCommon
+    function multicall(bytes[] calldata data) public virtual saveSender returns (bytes[] memory results) {
+        results = new bytes[](data.length);
+        for (uint256 i = 0; i < data.length; ++i) {
+            results[i] = Address.functionDelegateCall(address(this), data[i]);
+        }
+        return results;
+    }
+
+    function _getSignatureParts(bytes memory signature) private pure returns (SignatureParts memory signatureParts) {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+
+        /// @solidity memory-safe-assembly
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            r := mload(add(signature, 0x20))
+            s := mload(add(signature, 0x40))
+            v := byte(0, mload(add(signature, 0x60)))
+        }
+
+        signatureParts.r = r;
+        signatureParts.s = s;
+        signatureParts.v = v;
     }
 
     /**

--- a/pkg/vault/test/.contract-sizes/BatchRouter
+++ b/pkg/vault/test/.contract-sizes/BatchRouter
@@ -1,2 +1,2 @@
-Bytecode	14.834
-InitCode	16.366
+Bytecode	16.508
+InitCode	18.061

--- a/pkg/vault/test/foundry/Permit2.t.sol
+++ b/pkg/vault/test/foundry/Permit2.t.sol
@@ -10,6 +10,7 @@ import { IEIP712 } from "permit2/src/interfaces/IEIP712.sol";
 import { IAllowanceTransfer } from "permit2/src/interfaces/IAllowanceTransfer.sol";
 
 import { IRouter } from "@balancer-labs/v3-interfaces/contracts/vault/IRouter.sol";
+import { IRouterCommon } from "@balancer-labs/v3-interfaces/contracts/vault/IRouterCommon.sol";
 
 import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/ArrayHelpers.sol";
 
@@ -59,8 +60,8 @@ contract Permit2Test is BaseVaultTest {
         bptAmountOut = defaultAmount * 2;
         uint256[] memory amountsIn = [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray();
 
-        IRouter.PermitApproval[] memory permitBatch = new IRouter.PermitApproval[](1);
-        permitBatch[0] = IRouter.PermitApproval(pool, alice, address(router), bptAmountOut, 0, block.timestamp);
+        IRouterCommon.PermitApproval[] memory permitBatch = new IRouterCommon.PermitApproval[](1);
+        permitBatch[0] = IRouterCommon.PermitApproval(pool, alice, address(router), bptAmountOut, 0, block.timestamp);
 
         bytes[] memory permitSignatures = new bytes[](1);
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
@@ -127,7 +128,7 @@ contract Permit2Test is BaseVaultTest {
     }
 
     function testEmptyBatchAndCall() public {
-        IRouter.PermitApproval[] memory permitBatch = new IRouter.PermitApproval[](0);
+        IRouterCommon.PermitApproval[] memory permitBatch = new IRouterCommon.PermitApproval[](0);
         bytes[] memory permitSignatures = new bytes[](0);
         IAllowanceTransfer.PermitBatch memory permit2Batch;
         bytes[] memory multicallData = new bytes[](1);


### PR DESCRIPTION
# Description

We need `permitBatchAndCall` in the batch router as well. Moving this to the common layer does the trick.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A