### PR TITLE
Vault shaving (part 2)

### DIFF
--- a/pkg/vault/contracts/Vault.sol
+++ b/pkg/vault/contracts/Vault.sol
@@ -1204,8 +1204,13 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
 
         if (bufferBalances.getBalanceRaw() > amountOutUnderlying) {
             // the buffer has enough liquidity to facilitate the wrap without making an external call.
+            uint256 newRawBalance;
+            unchecked {
+                // We have verified above that this is safe to do unchecked.
+                newRawBalance = bufferBalances.getBalanceRaw() - amountOutUnderlying;
+            }
             bufferBalances = PackedTokenBalance.toPackedBalance(
-                bufferBalances.getBalanceRaw() - amountOutUnderlying,
+                newRawBalance,
                 bufferBalances.getBalanceDerived() + amountInWrapped
             );
             _bufferTokenBalances[IERC20(wrappedToken)] = bufferBalances;

--- a/pkg/vault/contracts/Vault.sol
+++ b/pkg/vault/contracts/Vault.sol
@@ -1083,9 +1083,15 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
         if (bufferBalances.getBalanceDerived() > amountOutWrapped) {
             // The buffer has enough liquidity to facilitate the wrap without making an external call.
 
+            uint256 newDerivedBalance;
+            unchecked {
+                // We have verified above that this is safe to do unchecked.
+                newDerivedBalance = bufferBalances.getBalanceDerived() - amountOutWrapped;
+            }
+
             bufferBalances = PackedTokenBalance.toPackedBalance(
                 bufferBalances.getBalanceRaw() + amountInUnderlying,
-                bufferBalances.getBalanceDerived() - amountOutWrapped
+                newDerivedBalance
             );
             _bufferTokenBalances[IERC20(wrappedToken)] = bufferBalances;
         } else {

--- a/pkg/vault/test/.contract-sizes/Vault
+++ b/pkg/vault/test/.contract-sizes/Vault
@@ -1,2 +1,2 @@
-Bytecode	23.744
-InitCode	25.033
+Bytecode	23.738
+InitCode	25.027

--- a/pkg/vault/test/.contract-sizes/Vault
+++ b/pkg/vault/test/.contract-sizes/Vault
@@ -1,2 +1,2 @@
-Bytecode	23.738
-InitCode	25.027
+Bytecode	23.691
+InitCode	24.980

--- a/pkg/vault/test/.contract-sizes/Vault
+++ b/pkg/vault/test/.contract-sizes/Vault
@@ -1,2 +1,2 @@
-Bytecode	23.921
-InitCode	25.210
+Bytecode	23.747
+InitCode	25.036

--- a/pkg/vault/test/.contract-sizes/Vault
+++ b/pkg/vault/test/.contract-sizes/Vault
@@ -1,2 +1,2 @@
-Bytecode	23.747
-InitCode	25.036
+Bytecode	23.744
+InitCode	25.033

--- a/pvt/helpers/src/contract-size.ts
+++ b/pvt/helpers/src/contract-size.ts
@@ -24,7 +24,7 @@ export async function saveSizeSnap(basePath: string, snap: string, deployedCodeS
 
   let fmtDeploySize = formatSize(deployedCodeSize, 'KiB');
   if (deployedCodeSize > DEPLOYED_SIZE_LIMIT) {
-    fmtDeploySize += '*';
+    fmtDeploySize += '* (' + (deployedCodeSize - DEPLOYED_SIZE_LIMIT) + ' over)';
   }
   let fmtInitSize = formatSize(initCodeSize, 'KiB');
   if (initCodeSize > INIT_SIZE_LIMIT) {


### PR DESCRIPTION
# Description

Since the upcoming guardrails PR goes over the bytecode again, time to make some room. This is another pass, inspired by #746, that gives the Vault an even closer shave (saves 230 bytes).

Also updates the Vault bytecode script to show how many bytes it's over, when it is (since the data type kind of obscures it).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [X] Optimization: [ ] gas / [X] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
