### PR TITLE
Remove unnecessary address wrapper

### DIFF
--- a/pkg/pool-hooks/test/foundry/DirectionalFeeHookExample.t.sol
+++ b/pkg/pool-hooks/test/foundry/DirectionalFeeHookExample.t.sol
@@ -119,7 +119,7 @@ contract DirectionalHookExampleTest is BaseVaultTest {
 
         uint256 daiExactAmountIn = poolInitAmount / 10;
 
-        BaseVaultTest.Balances memory balancesBefore = getBalances(address(lp));
+        BaseVaultTest.Balances memory balancesBefore = getBalances(lp);
 
         // Calculate the expected amount out (amount out without fees)
         uint256 poolInvariant = StableMath.computeInvariant(
@@ -139,7 +139,7 @@ contract DirectionalHookExampleTest is BaseVaultTest {
         vm.prank(bob);
         router.swapSingleTokenExactIn(pool, dai, usdc, daiExactAmountIn, 0, MAX_UINT256, false, bytes(""));
 
-        BaseVaultTest.Balances memory balancesAfter = getBalances(address(lp));
+        BaseVaultTest.Balances memory balancesAfter = getBalances(lp);
 
         // Measure actual amount out, which is expectedAmountOut - swapFeeAmount
         uint256 actualAmountOut = balancesAfter.bobTokens[usdcIdx] - balancesBefore.bobTokens[usdcIdx];
@@ -204,7 +204,7 @@ contract DirectionalHookExampleTest is BaseVaultTest {
         // Swap to meaningfully take the pool out of equilibrium
         uint256 daiExactAmountIn = poolInitAmount / 2;
 
-        BaseVaultTest.Balances memory balancesBefore = getBalances(address(lp));
+        BaseVaultTest.Balances memory balancesBefore = getBalances(lp);
         // Since there's no rate providers, and all tokens are 18 decimals, scaled18 and raw values are equal.
         uint256[] memory balancesScaled18 = balancesBefore.poolTokens;
 
@@ -241,7 +241,7 @@ contract DirectionalHookExampleTest is BaseVaultTest {
         vm.prank(bob);
         router.swapSingleTokenExactIn(pool, dai, usdc, daiExactAmountIn, 0, MAX_UINT256, false, bytes(""));
 
-        BaseVaultTest.Balances memory balancesAfter = getBalances(address(lp));
+        BaseVaultTest.Balances memory balancesAfter = getBalances(lp);
 
         // Measure actual amount out, which is expectedAmountOut - swapFeeAmount
         uint256 actualAmountOut = balancesAfter.bobTokens[usdcIdx] - balancesBefore.bobTokens[usdcIdx];
@@ -310,7 +310,7 @@ contract DirectionalHookExampleTest is BaseVaultTest {
 
     function _registerPoolWithHook(address directionalFeePool, TokenConfig[] memory tokenConfig) private {
         PoolRoleAccounts memory roleAccounts;
-        roleAccounts.poolCreator = address(lp);
+        roleAccounts.poolCreator = lp;
 
         LiquidityManagement memory liquidityManagement;
 

--- a/pkg/pool-hooks/test/foundry/ExitFeeHookExample.t.sol
+++ b/pkg/pool-hooks/test/foundry/ExitFeeHookExample.t.sol
@@ -50,7 +50,7 @@ contract ExitFeeHookExampleTest is BaseVaultTest {
         vm.label(address(newPool), label);
 
         PoolRoleAccounts memory roleAccounts;
-        roleAccounts.poolCreator = address(lp);
+        roleAccounts.poolCreator = lp;
 
         LiquidityManagement memory liquidityManagement;
         liquidityManagement.disableUnbalancedLiquidity = true;
@@ -107,12 +107,12 @@ contract ExitFeeHookExampleTest is BaseVaultTest {
         uint256 hookFee = amountOut.mulDown(exitFeePercentage);
         uint256[] memory minAmountsOut = [amountOut - hookFee, amountOut - hookFee].toMemoryArray();
 
-        BaseVaultTest.Balances memory balancesBefore = getBalances(address(lp));
+        BaseVaultTest.Balances memory balancesBefore = getBalances(lp);
 
         vm.prank(lp);
         router.removeLiquidityProportional(pool, 2 * amountOut, minAmountsOut, false, bytes(""));
 
-        BaseVaultTest.Balances memory balancesAfter = getBalances(address(lp));
+        BaseVaultTest.Balances memory balancesAfter = getBalances(lp);
 
         // LP gets original liquidity minus hook fee
         assertEq(
@@ -166,7 +166,7 @@ contract ExitFeeHookExampleTest is BaseVaultTest {
 
     function _registerPoolWithHook(address exitFeePool, TokenConfig[] memory tokenConfig, bool enableDonation) private {
         PoolRoleAccounts memory roleAccounts;
-        roleAccounts.poolCreator = address(lp);
+        roleAccounts.poolCreator = lp;
 
         LiquidityManagement memory liquidityManagement;
         liquidityManagement.disableUnbalancedLiquidity = true;

--- a/pkg/pool-hooks/test/foundry/FeeTakingHookExample.t.sol
+++ b/pkg/pool-hooks/test/foundry/FeeTakingHookExample.t.sol
@@ -54,7 +54,7 @@ contract FeeTakingHookExampleTest is BaseVaultTest {
         vm.label(address(newPool), label);
 
         PoolRoleAccounts memory roleAccounts;
-        roleAccounts.poolCreator = address(lp);
+        roleAccounts.poolCreator = lp;
 
         LiquidityManagement memory liquidityManagement;
         liquidityManagement.disableUnbalancedLiquidity = true;
@@ -80,7 +80,7 @@ contract FeeTakingHookExampleTest is BaseVaultTest {
         FeeTakingHookExample(poolHooksContract).setHookSwapFeePercentage(hookFeePercentage);
         uint256 hookFee = swapAmount.mulDown(hookFeePercentage);
 
-        BaseVaultTest.Balances memory balancesBefore = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesBefore = getBalances(bob);
 
         vm.prank(bob);
         vm.expectCall(
@@ -106,7 +106,7 @@ contract FeeTakingHookExampleTest is BaseVaultTest {
 
         router.swapSingleTokenExactIn(address(pool), dai, usdc, swapAmount, 0, MAX_UINT256, false, bytes(""));
 
-        BaseVaultTest.Balances memory balancesAfter = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesAfter = getBalances(bob);
 
         assertEq(
             balancesBefore.userTokens[daiIdx] - balancesAfter.userTokens[daiIdx],
@@ -138,7 +138,7 @@ contract FeeTakingHookExampleTest is BaseVaultTest {
         FeeTakingHookExample(poolHooksContract).setHookSwapFeePercentage(hookFeePercentage);
         uint256 hookFee = swapAmount.mulDown(hookFeePercentage);
 
-        BaseVaultTest.Balances memory balancesBefore = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesBefore = getBalances(bob);
 
         vm.prank(bob);
         vm.expectCall(
@@ -173,7 +173,7 @@ contract FeeTakingHookExampleTest is BaseVaultTest {
             bytes("")
         );
 
-        BaseVaultTest.Balances memory balancesAfter = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesAfter = getBalances(bob);
 
         assertEq(
             balancesAfter.userTokens[usdcIdx] - balancesBefore.userTokens[usdcIdx],
@@ -225,7 +225,7 @@ contract FeeTakingHookExampleTest is BaseVaultTest {
         uint256[] memory expectedBalances = [poolInitAmount + actualAmountIn, poolInitAmount + actualAmountIn]
             .toMemoryArray();
 
-        BaseVaultTest.Balances memory balancesBefore = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesBefore = getBalances(bob);
 
         vm.prank(bob);
         vm.expectCall(
@@ -280,7 +280,7 @@ contract FeeTakingHookExampleTest is BaseVaultTest {
         uint256[] memory expectedBalances = [2 * poolInitAmount - actualAmountOut, 2 * poolInitAmount - actualAmountOut]
             .toMemoryArray();
 
-        BaseVaultTest.Balances memory balancesBefore = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesBefore = getBalances(bob);
 
         vm.prank(bob);
         vm.expectCall(
@@ -338,7 +338,7 @@ contract FeeTakingHookExampleTest is BaseVaultTest {
         uint256 expectedBptOut,
         uint256 expectedHookFee
     ) private view {
-        BaseVaultTest.Balances memory balancesAfter = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesAfter = getBalances(bob);
 
         assertEq(balancesAfter.userBpt - balancesBefore.userBpt, expectedBptOut, "Bob BPT balance is wrong");
 
@@ -394,7 +394,7 @@ contract FeeTakingHookExampleTest is BaseVaultTest {
         uint256 expectedBptIn,
         uint256 expectedHookFee
     ) private view {
-        BaseVaultTest.Balances memory balancesAfter = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesAfter = getBalances(bob);
 
         assertEq(balancesBefore.userBpt - balancesAfter.userBpt, expectedBptIn, "Bob BPT balance is wrong");
 

--- a/pkg/pool-hooks/test/foundry/LotteryHookExample.t.sol
+++ b/pkg/pool-hooks/test/foundry/LotteryHookExample.t.sol
@@ -58,7 +58,7 @@ contract LotteryHookExampleTest is BaseVaultTest {
         vm.label(address(newPool), label);
 
         PoolRoleAccounts memory roleAccounts;
-        roleAccounts.poolCreator = address(lp);
+        roleAccounts.poolCreator = lp;
 
         LiquidityManagement memory liquidityManagement;
         liquidityManagement.disableUnbalancedLiquidity = true;
@@ -238,7 +238,7 @@ contract LotteryHookExampleTest is BaseVaultTest {
         LotteryHookExample(poolHooksContract).setHookSwapFeePercentage(hookFeePercentage);
         uint256 hookFee = swapAmount.mulDown(hookFeePercentage);
 
-        balancesBefore = getBalances(address(bob));
+        balancesBefore = getBalances(bob);
 
         accruedFees = new uint256[](2); // Store the fees collected on each token
         iterations = 0;
@@ -293,7 +293,7 @@ contract LotteryHookExampleTest is BaseVaultTest {
         assertNotEq(iterations, 1, "Only 1 iteration");
         assertNotEq(iterations, MAX_ITERATIONS, "Max iterations reached, no winner");
 
-        balancesAfter = getBalances(address(bob));
+        balancesAfter = getBalances(bob);
     }
 
     // @dev Check if pool balances and vault reserves reflect all swaps

--- a/pkg/pool-hooks/test/foundry/VeBALFeeDiscountHookExample.t.sol
+++ b/pkg/pool-hooks/test/foundry/VeBALFeeDiscountHookExample.t.sol
@@ -117,7 +117,7 @@ contract VeBALFeeDiscountHookExampleTest is BaseVaultTest {
 
     function testSwapWithVeBal() public {
         // Mint 1 veBAL to bob, so he's able to receive the fee discount
-        veBAL.mint(address(bob), 1);
+        veBAL.mint(bob, 1);
         assertGt(veBAL.balanceOf(bob), 0, "Bob does not have veBAL");
 
         _doSwapAndCheckBalances(trustedRouter);
@@ -125,7 +125,7 @@ contract VeBALFeeDiscountHookExampleTest is BaseVaultTest {
 
     function testSwapWithVeBalAndUntrustedRouter() public {
         // Mint 1 veBAL to bob, so he's able to receive the fee discount
-        veBAL.mint(address(bob), 1);
+        veBAL.mint(bob, 1);
         assertGt(veBAL.balanceOf(bob), 0, "Bob does not have veBAL");
 
         // Create an untrusted router
@@ -156,7 +156,7 @@ contract VeBALFeeDiscountHookExampleTest is BaseVaultTest {
         // Hook fee will remain in the pool, so the expected amount out discounts the fees
         expectedAmountOut -= expectedHookFee;
 
-        BaseVaultTest.Balances memory balancesBefore = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesBefore = getBalances(bob);
 
         vm.prank(bob);
         RouterMock(routerToUse).swapSingleTokenExactIn(
@@ -170,7 +170,7 @@ contract VeBALFeeDiscountHookExampleTest is BaseVaultTest {
             bytes("")
         );
 
-        BaseVaultTest.Balances memory balancesAfter = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesAfter = getBalances(bob);
 
         // Bob's balance of DAI is supposed to decrease, since DAI is the token in
         assertEq(

--- a/pkg/pool-stable/test/foundry/StablePoolFactory.t.sol
+++ b/pkg/pool-stable/test/foundry/StablePoolFactory.t.sol
@@ -119,9 +119,9 @@ contract StablePoolFactoryTest is BaseVaultTest {
     }
 
     function _createHookTestLocals(address pool) private view returns (HookTestLocals memory vars) {
-        vars.bob.daiBefore = dai.balanceOf(address(bob));
-        vars.bob.usdcBefore = usdc.balanceOf(address(bob));
-        vars.bob.bptBefore = IERC20(pool).balanceOf(address(bob));
+        vars.bob.daiBefore = dai.balanceOf(bob);
+        vars.bob.usdcBefore = usdc.balanceOf(bob);
+        vars.bob.bptBefore = IERC20(pool).balanceOf(bob);
         vars.vault.daiBefore = dai.balanceOf(address(vault));
         vars.vault.usdcBefore = usdc.balanceOf(address(vault));
         vars.poolBefore = vault.getRawBalances(pool);
@@ -129,9 +129,9 @@ contract StablePoolFactoryTest is BaseVaultTest {
     }
 
     function _fillAfterHookTestLocals(HookTestLocals memory vars, address pool) private view {
-        vars.bob.daiAfter = dai.balanceOf(address(bob));
-        vars.bob.usdcAfter = usdc.balanceOf(address(bob));
-        vars.bob.bptAfter = IERC20(pool).balanceOf(address(bob));
+        vars.bob.daiAfter = dai.balanceOf(bob);
+        vars.bob.usdcAfter = usdc.balanceOf(bob);
+        vars.bob.bptAfter = IERC20(pool).balanceOf(bob);
         vars.vault.daiAfter = dai.balanceOf(address(vault));
         vars.vault.usdcAfter = usdc.balanceOf(address(vault));
         vars.poolAfter = vault.getRawBalances(pool);

--- a/pkg/pool-weighted/test/foundry/WeightedPoolFactory.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedPoolFactory.t.sol
@@ -118,9 +118,9 @@ contract WeightedPoolFactoryTest is BaseVaultTest {
     }
 
     function _createHookTestLocals(address pool) private view returns (HookTestLocals memory vars) {
-        vars.bob.daiBefore = dai.balanceOf(address(bob));
-        vars.bob.usdcBefore = usdc.balanceOf(address(bob));
-        vars.bob.bptBefore = IERC20(pool).balanceOf(address(bob));
+        vars.bob.daiBefore = dai.balanceOf(bob);
+        vars.bob.usdcBefore = usdc.balanceOf(bob);
+        vars.bob.bptBefore = IERC20(pool).balanceOf(bob);
         vars.vault.daiBefore = dai.balanceOf(address(vault));
         vars.vault.usdcBefore = usdc.balanceOf(address(vault));
         vars.poolBefore = vault.getRawBalances(pool);
@@ -128,9 +128,9 @@ contract WeightedPoolFactoryTest is BaseVaultTest {
     }
 
     function _fillAfterHookTestLocals(HookTestLocals memory vars, address pool) private view {
-        vars.bob.daiAfter = dai.balanceOf(address(bob));
-        vars.bob.usdcAfter = usdc.balanceOf(address(bob));
-        vars.bob.bptAfter = IERC20(pool).balanceOf(address(bob));
+        vars.bob.daiAfter = dai.balanceOf(bob);
+        vars.bob.usdcAfter = usdc.balanceOf(bob);
+        vars.bob.bptAfter = IERC20(pool).balanceOf(bob);
         vars.vault.daiAfter = dai.balanceOf(address(vault));
         vars.vault.usdcAfter = usdc.balanceOf(address(vault));
         vars.poolAfter = vault.getRawBalances(pool);

--- a/pkg/solidity-utils/contracts/helpers/ArrayHelpers.sol
+++ b/pkg/solidity-utils/contracts/helpers/ArrayHelpers.sol
@@ -26,6 +26,27 @@ library ArrayHelpers {
         return ret;
     }
 
+    function toMemoryArray(address payable[1] memory array) internal pure returns (address[] memory) {
+        address[] memory ret = new address[](1);
+        ret[0] = array[0];
+        return ret;
+    }
+
+    function toMemoryArray(address payable[2] memory array) internal pure returns (address[] memory) {
+        address[] memory ret = new address[](2);
+        ret[0] = array[0];
+        ret[1] = array[1];
+        return ret;
+    }
+
+    function toMemoryArray(address payable[3] memory array) internal pure returns (address[] memory) {
+        address[] memory ret = new address[](3);
+        ret[0] = array[0];
+        ret[1] = array[1];
+        ret[2] = array[2];
+        return ret;
+    }
+
     function toMemoryArray(uint256[1] memory array) internal pure returns (uint256[] memory) {
         uint256[] memory ret = new uint256[](1);
         ret[0] = array[0];

--- a/pkg/vault/test/foundry/BoostedPoolBufferAsVaultPrimitive.t.sol
+++ b/pkg/vault/test/foundry/BoostedPoolBufferAsVaultPrimitive.t.sol
@@ -63,12 +63,12 @@ contract BoostedPoolBufferAsVaultPrimitiveTest is BaseVaultTest {
 
         // Can add the same amount again, since twice as much was minted
         vm.expectEmit();
-        emit IVaultEvents.LiquidityAddedToBuffer(waDAI, address(lp), bufferAmount, bufferAmount, bufferAmount * 2);
-        router.addLiquidityToBuffer(waDAI, bufferAmount, bufferAmount, address(lp));
+        emit IVaultEvents.LiquidityAddedToBuffer(waDAI, lp, bufferAmount, bufferAmount, bufferAmount * 2);
+        router.addLiquidityToBuffer(waDAI, bufferAmount, bufferAmount, lp);
 
         vm.expectEmit();
-        emit IVaultEvents.LiquidityAddedToBuffer(waUSDC, address(lp), bufferAmount, bufferAmount, bufferAmount * 2);
-        router.addLiquidityToBuffer(waUSDC, bufferAmount, bufferAmount, address(lp));
+        emit IVaultEvents.LiquidityAddedToBuffer(waUSDC, lp, bufferAmount, bufferAmount, bufferAmount * 2);
+        router.addLiquidityToBuffer(waUSDC, bufferAmount, bufferAmount, lp);
     }
 
     function testRemoveLiquidityEvents() public {
@@ -78,24 +78,12 @@ contract BoostedPoolBufferAsVaultPrimitiveTest is BaseVaultTest {
         authorizer.grantRole(vault.getActionId(IVaultAdmin.removeLiquidityFromBuffer.selector), address(router));
 
         vm.expectEmit();
-        emit IVaultEvents.LiquidityRemovedFromBuffer(
-            waDAI,
-            address(lp),
-            bufferAmount / 2,
-            bufferAmount / 2,
-            bufferAmount
-        );
+        emit IVaultEvents.LiquidityRemovedFromBuffer(waDAI, lp, bufferAmount / 2, bufferAmount / 2, bufferAmount);
         vm.prank(lp);
         router.removeLiquidityFromBuffer(waDAI, bufferAmount);
 
         vm.expectEmit();
-        emit IVaultEvents.LiquidityRemovedFromBuffer(
-            waUSDC,
-            address(lp),
-            bufferAmount / 2,
-            bufferAmount / 2,
-            bufferAmount
-        );
+        emit IVaultEvents.LiquidityRemovedFromBuffer(waUSDC, lp, bufferAmount / 2, bufferAmount / 2, bufferAmount);
         vm.prank(lp);
         router.removeLiquidityFromBuffer(waUSDC, bufferAmount);
     }
@@ -103,13 +91,13 @@ contract BoostedPoolBufferAsVaultPrimitiveTest is BaseVaultTest {
     function initializeBuffers() private {
         // Create and fund buffer pools
         vm.startPrank(lp);
-        dai.mint(address(lp), 2 * bufferAmount);
+        dai.mint(lp, 2 * bufferAmount);
         dai.approve(address(waDAI), 2 * bufferAmount);
-        waDAI.deposit(2 * bufferAmount, address(lp));
+        waDAI.deposit(2 * bufferAmount, lp);
 
-        usdc.mint(address(lp), 2 * bufferAmount);
+        usdc.mint(lp, 2 * bufferAmount);
         usdc.approve(address(waUSDC), 2 * bufferAmount);
-        waUSDC.deposit(2 * bufferAmount, address(lp));
+        waUSDC.deposit(2 * bufferAmount, lp);
         vm.stopPrank();
 
         vm.startPrank(lp);
@@ -120,8 +108,8 @@ contract BoostedPoolBufferAsVaultPrimitiveTest is BaseVaultTest {
         permit2.approve(address(waUSDC), address(router), type(uint160).max, type(uint48).max);
         permit2.approve(address(waUSDC), address(batchRouter), type(uint160).max, type(uint48).max);
 
-        router.addLiquidityToBuffer(waDAI, bufferAmount, bufferAmount, address(lp));
-        router.addLiquidityToBuffer(waUSDC, bufferAmount, bufferAmount, address(lp));
+        router.addLiquidityToBuffer(waDAI, bufferAmount, bufferAmount, lp);
+        router.addLiquidityToBuffer(waUSDC, bufferAmount, bufferAmount, lp);
         vm.stopPrank();
     }
 
@@ -149,13 +137,13 @@ contract BoostedPoolBufferAsVaultPrimitiveTest is BaseVaultTest {
         permit2.approve(address(waUSDC), address(router), type(uint160).max, type(uint48).max);
         permit2.approve(address(waUSDC), address(batchRouter), type(uint160).max, type(uint48).max);
 
-        dai.mint(address(bob), boostedPoolAmount);
+        dai.mint(bob, boostedPoolAmount);
         dai.approve(address(waDAI), boostedPoolAmount);
-        waDAI.deposit(boostedPoolAmount, address(bob));
+        waDAI.deposit(boostedPoolAmount, bob);
 
-        usdc.mint(address(bob), boostedPoolAmount);
+        usdc.mint(bob, boostedPoolAmount);
         usdc.approve(address(waUSDC), boostedPoolAmount);
-        waUSDC.deposit(boostedPoolAmount, address(bob));
+        waUSDC.deposit(boostedPoolAmount, bob);
 
         _initPool(boostedPool, [boostedPoolAmount, boostedPoolAmount].toMemoryArray(), boostedPoolAmount * 2 - MIN_BPT);
         vm.stopPrank();
@@ -174,12 +162,12 @@ contract BoostedPoolBufferAsVaultPrimitiveTest is BaseVaultTest {
 
         // LP should have correct amount of shares from buffer (invested amount in underlying minus burned "BPTs")
         assertEq(
-            vault.getBufferOwnerShares(IERC20(waDAI), address(lp)),
+            vault.getBufferOwnerShares(IERC20(waDAI), lp),
             bufferAmount * 2 - MIN_BPT,
             "Wrong share of waDAI buffer belonging to LP"
         );
         assertEq(
-            vault.getBufferOwnerShares(IERC20(waUSDC), address(lp)),
+            vault.getBufferOwnerShares(IERC20(waUSDC), lp),
             bufferAmount * 2 - MIN_BPT,
             "Wrong share of waUSDC buffer belonging to LP"
         );
@@ -288,9 +276,9 @@ contract BoostedPoolBufferAsVaultPrimitiveTest is BaseVaultTest {
     function testBoostedPoolSwapUnbalancedBufferExactIn() public {
         vm.startPrank(lp);
         // Surplus of underlying
-        router.addLiquidityToBuffer(waDAI, unbalanceDelta, 0, address(lp));
+        router.addLiquidityToBuffer(waDAI, unbalanceDelta, 0, lp);
         // Surplus of wrapped
-        router.addLiquidityToBuffer(waUSDC, 0, unbalanceDelta, address(lp));
+        router.addLiquidityToBuffer(waUSDC, 0, unbalanceDelta, lp);
         vm.stopPrank();
 
         SwapResultLocals memory vars = _createSwapResultLocals(SwapKind.EXACT_IN);
@@ -319,9 +307,9 @@ contract BoostedPoolBufferAsVaultPrimitiveTest is BaseVaultTest {
     function testBoostedPoolSwapUnbalancedBufferExactOut() public {
         vm.startPrank(lp);
         // Surplus of underlying
-        router.addLiquidityToBuffer(waDAI, unbalanceDelta, 0, address(lp));
+        router.addLiquidityToBuffer(waDAI, unbalanceDelta, 0, lp);
         // Surplus of wrapped
-        router.addLiquidityToBuffer(waUSDC, 0, unbalanceDelta, address(lp));
+        router.addLiquidityToBuffer(waUSDC, 0, unbalanceDelta, lp);
         vm.stopPrank();
 
         SwapResultLocals memory vars = _createSwapResultLocals(SwapKind.EXACT_OUT);
@@ -410,8 +398,8 @@ contract BoostedPoolBufferAsVaultPrimitiveTest is BaseVaultTest {
 
     function _createSwapResultLocals(SwapKind kind) private view returns (SwapResultLocals memory vars) {
         vars.kind = kind;
-        vars.aliceBalanceBeforeSwapDai = dai.balanceOf(address(alice));
-        vars.aliceBalanceBeforeSwapUsdc = usdc.balanceOf(address(alice));
+        vars.aliceBalanceBeforeSwapDai = dai.balanceOf(alice);
+        vars.aliceBalanceBeforeSwapUsdc = usdc.balanceOf(alice);
 
         uint256 underlyingBalance;
         uint256 wrappedBalance;

--- a/pkg/vault/test/foundry/BufferVaultPrimitive.t.sol
+++ b/pkg/vault/test/foundry/BufferVaultPrimitive.t.sol
@@ -51,13 +51,13 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
         // Create and fund buffer pools
         vm.startPrank(lp);
 
-        dai.mint(address(lp), _userAmount);
+        dai.mint(lp, _userAmount);
         dai.approve(address(waDAI), _userAmount);
-        waDAI.deposit(_userAmount, address(lp));
+        waDAI.deposit(_userAmount, lp);
 
-        usdc.mint(address(lp), _userAmount);
+        usdc.mint(lp, _userAmount);
         usdc.approve(address(waUSDC), _userAmount);
-        waUSDC.deposit(_userAmount, address(lp));
+        waUSDC.deposit(_userAmount, lp);
 
         // Minting wrong token to wrapped token contracts, to test changing the asset
         dai.mint(address(waUSDC), _userAmount);
@@ -96,7 +96,7 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
 
         // Add Liquidity with the right asset
         vm.prank(lp);
-        router.addLiquidityToBuffer(IERC4626(address(waDAI)), _wrapAmount, _wrapAmount, address(lp));
+        router.addLiquidityToBuffer(IERC4626(address(waDAI)), _wrapAmount, _wrapAmount, lp);
 
         // Change Asset to the wrong asset
         waDAI.setAsset(usdc);
@@ -119,14 +119,14 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
             IERC20(address(waDAI))
         );
 
-        uint256 lpUnderlyingBalanceBefore = dai.balanceOf(address(lp));
-        uint256 lpWrappedBalanceBefore = IERC20(address(waDAI)).balanceOf(address(lp));
+        uint256 lpUnderlyingBalanceBefore = dai.balanceOf(lp);
+        uint256 lpWrappedBalanceBefore = IERC20(address(waDAI)).balanceOf(lp);
 
         vm.prank(lp);
         batchRouter.swapExactIn(paths, MAX_UINT256, false, bytes(""));
 
-        uint256 lpUnderlyingBalanceAfter = dai.balanceOf(address(lp));
-        uint256 lpWrappedBalanceAfter = IERC20(address(waDAI)).balanceOf(address(lp));
+        uint256 lpUnderlyingBalanceAfter = dai.balanceOf(lp);
+        uint256 lpWrappedBalanceAfter = IERC20(address(waDAI)).balanceOf(lp);
 
         assertEq(
             lpUnderlyingBalanceAfter,
@@ -226,14 +226,14 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
             IERC20(address(waDAI))
         );
 
-        uint256 lpUnderlyingBalanceBefore = dai.balanceOf(address(lp));
-        uint256 lpWrappedBalanceBefore = IERC20(address(waDAI)).balanceOf(address(lp));
+        uint256 lpUnderlyingBalanceBefore = dai.balanceOf(lp);
+        uint256 lpWrappedBalanceBefore = IERC20(address(waDAI)).balanceOf(lp);
 
         vm.prank(lp);
         batchRouter.swapExactOut(paths, MAX_UINT256, false, bytes(""));
 
-        uint256 lpUnderlyingBalanceAfter = dai.balanceOf(address(lp));
-        uint256 lpWrappedBalanceAfter = IERC20(address(waDAI)).balanceOf(address(lp));
+        uint256 lpUnderlyingBalanceAfter = dai.balanceOf(lp);
+        uint256 lpWrappedBalanceAfter = IERC20(address(waDAI)).balanceOf(lp);
 
         assertEq(
             lpUnderlyingBalanceAfter,
@@ -329,14 +329,14 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
             IERC20(address(waDAI))
         );
 
-        uint256 lpUnderlyingBalanceBefore = dai.balanceOf(address(lp));
-        uint256 lpWrappedBalanceBefore = IERC20(address(waDAI)).balanceOf(address(lp));
+        uint256 lpUnderlyingBalanceBefore = dai.balanceOf(lp);
+        uint256 lpWrappedBalanceBefore = IERC20(address(waDAI)).balanceOf(lp);
 
         vm.prank(lp);
         batchRouter.swapExactIn(paths, MAX_UINT256, false, bytes(""));
 
-        uint256 lpUnderlyingBalanceAfter = dai.balanceOf(address(lp));
-        uint256 lpWrappedBalanceAfter = IERC20(address(waDAI)).balanceOf(address(lp));
+        uint256 lpUnderlyingBalanceAfter = dai.balanceOf(lp);
+        uint256 lpWrappedBalanceAfter = IERC20(address(waDAI)).balanceOf(lp);
 
         assertEq(
             lpUnderlyingBalanceAfter,
@@ -379,7 +379,7 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
 
         vm.startPrank(lp);
         // Call addLiquidity so vault has enough liquidity to cover extra wrapped amount
-        router.addLiquidityToBuffer(IERC4626(address(waDAI)), _wrapAmount, _wrapAmount, address(lp));
+        router.addLiquidityToBuffer(IERC4626(address(waDAI)), _wrapAmount, _wrapAmount, lp);
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.WrongWrappedAmount.selector, address(waDAI)));
         batchRouter.swapExactIn(paths, MAX_UINT256, false, bytes(""));
         vm.stopPrank();
@@ -429,14 +429,14 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
             IERC20(address(waDAI))
         );
 
-        uint256 lpUnderlyingBalanceBefore = dai.balanceOf(address(lp));
-        uint256 lpWrappedBalanceBefore = IERC20(address(waDAI)).balanceOf(address(lp));
+        uint256 lpUnderlyingBalanceBefore = dai.balanceOf(lp);
+        uint256 lpWrappedBalanceBefore = IERC20(address(waDAI)).balanceOf(lp);
 
         vm.prank(lp);
         batchRouter.swapExactOut(paths, MAX_UINT256, false, bytes(""));
 
-        uint256 lpUnderlyingBalanceAfter = dai.balanceOf(address(lp));
-        uint256 lpWrappedBalanceAfter = IERC20(address(waDAI)).balanceOf(address(lp));
+        uint256 lpUnderlyingBalanceAfter = dai.balanceOf(lp);
+        uint256 lpWrappedBalanceAfter = IERC20(address(waDAI)).balanceOf(lp);
 
         assertEq(
             lpUnderlyingBalanceAfter,
@@ -475,7 +475,7 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
 
         vm.startPrank(lp);
         // Call addLiquidity so vault has enough liquidity to cover extra wrapped amount
-        router.addLiquidityToBuffer(IERC4626(address(waDAI)), _wrapAmount, _wrapAmount, address(lp));
+        router.addLiquidityToBuffer(IERC4626(address(waDAI)), _wrapAmount, _wrapAmount, lp);
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.WrongWrappedAmount.selector, address(waDAI)));
         batchRouter.swapExactOut(paths, MAX_UINT256, false, bytes(""));
         vm.stopPrank();
@@ -539,7 +539,7 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
 
     function testDisableVaultBuffer() public {
         vm.prank(lp);
-        router.addLiquidityToBuffer(IERC4626(address(waDAI)), _wrapAmount, _wrapAmount, address(lp));
+        router.addLiquidityToBuffer(IERC4626(address(waDAI)), _wrapAmount, _wrapAmount, lp);
 
         vm.prank(admin);
         IVaultAdmin(address(vault)).pauseVaultBuffers();
@@ -559,7 +559,7 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
         batchRouter.swapExactIn(paths, MAX_UINT256, false, bytes(""));
 
         vm.expectRevert(IVaultErrors.VaultBuffersArePaused.selector);
-        router.addLiquidityToBuffer(IERC4626(address(waDAI)), _wrapAmount, _wrapAmount, address(lp));
+        router.addLiquidityToBuffer(IERC4626(address(waDAI)), _wrapAmount, _wrapAmount, lp);
 
         // remove liquidity is supposed to pass even with buffers paused, so revert is not expected
         router.removeLiquidityFromBuffer(IERC4626(address(waDAI)), _wrapAmount);

--- a/pkg/vault/test/foundry/HookAdjustedLiquidity.t.sol
+++ b/pkg/vault/test/foundry/HookAdjustedLiquidity.t.sol
@@ -54,7 +54,7 @@ contract HookAdjustedLiquidityTest is BaseVaultTest {
         vm.label(address(newPool), label);
 
         PoolRoleAccounts memory roleAccounts;
-        roleAccounts.poolCreator = address(lp);
+        roleAccounts.poolCreator = lp;
 
         LiquidityManagement memory liquidityManagement;
         liquidityManagement.disableUnbalancedLiquidity = true;
@@ -105,7 +105,7 @@ contract HookAdjustedLiquidityTest is BaseVaultTest {
         uint256[] memory expectedBalances = [poolInitAmount + actualAmountIn, poolInitAmount + actualAmountIn]
             .toMemoryArray();
 
-        BaseVaultTest.Balances memory balancesBefore = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesBefore = getBalances(bob);
 
         vm.prank(bob);
         vm.expectCall(
@@ -152,7 +152,7 @@ contract HookAdjustedLiquidityTest is BaseVaultTest {
         uint256[] memory expectedBalances = [poolInitAmount + actualAmountIn, poolInitAmount + actualAmountIn]
             .toMemoryArray();
 
-        BaseVaultTest.Balances memory balancesBefore = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesBefore = getBalances(bob);
 
         vm.prank(bob);
         vm.expectCall(
@@ -255,7 +255,7 @@ contract HookAdjustedLiquidityTest is BaseVaultTest {
         uint256[] memory expectedBalances = [2 * poolInitAmount - actualAmountOut, 2 * poolInitAmount - actualAmountOut]
             .toMemoryArray();
 
-        BaseVaultTest.Balances memory balancesBefore = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesBefore = getBalances(bob);
 
         vm.prank(bob);
         vm.expectCall(
@@ -313,7 +313,7 @@ contract HookAdjustedLiquidityTest is BaseVaultTest {
         uint256[] memory expectedBalances = [2 * poolInitAmount - actualAmountOut, 2 * poolInitAmount - actualAmountOut]
             .toMemoryArray();
 
-        BaseVaultTest.Balances memory balancesBefore = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesBefore = getBalances(bob);
 
         vm.prank(bob);
         vm.expectCall(
@@ -416,7 +416,7 @@ contract HookAdjustedLiquidityTest is BaseVaultTest {
         uint256 expectedBptOut,
         int256 expectedHookDelta
     ) private view {
-        BaseVaultTest.Balances memory balancesAfter = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesAfter = getBalances(bob);
 
         assertEq(balancesAfter.poolSupply - balancesBefore.poolSupply, expectedBptOut, "Pool Supply is wrong");
         assertEq(
@@ -471,7 +471,7 @@ contract HookAdjustedLiquidityTest is BaseVaultTest {
         uint256 expectedBptIn,
         int256 expectedHookDelta
     ) private view {
-        BaseVaultTest.Balances memory balancesAfter = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesAfter = getBalances(bob);
 
         assertEq(balancesBefore.poolSupply - balancesAfter.poolSupply, expectedBptIn, "Pool Supply is wrong");
         assertEq(

--- a/pkg/vault/test/foundry/HookAdjustedSwap.t.sol
+++ b/pkg/vault/test/foundry/HookAdjustedSwap.t.sol
@@ -50,7 +50,7 @@ contract HookAdjustedSwapTest is BaseVaultTest {
         vm.label(address(newPool), label);
 
         PoolRoleAccounts memory roleAccounts;
-        roleAccounts.poolCreator = address(lp);
+        roleAccounts.poolCreator = lp;
 
         LiquidityManagement memory liquidityManagement;
         liquidityManagement.disableUnbalancedLiquidity = true;
@@ -75,7 +75,7 @@ contract HookAdjustedSwapTest is BaseVaultTest {
         PoolHooksMock(poolHooksContract).setHookSwapFeePercentage(hookFeePercentage);
         uint256 hookFee = swapAmount.mulDown(hookFeePercentage);
 
-        BaseVaultTest.Balances memory balancesBefore = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesBefore = getBalances(bob);
 
         vm.prank(bob);
         vm.expectCall(
@@ -101,7 +101,7 @@ contract HookAdjustedSwapTest is BaseVaultTest {
 
         router.swapSingleTokenExactIn(address(pool), dai, usdc, swapAmount, 0, MAX_UINT256, false, bytes(""));
 
-        BaseVaultTest.Balances memory balancesAfter = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesAfter = getBalances(bob);
 
         assertEq(
             balancesBefore.userTokens[daiIdx] - balancesAfter.userTokens[daiIdx],
@@ -135,7 +135,7 @@ contract HookAdjustedSwapTest is BaseVaultTest {
         // Hook needs to pay the discount to the pool. Since it's exact in, the discount is paid in tokenOut amount.
         usdc.mint(address(poolHooksContract), hookDiscount);
 
-        BaseVaultTest.Balances memory balancesBefore = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesBefore = getBalances(bob);
 
         // Check that the swap gets updated balances that reflect the updated balance in the before hook
         vm.prank(bob);
@@ -163,7 +163,7 @@ contract HookAdjustedSwapTest is BaseVaultTest {
 
         router.swapSingleTokenExactIn(address(pool), dai, usdc, swapAmount, 0, MAX_UINT256, false, bytes(""));
 
-        BaseVaultTest.Balances memory balancesAfter = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesAfter = getBalances(bob);
 
         assertEq(
             balancesBefore.userTokens[daiIdx] - balancesAfter.userTokens[daiIdx],
@@ -194,7 +194,7 @@ contract HookAdjustedSwapTest is BaseVaultTest {
         PoolHooksMock(poolHooksContract).setHookSwapFeePercentage(hookFeePercentage);
         uint256 hookFee = swapAmount.mulDown(hookFeePercentage);
 
-        BaseVaultTest.Balances memory balancesBefore = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesBefore = getBalances(bob);
 
         // Check that the swap gets updated balances that reflect the updated balance in the before hook
         vm.prank(bob);
@@ -231,7 +231,7 @@ contract HookAdjustedSwapTest is BaseVaultTest {
             bytes("")
         );
 
-        BaseVaultTest.Balances memory balancesAfter = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesAfter = getBalances(bob);
 
         assertEq(
             balancesAfter.userTokens[usdcIdx] - balancesBefore.userTokens[usdcIdx],
@@ -265,7 +265,7 @@ contract HookAdjustedSwapTest is BaseVaultTest {
         // Hook needs to pay the discount to the pool. Since it's exact out, the discount is paid in tokenIn amount.
         dai.mint(address(poolHooksContract), hookDiscount);
 
-        BaseVaultTest.Balances memory balancesBefore = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesBefore = getBalances(bob);
 
         // Check that the swap gets updated balances that reflect the updated balance in the before hook
         vm.prank(bob);
@@ -302,7 +302,7 @@ contract HookAdjustedSwapTest is BaseVaultTest {
             bytes("")
         );
 
-        BaseVaultTest.Balances memory balancesAfter = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesAfter = getBalances(bob);
 
         assertEq(
             balancesAfter.userTokens[usdcIdx] - balancesBefore.userTokens[usdcIdx],

--- a/pkg/vault/test/foundry/PoolDonation.t.sol
+++ b/pkg/vault/test/foundry/PoolDonation.t.sol
@@ -36,12 +36,12 @@ contract PoolDonationTest is BaseVaultTest {
         uint256[] memory amountsToDonate = new uint256[](2);
         amountsToDonate[daiIdx] = amountToDonate;
 
-        BaseVaultTest.Balances memory balancesBefore = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesBefore = getBalances(bob);
 
         vm.prank(bob);
         router.donate(pool, amountsToDonate, false, bytes(""));
 
-        BaseVaultTest.Balances memory balancesAfter = getBalances(address(bob));
+        BaseVaultTest.Balances memory balancesAfter = getBalances(bob);
 
         // Bob balances
         assertEq(

--- a/pkg/vault/test/foundry/PoolSwapManager.t.sol
+++ b/pkg/vault/test/foundry/PoolSwapManager.t.sol
@@ -99,7 +99,7 @@ contract PoolSwapManagerTest is BaseVaultTest {
     }
 
     function testCannotSetSwapFeePercentageIfNotManager() public {
-        require(vault.getPoolRoleAccounts(pool).swapFeeManager == address(admin), "Wrong swap fee manager");
+        require(vault.getPoolRoleAccounts(pool).swapFeeManager == admin, "Wrong swap fee manager");
 
         vm.prank(bob);
         vm.expectRevert(IAuthentication.SenderNotAllowed.selector);

--- a/pkg/vault/test/foundry/QueryERC4626Buffer.t.sol
+++ b/pkg/vault/test/foundry/QueryERC4626Buffer.t.sol
@@ -73,12 +73,12 @@ contract QueryERC4626BufferTest is BaseVaultTest {
 
         // LP should have correct amount of shares from buffer (invested amount in underlying minus burned "BPTs")
         assertEq(
-            vault.getBufferOwnerShares(IERC20(waDAI), address(lp)),
+            vault.getBufferOwnerShares(IERC20(waDAI), lp),
             bufferAmount * 2 - MIN_BPT,
             "Wrong share of waDAI buffer belonging to LP"
         );
         assertEq(
-            vault.getBufferOwnerShares(IERC20(waUSDC), address(lp)),
+            vault.getBufferOwnerShares(IERC20(waUSDC), lp),
             bufferAmount * 2 - MIN_BPT,
             "Wrong share of waUSDC buffer belonging to LP"
         );
@@ -223,13 +223,13 @@ contract QueryERC4626BufferTest is BaseVaultTest {
     function _initializeBuffers() private {
         // Create and fund buffer pools
         vm.startPrank(lp);
-        dai.mint(address(lp), bufferAmount);
+        dai.mint(lp, bufferAmount);
         dai.approve(address(waDAI), bufferAmount);
-        waDAI.deposit(bufferAmount, address(lp));
+        waDAI.deposit(bufferAmount, lp);
 
-        usdc.mint(address(lp), bufferAmount);
+        usdc.mint(lp, bufferAmount);
         usdc.approve(address(waUSDC), bufferAmount);
-        waUSDC.deposit(bufferAmount, address(lp));
+        waUSDC.deposit(bufferAmount, lp);
         vm.stopPrank();
 
         vm.startPrank(lp);
@@ -240,8 +240,8 @@ contract QueryERC4626BufferTest is BaseVaultTest {
         permit2.approve(address(waUSDC), address(router), type(uint160).max, type(uint48).max);
         permit2.approve(address(waUSDC), address(batchRouter), type(uint160).max, type(uint48).max);
 
-        router.addLiquidityToBuffer(waDAI, bufferAmount, bufferAmount, address(lp));
-        router.addLiquidityToBuffer(waUSDC, bufferAmount, bufferAmount, address(lp));
+        router.addLiquidityToBuffer(waDAI, bufferAmount, bufferAmount, lp);
+        router.addLiquidityToBuffer(waUSDC, bufferAmount, bufferAmount, lp);
         vm.stopPrank();
     }
 
@@ -269,19 +269,19 @@ contract QueryERC4626BufferTest is BaseVaultTest {
         permit2.approve(address(waUSDC), address(router), type(uint160).max, type(uint48).max);
         permit2.approve(address(waUSDC), address(batchRouter), type(uint160).max, type(uint48).max);
 
-        dai.mint(address(bob), boostedPoolAmount);
+        dai.mint(bob, boostedPoolAmount);
         dai.approve(address(waDAI), boostedPoolAmount);
-        waDAI.deposit(boostedPoolAmount, address(bob));
+        waDAI.deposit(boostedPoolAmount, bob);
 
-        usdc.mint(address(bob), boostedPoolAmount);
+        usdc.mint(bob, boostedPoolAmount);
         usdc.approve(address(waUSDC), boostedPoolAmount);
-        waUSDC.deposit(boostedPoolAmount, address(bob));
+        waUSDC.deposit(boostedPoolAmount, bob);
 
         _initPool(boostedPool, [boostedPoolAmount, boostedPoolAmount].toMemoryArray(), boostedPoolAmount * 2 - MIN_BPT);
         vm.stopPrank();
     }
 
     function _initializeUser() private {
-        dai.mint(address(alice), boostedPoolAmount);
+        dai.mint(alice, boostedPoolAmount);
     }
 }

--- a/pkg/vault/test/foundry/Router.t.sol
+++ b/pkg/vault/test/foundry/Router.t.sol
@@ -205,7 +205,7 @@ contract RouterTest is BaseVaultTest {
         );
 
         // weth was deposited, pool tokens were minted to Alice.
-        assertEq(address(alice).balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
+        assertEq(alice.balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
         assertEq(wethPoolNoInit.balanceOf(alice), bptAmountOut, "Wrong WETH pool balance");
         assertGt(bptAmountOut, 0, "bptAmountOut is zero");
     }
@@ -225,7 +225,7 @@ contract RouterTest is BaseVaultTest {
         );
 
         // weth was deposited, excess ETH was returned, pool tokens were minted to Alice.
-        assertEq(address(alice).balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
+        assertEq(alice.balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
         assertEq(wethPoolNoInit.balanceOf(alice), bptAmountOut, "Wrong WETH pool balance");
         assertGt(bptAmountOut, 0, "bptAmountOut is zero");
     }
@@ -272,7 +272,7 @@ contract RouterTest is BaseVaultTest {
         );
 
         // weth was deposited, pool tokens were minted to Alice.
-        assertEq(address(alice).balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
+        assertEq(alice.balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
         assertEq(wethPool.balanceOf(alice), bptAmountOut, "Wrong WETH pool balance");
     }
 
@@ -289,7 +289,7 @@ contract RouterTest is BaseVaultTest {
         );
 
         // weth was deposited, excess was returned, pool tokens were minted to Alice.
-        assertEq(address(alice).balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
+        assertEq(alice.balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
         assertEq(wethPool.balanceOf(alice), bptAmountOut, "Wrong WETH pool balance");
     }
 
@@ -315,7 +315,7 @@ contract RouterTest is BaseVaultTest {
         // Liquidity position was removed, Alice gets weth back
         assertEq(weth.balanceOf(alice), defaultBalance + ethAmountIn, "Wrong WETH balance");
         assertEq(wethPool.balanceOf(alice), 0, "WETH pool balance is > 0");
-        assertEq(address(alice).balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
+        assertEq(alice.balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
     }
 
     function testRemoveLiquidityNative() public {
@@ -331,7 +331,7 @@ contract RouterTest is BaseVaultTest {
             bytes("")
         );
 
-        uint256 aliceNativeBalanceBefore = address(alice).balance;
+        uint256 aliceNativeBalanceBefore = alice.balance;
         checkRemoveLiquidityPreConditions();
 
         router.removeLiquidityCustom(
@@ -345,7 +345,7 @@ contract RouterTest is BaseVaultTest {
         // Liquidity position was removed, Alice gets ETH back
         assertEq(weth.balanceOf(alice), defaultBalance, "Wrong WETH balance");
         assertEq(wethPool.balanceOf(alice), 0, "WETH pool balance is > 0");
-        assertEq(address(alice).balance, aliceNativeBalanceBefore + ethAmountIn, "Wrong ETH balance");
+        assertEq(alice.balance, aliceNativeBalanceBefore + ethAmountIn, "Wrong ETH balance");
     }
 
     function testSwapExactInWETH() public {

--- a/pkg/vault/test/foundry/SwapWithNonExistentBuffer.t.sol
+++ b/pkg/vault/test/foundry/SwapWithNonExistentBuffer.t.sol
@@ -80,13 +80,13 @@ contract SwapWithNonExistentBufferTest is BaseVaultTest {
         permit2.approve(address(waUSDC), address(router), type(uint160).max, type(uint48).max);
         permit2.approve(address(waUSDC), address(batchRouter), type(uint160).max, type(uint48).max);
 
-        dai.mint(address(bob), boostedPoolAmount);
+        dai.mint(bob, boostedPoolAmount);
         dai.approve(address(waDAI), boostedPoolAmount);
-        waDAI.deposit(boostedPoolAmount, address(bob));
+        waDAI.deposit(boostedPoolAmount, bob);
 
-        usdc.mint(address(bob), boostedPoolAmount);
+        usdc.mint(bob, boostedPoolAmount);
         usdc.approve(address(waUSDC), boostedPoolAmount);
-        waUSDC.deposit(boostedPoolAmount, address(bob));
+        waUSDC.deposit(boostedPoolAmount, bob);
 
         _initPool(boostedPool, [boostedPoolAmount, boostedPoolAmount].toMemoryArray(), boostedPoolAmount * 2 - MIN_BPT);
         vm.stopPrank();

--- a/pkg/vault/test/foundry/VaultSwap.t.sol
+++ b/pkg/vault/test/foundry/VaultSwap.t.sol
@@ -383,7 +383,7 @@ contract VaultSwapTest is BaseVaultTest {
             admin
         );
         vm.prank(admin);
-        feeController.withdrawProtocolFees(pool, address(admin));
+        feeController.withdrawProtocolFees(pool, admin);
 
         // protocol fees are zero
         assertEq(0, feeAmounts[usdcIdx], "Protocol fees are not zero");

--- a/pkg/vault/test/foundry/VaultTokens.t.sol
+++ b/pkg/vault/test/foundry/VaultTokens.t.sol
@@ -103,17 +103,17 @@ contract VaultTokenTest is BaseVaultTest {
         // Establish assets and supply so that buffer creation doesn't fail
         vm.startPrank(alice);
 
-        dai.mint(address(alice), 2 * defaultAmount);
+        dai.mint(alice, 2 * defaultAmount);
 
         dai.approve(address(waDAI), defaultAmount);
-        waDAI.deposit(defaultAmount, address(alice));
+        waDAI.deposit(defaultAmount, alice);
 
         dai.approve(address(cDAI), defaultAmount);
-        cDAI.deposit(defaultAmount, address(alice));
+        cDAI.deposit(defaultAmount, alice);
 
-        usdc.mint(address(alice), defaultAmount);
+        usdc.mint(alice, defaultAmount);
         usdc.approve(address(waUSDC), defaultAmount);
-        waUSDC.deposit(defaultAmount, address(alice));
+        waUSDC.deposit(defaultAmount, alice);
         vm.stopPrank();
     }
 

--- a/pkg/vault/test/foundry/fork/BoostedPoolWithEmptyBuffer.t.sol
+++ b/pkg/vault/test/foundry/fork/BoostedPoolWithEmptyBuffer.t.sol
@@ -275,8 +275,8 @@ contract BoostedPoolWithEmptyBufferTest is BaseVaultTest {
 
     function _createSwapResultLocals(SwapKind kind) private view returns (SwapResultLocals memory vars) {
         vars.kind = kind;
-        vars.aliceBalanceBeforeSwapDai = daiMainnet.balanceOf(address(alice));
-        vars.aliceBalanceBeforeSwapUsdc = usdcMainnet.balanceOf(address(alice));
+        vars.aliceBalanceBeforeSwapDai = daiMainnet.balanceOf(alice);
+        vars.aliceBalanceBeforeSwapUsdc = usdcMainnet.balanceOf(alice);
 
         uint256 underlyingBalance;
         uint256 wrappedBalance;
@@ -389,7 +389,7 @@ contract BoostedPoolWithEmptyBufferTest is BaseVaultTest {
     }
 
     function _transferTokensFromDonorToUsers() private {
-        address[] memory usersToTransfer = [address(lp), address(bob), address(alice)].toMemoryArray();
+        address[] memory usersToTransfer = [lp, bob, alice].toMemoryArray();
 
         for (uint256 i = 0; i < usersToTransfer.length; ++i) {
             address userAddress = usersToTransfer[i];

--- a/pkg/vault/test/foundry/fork/BoostedPoolWithInitializedBuffer.t.sol
+++ b/pkg/vault/test/foundry/fork/BoostedPoolWithInitializedBuffer.t.sol
@@ -141,13 +141,13 @@ contract BoostedPoolWithInitializedBufferTest is BaseVaultTest {
 
         // LP should have correct amount of shares from buffer (invested amount in underlying minus burned ""BPTs)
         assertApproxEqAbs(
-            vault.getBufferOwnerShares(IERC20(waDAI), address(lp)),
+            vault.getBufferOwnerShares(IERC20(waDAI), lp),
             bufferAmount * 2 - MIN_BPT,
             1,
             "Wrong share of waDAI buffer belonging to LP"
         );
         assertApproxEqAbs(
-            vault.getBufferOwnerShares(IERC20(waUSDC), address(lp)),
+            vault.getBufferOwnerShares(IERC20(waUSDC), lp),
             (bufferAmount * 2) / USDC_FACTOR - MIN_BPT,
             1,
             "Wrong share of waUSDC buffer belonging to LP"
@@ -364,8 +364,8 @@ contract BoostedPoolWithInitializedBufferTest is BaseVaultTest {
 
     function _createSwapResultLocals(SwapKind kind) private view returns (SwapResultLocals memory vars) {
         vars.kind = kind;
-        vars.aliceBalanceBeforeSwapDai = daiMainnet.balanceOf(address(alice));
-        vars.aliceBalanceBeforeSwapUsdc = usdcMainnet.balanceOf(address(alice));
+        vars.aliceBalanceBeforeSwapDai = daiMainnet.balanceOf(alice);
+        vars.aliceBalanceBeforeSwapUsdc = usdcMainnet.balanceOf(alice);
 
         uint256 underlyingBalance;
         uint256 wrappedBalance;
@@ -498,7 +498,7 @@ contract BoostedPoolWithInitializedBufferTest is BaseVaultTest {
     }
 
     function _transferTokensFromDonorToUsers() private {
-        address[] memory usersToTransfer = [address(lp), address(bob), address(alice)].toMemoryArray();
+        address[] memory usersToTransfer = [lp, bob, alice].toMemoryArray();
 
         for (uint256 i = 0; i < usersToTransfer.length; ++i) {
             address userAddress = usersToTransfer[i];
@@ -537,8 +537,8 @@ contract BoostedPoolWithInitializedBufferTest is BaseVaultTest {
         uint256 wrappedBufferAmountUSDC = waUSDC.convertToShares(bufferAmount / USDC_FACTOR);
 
         vm.startPrank(lp);
-        router.addLiquidityToBuffer(waDAI, bufferAmount, wrappedBufferAmountDai, address(lp));
-        router.addLiquidityToBuffer(waUSDC, bufferAmount / USDC_FACTOR, wrappedBufferAmountUSDC, address(lp));
+        router.addLiquidityToBuffer(waDAI, bufferAmount, wrappedBufferAmountDai, lp);
+        router.addLiquidityToBuffer(waUSDC, bufferAmount / USDC_FACTOR, wrappedBufferAmountUSDC, lp);
         vm.stopPrank();
     }
 }

--- a/pkg/vault/test/foundry/mutation/vault/VaultAdmin.t.sol
+++ b/pkg/vault/test/foundry/mutation/vault/VaultAdmin.t.sol
@@ -184,7 +184,7 @@ contract VaultAdminMutationTest is BaseVaultTest {
     function testSetProtocolFeeControllerSuccessfully() public {
         IProtocolFeeController newProtocolFeeController = IProtocolFeeController(address(0x123));
 
-        authorizer.grantRole(vault.getActionId(IVaultAdmin.setProtocolFeeController.selector), address(admin));
+        authorizer.grantRole(vault.getActionId(IVaultAdmin.setProtocolFeeController.selector), admin);
         vm.prank(admin);
         vault.setProtocolFeeController(newProtocolFeeController);
 
@@ -328,7 +328,7 @@ contract VaultAdminMutationTest is BaseVaultTest {
     function testSetAuthorizer() public {
         IAuthorizer newAuthorizer = IAuthorizer(address(0x123));
 
-        authorizer.grantRole(vault.getActionId(IVaultAdmin.setAuthorizer.selector), address(admin));
+        authorizer.grantRole(vault.getActionId(IVaultAdmin.setAuthorizer.selector), admin);
         vm.prank(admin);
         vault.setAuthorizer(newAuthorizer);
 

--- a/pkg/vault/test/foundry/unit/VaultAdminUnit.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultAdminUnit.t.sol
@@ -117,20 +117,20 @@ contract VaultAdminUnitTest is BaseVaultTest {
 
     function testAddLiquidityToBufferBaseTokenChanged() public {
         vm.startPrank(bob);
-        router.addLiquidityToBuffer(waDAI, liquidityAmount, liquidityAmount, address(bob));
+        router.addLiquidityToBuffer(waDAI, liquidityAmount, liquidityAmount, bob);
 
         // Changes the wrapped token asset. The function `addLiquidityToBuffer` should revert, since the buffer was
         // initialized already with another underlying asset.
         waDAI.setAsset(usdc);
 
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.WrongWrappedTokenAsset.selector, address(waDAI)));
-        router.addLiquidityToBuffer(waDAI, liquidityAmount, liquidityAmount, address(bob));
+        router.addLiquidityToBuffer(waDAI, liquidityAmount, liquidityAmount, bob);
         vm.stopPrank();
     }
 
     function testRemoveLiquidityFromBufferNotEnoughShares() public {
         vm.startPrank(bob);
-        uint256 shares = router.addLiquidityToBuffer(waDAI, liquidityAmount, liquidityAmount, address(bob));
+        uint256 shares = router.addLiquidityToBuffer(waDAI, liquidityAmount, liquidityAmount, bob);
 
         authorizer.grantRole(vault.getActionId(IVaultAdmin.removeLiquidityFromBuffer.selector), address(router));
         vm.expectRevert(IVaultErrors.NotEnoughBufferShares.selector);
@@ -146,7 +146,7 @@ contract VaultAdminUnitTest is BaseVaultTest {
         permit2.approve(address(waDAI), address(router), type(uint160).max, type(uint48).max);
 
         // Deposit some DAI to mint waDAI to bob, so he can add liquidity to the buffer.
-        waDAI.deposit(underlyingTokensToDeposit, address(bob));
+        waDAI.deposit(underlyingTokensToDeposit, bob);
         vm.stopPrank();
     }
 }

--- a/pkg/vault/test/foundry/unit/VaultBufferUnit.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultBufferUnit.t.sol
@@ -133,7 +133,7 @@ contract VaultBufferUnitTest is BaseVaultTest {
         // Simulate a wrapping operation
 
         // 1) Vault deposits underlying tokens into yield bearing protocol (a.k.a. Bob)
-        vault.manualTransfer(dai, address(bob), underlyingDeposited);
+        vault.manualTransfer(dai, bob, underlyingDeposited);
 
         vm.prank(bob);
         // 2) Yield bearing protocol transfers wrapped tokens to vault (simulating an yield bearing protocol)
@@ -172,7 +172,7 @@ contract VaultBufferUnitTest is BaseVaultTest {
         // Simulate a wrapping operation
 
         // 1) Vault burns wrapped tokens (simulated by depositing to Bob, the YB Protocol)
-        vault.manualTransfer(IERC20(address(wDaiInitialized)), address(bob), wrappedBurned);
+        vault.manualTransfer(IERC20(address(wDaiInitialized)), bob, wrappedBurned);
 
         vm.prank(bob);
         // 2) Yield bearing protocol transfers underlying tokens to vault (simulating an yield bearing protocol)
@@ -217,13 +217,13 @@ contract VaultBufferUnitTest is BaseVaultTest {
         // Fund LP
         vm.startPrank(lp);
 
-        dai.mint(address(lp), 3 * _userAmount);
+        dai.mint(lp, 3 * _userAmount);
         dai.approve(address(wDaiInitialized), _userAmount);
-        wDaiInitialized.deposit(_userAmount, address(lp));
+        wDaiInitialized.deposit(_userAmount, lp);
 
-        usdc.mint(address(lp), 3 * _userAmount);
+        usdc.mint(lp, 3 * _userAmount);
         usdc.approve(address(wUSDCNotInitialized), _userAmount);
-        wUSDCNotInitialized.deposit(_userAmount, address(lp));
+        wUSDCNotInitialized.deposit(_userAmount, lp);
 
         wDaiInitialized.approve(address(permit2), MAX_UINT256);
         permit2.approve(address(wDaiInitialized), address(router), type(uint160).max, type(uint48).max);
@@ -236,13 +236,13 @@ contract VaultBufferUnitTest is BaseVaultTest {
         // Fund an Yield-Bearing Protocol, in this case represented by Bob
         vm.startPrank(bob);
 
-        dai.mint(address(bob), 3 * _userAmount);
+        dai.mint(bob, 3 * _userAmount);
         dai.approve(address(wDaiInitialized), _userAmount);
-        wDaiInitialized.deposit(_userAmount, address(bob));
+        wDaiInitialized.deposit(_userAmount, bob);
 
-        usdc.mint(address(bob), 3 * _userAmount);
+        usdc.mint(bob, 3 * _userAmount);
         usdc.approve(address(wUSDCNotInitialized), _userAmount);
-        wUSDCNotInitialized.deposit(_userAmount, address(bob));
+        wUSDCNotInitialized.deposit(_userAmount, bob);
 
         wDaiInitialized.approve(address(permit2), MAX_UINT256);
         permit2.approve(address(wDaiInitialized), address(router), type(uint160).max, type(uint48).max);
@@ -255,7 +255,7 @@ contract VaultBufferUnitTest is BaseVaultTest {
 
     function _initializeBuffer() private {
         vm.prank(lp);
-        router.addLiquidityToBuffer(IERC4626(address(wDaiInitialized)), _wrapAmount, _wrapAmount, address(lp));
+        router.addLiquidityToBuffer(IERC4626(address(wDaiInitialized)), _wrapAmount, _wrapAmount, lp);
     }
 
     function _exactInWrapUnwrapPath(

--- a/pkg/vault/test/foundry/utils/BaseVaultTest.sol
+++ b/pkg/vault/test/foundry/utils/BaseVaultTest.sol
@@ -186,12 +186,7 @@ abstract contract BaseVaultTest is VaultStorage, BaseTest, Permit2Helpers {
         address newPool = factoryMock.createPool("ERC20 Pool", "ERC20POOL");
         vm.label(newPool, label);
 
-        factoryMock.registerTestPool(
-            newPool,
-            vault.buildTokenConfig(tokens.asIERC20()),
-            poolHooksContract,
-            address(lp)
-        );
+        factoryMock.registerTestPool(newPool, vault.buildTokenConfig(tokens.asIERC20()), poolHooksContract, lp);
 
         return newPool;
     }


### PR DESCRIPTION
# Description

Alice, Bob, LP, and Admin are addresses already, but tests don't treat them like this. Remove the unnecessary address() to clear the test code a bit.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge
