### PR TITLE
Fix top level README setup instructions by adding `,g` to `sed` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You will also need to configure your environment variables to point to RPC endpo
 Write your preferred RPC URL to `.env`, and source it. For example:
 
 ```bash
-$ sed 's,YOUR_MAINNET_RPC_URL,<YOUR_RPC_URL>' .env.example > .env
+$ sed 's,YOUR_MAINNET_RPC_URL,<YOUR_RPC_URL>,g' .env.example > .env
 $ source .env
 ```
 


### PR DESCRIPTION
# Description
Add the `,g` to the `sed` command for adding your RPC URL to your `.env` file. Running the command as currently written results in the following error:
`sed: 1: "s,YOUR_MAINNET_RPC_URL, ...": unterminated substitute in regular expression`

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [x] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
