### PR TITLE
Vault Explorer (V2 - read-only)

### DIFF
--- a/pkg/interfaces/contracts/vault/IVaultExplorer.sol
+++ b/pkg/interfaces/contracts/vault/IVaultExplorer.sol
@@ -364,17 +364,6 @@ interface IVaultExplorer {
     function getVaultPausedState() external view returns (bool, uint32, uint32);
 
     /*******************************************************************************
-                                   Fees
-    *******************************************************************************/
-
-    /**
-     * @notice Collects accumulated aggregate swap and yield fees for the specified pool.
-     * @dev Fees are sent to the ProtocolFeeController address.
-     * @param pool The pool on which all aggregate fees should be collected
-     */
-    function collectAggregateFees(address pool) external;
-
-    /*******************************************************************************
                                 Wrapped Token Buffers
     *******************************************************************************/
 

--- a/pkg/interfaces/contracts/vault/IVaultExplorer.sol
+++ b/pkg/interfaces/contracts/vault/IVaultExplorer.sol
@@ -4,10 +4,8 @@ pragma solidity ^0.8.24;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {
-    TokenConfig,
     TokenInfo,
     PoolRoleAccounts,
-    LiquidityManagement,
     PoolData,
     PoolConfig,
     HooksConfig

--- a/pkg/interfaces/contracts/vault/IVaultExplorer.sol
+++ b/pkg/interfaces/contracts/vault/IVaultExplorer.sol
@@ -3,13 +3,7 @@
 pragma solidity ^0.8.24;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {
-    TokenInfo,
-    PoolRoleAccounts,
-    PoolData,
-    PoolConfig,
-    HooksConfig
-} from "./VaultTypes.sol";
+import { TokenInfo, PoolRoleAccounts, PoolData, PoolConfig, HooksConfig } from "./VaultTypes.sol";
 
 import { IBasePool } from "./IBasePool.sol";
 

--- a/pkg/interfaces/contracts/vault/IVaultExplorer.sol
+++ b/pkg/interfaces/contracts/vault/IVaultExplorer.sol
@@ -88,40 +88,6 @@ interface IVaultExplorer {
     *******************************************************************************/
 
     /**
-     * @notice Registers a pool, associating it with its factory and the tokens it manages.
-     * @dev A pool can opt-out of pausing by providing a zero value for the pause window, or allow pausing indefinitely
-     * by providing a large value. (Pool pause windows are not limited by the Vault maximums.) The vault defines an
-     * additional buffer period during which a paused pool will stay paused. After the buffer period passes, a paused
-     * pool will automatically unpause.
-     *
-     * A pool can opt out of Balancer governance pausing by providing a custom `pauseManager`. This might be a
-     * multi-sig contract or an arbitrary smart contract with its own access controls, that forwards calls to
-     * the Vault.
-     *
-     * If the zero address is provided for the `pauseManager`, permissions for pausing the pool will default to the
-     * authorizer.
-     *
-     * @param pool The address of the pool being registered
-     * @param tokenConfig An array of descriptors for the tokens the pool will manage
-     * @param swapFeePercentage The initial static swap fee percentage of the pool
-     * @param pauseWindowEndTime The timestamp after which it is no longer possible to pause the pool
-     * @param protocolFeeExempt If true, the pool's initial aggregate fees will be set to 0
-     * @param roleAccounts Addresses the Vault will allow to change certain pool settings
-     * @param poolHooksContract Contract that implements the hooks for the pool
-     * @param liquidityManagement Liquidity management flags with implemented methods
-     */
-    function registerPool(
-        address pool,
-        TokenConfig[] memory tokenConfig,
-        uint256 swapFeePercentage,
-        uint32 pauseWindowEndTime,
-        bool protocolFeeExempt,
-        PoolRoleAccounts calldata roleAccounts,
-        address poolHooksContract,
-        LiquidityManagement calldata liquidityManagement
-    ) external;
-
-    /**
      * @notice Checks whether a pool is registered.
      * @param pool Address of the pool to check
      * @return True if the pool is registered, false otherwise

--- a/pkg/vault/contracts/VaultExplorer.sol
+++ b/pkg/vault/contracts/VaultExplorer.sol
@@ -10,10 +10,8 @@ import { IAuthorizer } from "@balancer-labs/v3-interfaces/contracts/vault/IAutho
 import { IVaultExtension } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultExtension.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import {
-    TokenConfig,
     TokenInfo,
     PoolRoleAccounts,
-    LiquidityManagement,
     PoolConfig,
     HooksConfig,
     PoolData

--- a/pkg/vault/contracts/VaultExplorer.sol
+++ b/pkg/vault/contracts/VaultExplorer.sol
@@ -280,15 +280,6 @@ contract VaultExplorer is IVaultExplorer {
     }
 
     /*******************************************************************************
-                                        Fees
-    *******************************************************************************/
-
-    /// @inheritdoc IVaultExplorer
-    function collectAggregateFees(address pool) external {
-        return _vault.collectAggregateFees(pool);
-    }
-
-    /*******************************************************************************
                                 Wrapped Token Buffers
     *******************************************************************************/
 

--- a/pkg/vault/contracts/VaultExplorer.sol
+++ b/pkg/vault/contracts/VaultExplorer.sol
@@ -84,30 +84,6 @@ contract VaultExplorer is IVaultExplorer {
     *******************************************************************************/
 
     /// @inheritdoc IVaultExplorer
-    function registerPool(
-        address pool,
-        TokenConfig[] memory tokenConfig,
-        uint256 swapFeePercentage,
-        uint32 pauseWindowEndTime,
-        bool protocolFeeExempt,
-        PoolRoleAccounts calldata roleAccounts,
-        address poolHooksContract,
-        LiquidityManagement calldata liquidityManagement
-    ) external {
-        return
-            _vault.registerPool(
-                pool,
-                tokenConfig,
-                swapFeePercentage,
-                pauseWindowEndTime,
-                protocolFeeExempt,
-                roleAccounts,
-                poolHooksContract,
-                liquidityManagement
-            );
-    }
-
-    /// @inheritdoc IVaultExplorer
     function isPoolRegistered(address pool) external view returns (bool) {
         return _vault.isPoolRegistered(pool);
     }

--- a/pkg/vault/test/foundry/VaultExplorer.t.sol
+++ b/pkg/vault/test/foundry/VaultExplorer.t.sol
@@ -642,7 +642,7 @@ contract VaultExplorerTest is BaseVaultTest {
         TokenConfig[] memory tokenConfig = vault.buildTokenConfig(tokens);
         LiquidityManagement memory liquidityManagement;
 
-        explorer.registerPool(newPool, tokenConfig, 0, 0, false, roleAccounts, address(0), liquidityManagement);
+        vault.registerPool(newPool, tokenConfig, 0, 0, false, roleAccounts, address(0), liquidityManagement);
 
         if (initializeNewPool) {
             vm.prank(alice);

--- a/pkg/vault/test/foundry/VaultExplorer.t.sol
+++ b/pkg/vault/test/foundry/VaultExplorer.t.sol
@@ -160,21 +160,6 @@ contract VaultExplorerTest is BaseVaultTest {
         assertEq(explorer.getReservesOf(dai), defaultAmount, "Wrong Explorer reserves");
     }
 
-    function testPoolRegistration() public {
-        assertTrue(vault.isPoolRegistered(pool), "Default pool not registered (Vault)");
-        assertTrue(explorer.isPoolRegistered(pool), "Default pool not registered (Explorer)");
-
-        address newPool = address(new PoolMock(IVault(address(vault)), "ERC20 Pool", "ERC20POOL"));
-
-        assertFalse(vault.isPoolRegistered(newPool), "New pool magically registered (Vault)");
-        assertFalse(explorer.isPoolRegistered(newPool), "New pool magically registered (Explorer)");
-
-        _registerPool(newPool, false);
-
-        assertTrue(vault.isPoolRegistered(newPool), "New pool not registered (Vault)");
-        assertTrue(explorer.isPoolRegistered(newPool), "New pool not registered (Explorer)");
-    }
-
     function testPoolInitialization() public {
         assertTrue(vault.isPoolInitialized(pool), "Default pool not initialized (Vault)");
         assertTrue(explorer.isPoolInitialized(pool), "Default pool not initialized (Explorer)");


### PR DESCRIPTION
# Description

Based on #760, this removes the two "write" operations that are externally available: `registerPool` and `collectAggregateFees`. To be merged if we want the Vault Explorer to be read-only.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
