### PR TITLE
Missing token indices

### DIFF
--- a/pkg/pool-hooks/test/foundry/FeeTakingHookExample.t.sol
+++ b/pkg/pool-hooks/test/foundry/FeeTakingHookExample.t.sol
@@ -222,7 +222,7 @@ contract FeeTakingHookExampleTest is BaseVaultTest {
             BalancerPoolToken(pool).totalSupply(),
             expectedBptOut
         );
-        uint256 actualAmountIn = actualAmountsIn[0];
+        uint256 actualAmountIn = actualAmountsIn[daiIdx]; // Proportional, so doesn't matter which token
         uint256 hookFee = actualAmountIn.mulDown(hookFeePercentage);
 
         uint256[] memory expectedBalances = [poolInitAmount + actualAmountIn, poolInitAmount + actualAmountIn]
@@ -278,7 +278,7 @@ contract FeeTakingHookExampleTest is BaseVaultTest {
             BalancerPoolToken(pool).totalSupply(),
             expectedBptIn
         );
-        uint256 actualAmountOut = actualAmountsOut[0];
+        uint256 actualAmountOut = actualAmountsOut[usdcIdx];
         uint256 hookFee = actualAmountOut.mulDown(hookFeePercentage);
 
         uint256[] memory expectedBalances = [2 * poolInitAmount - actualAmountOut, 2 * poolInitAmount - actualAmountOut]

--- a/pkg/pool-weighted/test/foundry/WeightedPool.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedPool.t.sol
@@ -111,8 +111,8 @@ contract WeightedPoolTest is BaseVaultTest {
 
         // Tokens are deposited to the pool
         (, , uint256[] memory balances, ) = vault.getPoolTokenInfo(address(pool));
-        assertEq(balances[0], DAI_AMOUNT, "Pool: Wrong DAI balance");
-        assertEq(balances[1], USDC_AMOUNT, "Pool: Wrong USDC balance");
+        assertEq(balances[daiIdx], DAI_AMOUNT, "Pool: Wrong DAI balance");
+        assertEq(balances[usdcIdx], USDC_AMOUNT, "Pool: Wrong USDC balance");
 
         // should mint correct amount of BPT tokens
         // Account for the precision loss
@@ -135,8 +135,8 @@ contract WeightedPoolTest is BaseVaultTest {
 
         // Tokens are deposited to the pool
         (, , uint256[] memory balances, ) = vault.getPoolTokenInfo(address(pool));
-        assertEq(balances[0], DAI_AMOUNT * 2, "Pool: Wrong DAI balance");
-        assertEq(balances[1], USDC_AMOUNT * 2, "Pool: Wrong USDC balance");
+        assertEq(balances[daiIdx], DAI_AMOUNT * 2, "Pool: Wrong DAI balance");
+        assertEq(balances[usdcIdx], USDC_AMOUNT * 2, "Pool: Wrong USDC balance");
 
         // should mint correct amount of BPT tokens
         assertApproxEqAbs(weightedPool.balanceOf(bob), bptAmountOut, DELTA, "LP: Wrong bptAmountOut");
@@ -178,12 +178,12 @@ contract WeightedPoolTest is BaseVaultTest {
 
         // Tokens are deposited to the pool
         (, , uint256[] memory balances, ) = vault.getPoolTokenInfo(address(pool));
-        assertApproxEqAbs(balances[0], DAI_AMOUNT, DELTA, "Pool: Wrong DAI balance");
-        assertApproxEqAbs(balances[1], USDC_AMOUNT, DELTA, "Pool: Wrong USDC balance");
+        assertApproxEqAbs(balances[daiIdx], DAI_AMOUNT, DELTA, "Pool: Wrong DAI balance");
+        assertApproxEqAbs(balances[usdcIdx], USDC_AMOUNT, DELTA, "Pool: Wrong USDC balance");
 
         // amountsOut are correct
-        assertApproxEqAbs(amountsOut[0], DAI_AMOUNT, DELTA, "Wrong DAI AmountOut");
-        assertApproxEqAbs(amountsOut[1], USDC_AMOUNT, DELTA, "Wrong USDC AmountOut");
+        assertApproxEqAbs(amountsOut[daiIdx], DAI_AMOUNT, DELTA, "Wrong DAI AmountOut");
+        assertApproxEqAbs(amountsOut[usdcIdx], USDC_AMOUNT, DELTA, "Wrong USDC AmountOut");
 
         // should mint correct amount of BPT tokens
         assertEq(weightedPool.balanceOf(bob), 0, "LP: Non-zero BPT balance");
@@ -267,8 +267,8 @@ contract WeightedPoolTest is BaseVaultTest {
     function testFailSwapFeeTooLow() public {
         TokenConfig[] memory tokens = new TokenConfig[](2);
         PoolRoleAccounts memory roleAccounts;
-        tokens[0].token = IERC20(dai);
-        tokens[1].token = IERC20(usdc);
+        tokens[daiIdx].token = IERC20(dai);
+        tokens[usdcIdx].token = IERC20(usdc);
 
         address lowFeeWeightedPool = factory.create(
             "ERC20 Pool",

--- a/pkg/pool-weighted/test/foundry/WeightedPool.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedPool.t.sol
@@ -41,8 +41,14 @@ contract WeightedPoolTest is BaseVaultTest {
     uint256[] internal weights;
     uint256 internal bptAmountOut;
 
+    uint256 daiIdx;
+    uint256 usdcIdx;
+
     function setUp() public virtual override {
         BaseVaultTest.setUp();
+
+        (daiIdx, usdcIdx) = getSortedIndexes(address(dai), address(usdc));
+
         weightedPool = WeightedPool(pool);
     }
 
@@ -215,8 +221,6 @@ contract WeightedPoolTest is BaseVaultTest {
         assertEq(dai.balanceOf(address(vault)), DAI_AMOUNT + DAI_AMOUNT_IN, "Vault: Wrong DAI balance");
 
         (, , uint256[] memory balances, ) = vault.getPoolTokenInfo(address(pool));
-
-        (uint256 daiIdx, uint256 usdcIdx) = getSortedIndexes(address(dai), address(usdc));
 
         assertEq(balances[daiIdx], DAI_AMOUNT + DAI_AMOUNT_IN, "Pool: Wrong DAI balance");
         assertEq(balances[usdcIdx], USDC_AMOUNT - amountCalculated, "Pool: Wrong USDC balance");

--- a/pkg/pool-weighted/test/foundry/WeightedPool8020Factory.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedPool8020Factory.t.sol
@@ -43,6 +43,7 @@ contract WeightedPool8020FactoryTest is Test {
         tokenConfig[0].token = highToken;
         tokenConfig[1].token = lowToken;
 
+        // The factory will sort the tokens.
         return WeightedPool(factory.create(tokenConfig[0], tokenConfig[1], roleAccounts, DEFAULT_SWAP_FEE));
     }
 

--- a/pkg/vault/test/foundry/GetBptRate.t.sol
+++ b/pkg/vault/test/foundry/GetBptRate.t.sol
@@ -29,8 +29,13 @@ contract GetBptRateTest is BaseVaultTest {
     uint256 private daiMockRate = 1.5e18;
     uint256 private usdcMockRate = 0.5e18;
 
+    uint256 daiIdx;
+    uint256 usdcIdx;
+
     function setUp() public virtual override {
         BaseVaultTest.setUp();
+
+        (daiIdx, usdcIdx) = getSortedIndexes(address(dai), address(usdc));
     }
 
     function _createPool(address[] memory tokens, string memory label) internal virtual override returns (address) {
@@ -44,6 +49,7 @@ contract GetBptRateTest is BaseVaultTest {
         RateProviderMock rateProviderUsdc = new RateProviderMock();
         rateProviderUsdc.mockRate(usdcMockRate);
 
+        // The rate providers will be sorted along with the tokens, by `buildTokenConfig`
         IRateProvider[] memory rateProviders = new IRateProvider[](2);
         rateProviders[0] = IRateProvider(rateProviderDai);
         rateProviders[1] = IRateProvider(rateProviderUsdc);
@@ -74,19 +80,25 @@ contract GetBptRateTest is BaseVaultTest {
 
     function testGetBptRateWithRateProvider() public {
         uint256 totalSupply = initBptAmountOut + MIN_BPT;
-        uint256[] memory liveBalances = [defaultAmount.mulDown(daiMockRate), defaultAmount.mulDown(usdcMockRate)]
-            .toMemoryArray();
+        uint256[] memory liveBalances = new uint256[](2);
+        liveBalances[daiIdx] = defaultAmount.mulDown(daiMockRate);
+        liveBalances[usdcIdx] = defaultAmount.mulDown(usdcMockRate);
+
         uint256 weightedInvariant = WeightedMath.computeInvariant(weights, liveBalances);
         uint256 expectedRate = weightedInvariant.divDown(totalSupply);
         uint256 actualRate = vault.getBptRate(pool);
         assertEq(actualRate, expectedRate, "Wrong rate");
 
-        uint256[] memory amountsIn = [defaultAmount, 0].toMemoryArray();
+        uint256[] memory amountsIn = new uint256[](2);
+        amountsIn[daiIdx] = defaultAmount;
+
         vm.prank(bob);
         uint256 addLiquidityBptAmountOut = router.addLiquidityUnbalanced(pool, amountsIn, 0, false, bytes(""));
 
         totalSupply += addLiquidityBptAmountOut;
-        liveBalances = [2 * defaultAmount.mulDown(daiMockRate), defaultAmount.mulDown(usdcMockRate)].toMemoryArray();
+        liveBalances[daiIdx] = 2 * defaultAmount.mulDown(daiMockRate);
+        liveBalances[usdcIdx] = defaultAmount.mulDown(usdcMockRate);
+
         weightedInvariant = WeightedMath.computeInvariant(weights, liveBalances);
 
         expectedRate = weightedInvariant.divDown(totalSupply);

--- a/pkg/vault/test/foundry/HooksAlteringRates.t.sol
+++ b/pkg/vault/test/foundry/HooksAlteringRates.t.sol
@@ -37,7 +37,7 @@ contract HooksAlteringRatesTest is BaseVaultTest {
 
     function createPool() internal virtual override returns (address) {
         IRateProvider[] memory rateProviders = new IRateProvider[](2);
-        // Rate providers will by sorted along with tokens by buildTokenConfig.
+        // Rate providers will by sorted along with tokens by `buildTokenConfig`.
         rateProvider = new RateProviderMock();
         rateProviders[0] = rateProvider;
 

--- a/pkg/vault/test/foundry/PoolData.t.sol
+++ b/pkg/vault/test/foundry/PoolData.t.sol
@@ -32,6 +32,7 @@ contract PoolDataTest is BaseVaultTest {
         wstETHRateProvider = new RateProviderMock();
         daiRateProvider = new RateProviderMock();
 
+        // Providers will be sorted along with the tokens by `buildTokenConfig`.
         rateProviders[0] = daiRateProvider;
         rateProviders[1] = wstETHRateProvider;
 


### PR DESCRIPTION
# Description

There are still some tests that work accidentally, without specifying token order. Sometimes it's ok - there are tests that set parallel token arrays for tokens and rate providers, where 0 = dai and 1 = usdc, but those arrays are then passed into functions that sort them.

There are also plenty of cases that are going to revert anyway, so using numeric indices is ok. Or both entries have the same value (or token type, etc.), so it likewise doesn't matter what order they're in. Those are fine and unchanged.

Even where it's not strictly necessary, it's good documentation to use indices. (And often it is necessary.)

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
