### PR TITLE
Fix TransientEnumerableSet's remove

### DIFF
--- a/pkg/solidity-utils/contracts/openzeppelin/TransientEnumerableSet.sol
+++ b/pkg/solidity-utils/contracts/openzeppelin/TransientEnumerableSet.sol
@@ -114,7 +114,9 @@ library TransientEnumerableSet {
             // Delete the slot where the moved value was stored
             _values(set).tPop();
 
-            // We don't need to delete the index for the deleted slot with transient storage.
+            // We need to delete the index for the deleted slot with transient storage because another operation in the
+            // same transaction may want to add the same element to the array again.
+            _indexes(set).tSet(value, 0);
 
             return true;
         } else {


### PR DESCRIPTION
# Description

The remove function worked properly when a removed element was never inserted again in the same transaction. However, sometimes this is not true, like when we use batch router to wrap/unwrap a token and call batch router again to swap with a boosted pool in the same transaction. This PR fixes it. (tests in TransientEnumerableSet are required, there's a ticket for that, #784)

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

