### PR TITLE
Simplify WeightedPool initialization

### DIFF
--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -67,14 +67,12 @@ contract WeightedPool is IWeightedPool, BalancerPoolToken, PoolInfo, Version {
         NewPoolParams memory params,
         IVault vault
     ) BalancerPoolToken(vault, params.name, params.symbol) PoolInfo(vault) Version(params.version) {
-        uint256 numTokens = params.numTokens;
-        InputHelpers.ensureInputLengthMatch(numTokens, params.normalizedWeights.length);
-
-        _totalTokens = numTokens;
+        _totalTokens = params.numTokens;
+        InputHelpers.ensureInputLengthMatch(_totalTokens, params.normalizedWeights.length);
 
         // Ensure each normalized weight is above the minimum
         uint256 normalizedSum = 0;
-        for (uint8 i = 0; i < numTokens; ++i) {
+        for (uint8 i = 0; i < _totalTokens; ++i) {
             uint256 normalizedWeight = params.normalizedWeights[i];
 
             if (normalizedWeight < WeightedMath._MIN_WEIGHT) {

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -81,21 +81,22 @@ contract WeightedPool is IWeightedPool, BalancerPoolToken, PoolInfo, Version {
                 revert MinWeight();
             }
             normalizedSum = normalizedSum + normalizedWeight;
+
+            // prettier-ignore
+            if (i == 0) { _normalizedWeight0 = normalizedWeight; }
+            else if (i == 1) { _normalizedWeight1 = normalizedWeight; }
+            else if (i == 2) { _normalizedWeight2 = normalizedWeight; }
+            else if (i == 3) { _normalizedWeight3 = normalizedWeight; }
+            else if (i == 4) { _normalizedWeight4 = normalizedWeight; }
+            else if (i == 5) { _normalizedWeight5 = normalizedWeight; }
+            else if (i == 6) { _normalizedWeight6 = normalizedWeight; }
+            else if (i == 7) { _normalizedWeight7 = normalizedWeight; }
         }
+
         // Ensure that the normalized weights sum to ONE
         if (normalizedSum != FixedPoint.ONE) {
             revert NormalizedWeightInvariant();
         }
-
-        // Immutable variables cannot be initialized inside an if statement, so we must do conditional assignments
-        _normalizedWeight0 = params.normalizedWeights[0];
-        _normalizedWeight1 = params.normalizedWeights[1];
-        _normalizedWeight2 = numTokens > 2 ? params.normalizedWeights[2] : 0;
-        _normalizedWeight3 = numTokens > 3 ? params.normalizedWeights[3] : 0;
-        _normalizedWeight4 = numTokens > 4 ? params.normalizedWeights[4] : 0;
-        _normalizedWeight5 = numTokens > 5 ? params.normalizedWeights[5] : 0;
-        _normalizedWeight6 = numTokens > 6 ? params.normalizedWeights[6] : 0;
-        _normalizedWeight7 = numTokens > 7 ? params.normalizedWeights[7] : 0;
     }
 
     /// @inheritdoc IBasePool


### PR DESCRIPTION
# Description

Found a lot of stuff looking at generalizing Weighted Pool tests.

One is an out-dated comment saying you can't access immutables in constructors or if statements. Was true when originally written in v2 - but you can do it with modern Solidity.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
