### PR TITLE
Add DELTA and error messages to WeightedMathTest

### DIFF
--- a/pkg/solidity-utils/test/foundry/WeightedMathRounding.t.sol
+++ b/pkg/solidity-utils/test/foundry/WeightedMathRounding.t.sol
@@ -7,7 +7,7 @@ import "forge-std/Test.sol";
 import "../../contracts/math/FixedPoint.sol";
 import "../../contracts/test/WeightedMathMock.sol";
 
-contract WeightedMathTest is Test {
+contract WeightedMathRoundingTest is Test {
     uint256 constant MIN_WEIGHT = 0.1e18;
     uint256 constant MAX_WEIGHT = 0.9e18;
     uint256 constant MIN_BALANCE = 1e18;


### PR DESCRIPTION
# Description

This PR fixes a test that was skipped, adds error messages, and renames the test file because these tests don't test WeightedMath, they only test rounding.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [X] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #524

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
