### PR TITLE
Removing redundant check from Router.sol

### DIFF
--- a/pkg/interfaces/contracts/vault/IRouter.sol
+++ b/pkg/interfaces/contracts/vault/IRouter.sol
@@ -204,9 +204,6 @@ interface IRouter {
         bytes userData;
     }
 
-    /// @dev The actual bptAmountOut is below the minimum limit specified in the exit.
-    error ExitBelowMin(uint256 amount, uint256 limit);
-
     /**
      * @notice Removes liquidity with proportional token amounts from a pool, burning an exact pool token amount.
      * @param pool Address of the liquidity pool

--- a/pkg/vault/contracts/Router.sol
+++ b/pkg/vault/contracts/Router.sol
@@ -474,10 +474,6 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
             uint256 amountOut = amountsOut[i];
             IERC20 token = tokens[i];
 
-            if (amountOut < params.minAmountsOut[i]) {
-                revert ExitBelowMin(amountOut, params.minAmountsOut[i]);
-            }
-
             // There can be only one WETH token in the pool
             if (params.wethIsEth && address(token) == address(_weth)) {
                 // Send WETH here and unwrap to native ETH


### PR DESCRIPTION
# Description

The vault already checks if `amountsOut` are greater than minimum, the router does not need to check again.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge
