### PR TITLE
Factor out staticcall prank in query tests

### DIFF
--- a/pkg/vault/test/foundry/QueryERC4626Buffer.t.sol
+++ b/pkg/vault/test/foundry/QueryERC4626Buffer.t.sol
@@ -122,8 +122,7 @@ contract QueryERC4626BufferTest is BaseVaultTest {
         // Snapshots the current state of the network
         uint256 snapshotId = vm.snapshot();
 
-        // Prank address 0x0 for both msg.sender and tx.origin (to identify as a staticcall)
-        vm.prank(address(0), address(0));
+        _prankStaticCall();
         // Not using staticCall because it does not allow changes in the transient storage, and reverts with
         // a StateChangeDuringStaticCall error
         (
@@ -152,8 +151,7 @@ contract QueryERC4626BufferTest is BaseVaultTest {
         // Snapshots the current state of the network
         uint256 snapshotId = vm.snapshot();
 
-        // Prank address 0x0 for both msg.sender and tx.origin (to identify as a staticcall)
-        vm.prank(address(0), address(0));
+        _prankStaticCall();
         // Not using staticCall because it does not allow changes in the transient storage, and reverts with
         // a StateChangeDuringStaticCall error
         (

--- a/pkg/vault/test/foundry/Router.t.sol
+++ b/pkg/vault/test/foundry/Router.t.sol
@@ -135,7 +135,7 @@ contract RouterTest is BaseVaultTest {
 
         vm.expectRevert(IVaultErrors.QueriesDisabled.selector);
 
-        vm.prank(address(0), address(0));
+        _prankStaticCall();
         router.querySwapSingleTokenExactIn(pool, usdc, dai, usdcAmountIn, bytes(""));
     }
 

--- a/pkg/vault/test/foundry/mutation/vault/VaultExtension.t.sol
+++ b/pkg/vault/test/foundry/mutation/vault/VaultExtension.t.sol
@@ -196,13 +196,13 @@ contract VaultExtensionMutationTest is BaseVaultTest {
     }
 
     function testCalculateBufferAmountsWhenNotVault() public {
-        vm.prank(address(0), address(0));
+        _prankStaticCall();
         vm.expectRevert(IVaultErrors.NotVaultDelegateCall.selector);
         vaultExtension.calculateBufferAmounts(WrappingDirection.WRAP, SwapKind.EXACT_IN, IERC4626(address(0)), 0);
     }
 
     function testQuoteWhenNotVault() public {
-        vm.prank(address(0), address(0));
+        _prankStaticCall();
         vm.expectRevert(IVaultErrors.NotVaultDelegateCall.selector);
         vaultExtension.quote(bytes(""));
     }
@@ -214,7 +214,7 @@ contract VaultExtensionMutationTest is BaseVaultTest {
 
     function testQuoteAndRevertWhenNotVault() public {
         vm.expectRevert(IVaultErrors.NotVaultDelegateCall.selector);
-        vm.prank(address(0), address(0));
+        _prankStaticCall();
         vaultExtension.quoteAndRevert(bytes(""));
     }
 

--- a/pkg/vault/test/foundry/utils/BaseVaultTest.sol
+++ b/pkg/vault/test/foundry/utils/BaseVaultTest.sol
@@ -264,4 +264,10 @@ abstract contract BaseVaultTest is VaultStorage, BaseTest, Permit2Helpers {
             ((protocolFeePercentage + protocolFeePercentage.complement().mulDown(creatorFeePercentage)) /
                 FEE_SCALING_FACTOR) * FEE_SCALING_FACTOR;
     }
+
+    function _prankStaticCall() internal {
+        // Prank address 0x0 for both msg.sender and tx.origin (to identify as a staticcall)
+        vm.prank(address(0), address(0));
+    }
+
 }

--- a/pkg/vault/test/foundry/utils/BaseVaultTest.sol
+++ b/pkg/vault/test/foundry/utils/BaseVaultTest.sol
@@ -269,5 +269,4 @@ abstract contract BaseVaultTest is VaultStorage, BaseTest, Permit2Helpers {
         // Prank address 0x0 for both msg.sender and tx.origin (to identify as a staticcall)
         vm.prank(address(0), address(0));
     }
-
 }


### PR DESCRIPTION
# Description

It took us a second to successfully prank static calls (you have to set the `tx.origin` to 0 as well, which is the seldom-used second argument to prank), and we weren't commenting that consistently.

This PR factors out that prank call (and comment) to an internal function of `BaseVaultTest`, so that we can just say `_prankStaticCall();` everywhere.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
