### PR TITLE
Factory arguments in benchmarks

### DIFF
--- a/pvt/benchmarks/test/foundry/WeightedPoolSwaps.t.sol
+++ b/pvt/benchmarks/test/foundry/WeightedPoolSwaps.t.sol
@@ -71,6 +71,7 @@ contract WeightedPoolSwaps is BaseVaultTest {
                 swapFee,
                 address(0),
                 false,
+                false,
                 bytes32(0)
             )
         );
@@ -84,6 +85,7 @@ contract WeightedPoolSwaps is BaseVaultTest {
                 poolRoleAccounts,
                 swapFee,
                 address(0),
+                false,
                 false,
                 bytes32(uint256(1))
             )

--- a/pvt/benchmarks/test/foundry/YieldFees.t.sol
+++ b/pvt/benchmarks/test/foundry/YieldFees.t.sol
@@ -80,6 +80,7 @@ contract YieldFeesTest is BaseVaultTest {
                 swapFee,
                 address(0),
                 false,
+                false,
                 bytes32(0)
             )
         );


### PR DESCRIPTION
# Description

#762 broke the benchmark tests. This just adds in the extra factory argument.

## Type of change

- [X] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
