### PR TITLE
Aggregate fee tests

### DIFF
--- a/pkg/vault/test/foundry/Hooks.t.sol
+++ b/pkg/vault/test/foundry/Hooks.t.sol
@@ -267,7 +267,7 @@ contract HooksTest is BaseVaultTest {
         vault.manualSetHooksConfig(pool, hooksConfig);
 
         setSwapFeePercentage(swapFeePercentage);
-        vault.manualSetAggregateSwapFeePercentage(pool, _getAggregateFeePercentage(protocolSwapFeePercentage, 0));
+        vault.manualSetAggregateSwapFeePercentage(pool, protocolSwapFeePercentage);
         PoolHooksMock(poolHooksContract).setDynamicSwapFeePercentage(swapFeePercentage);
 
         uint256 expectedAmountOut = defaultAmount.mulDown(swapFeePercentage.complement());

--- a/pkg/vault/test/foundry/ProtocolFeeController.t.sol
+++ b/pkg/vault/test/foundry/ProtocolFeeController.t.sol
@@ -35,7 +35,6 @@ contract ProtocolFeeControllerTest is BaseVaultTest {
     uint256 internal constant PROTOCOL_SWAP_FEE_AMOUNT = 100e18;
     uint256 internal constant PROTOCOL_YIELD_FEE_AMOUNT = 50e18;
 
-    IProtocolFeeController feeController;
     IAuthentication feeControllerAuth;
 
     uint256 internal daiIdx;
@@ -44,7 +43,6 @@ contract ProtocolFeeControllerTest is BaseVaultTest {
     function setUp() public override {
         BaseVaultTest.setUp();
 
-        feeController = vault.getProtocolFeeController();
         feeControllerAuth = IAuthentication(address(feeController));
 
         (daiIdx, usdcIdx) = getSortedIndexes(address(dai), address(usdc));

--- a/pkg/vault/test/foundry/ProtocolFeeExemption.t.sol
+++ b/pkg/vault/test/foundry/ProtocolFeeExemption.t.sol
@@ -19,7 +19,6 @@ contract ProtocolFeeExemptionTest is BaseVaultTest {
     uint256 internal GLOBAL_SWAP_FEE = 50e16;
     uint256 internal GLOBAL_YIELD_FEE = 20e16;
 
-    IProtocolFeeController internal feeController;
     PoolRoleAccounts internal roleAccounts;
 
     uint256 daiIdx;
@@ -30,7 +29,6 @@ contract ProtocolFeeExemptionTest is BaseVaultTest {
 
         (daiIdx, usdcIdx) = getSortedIndexes(address(dai), address(usdc));
 
-        feeController = vault.getProtocolFeeController();
         IAuthentication feeControllerAuth = IAuthentication(address(feeController));
 
         // Set default protocol fees.

--- a/pkg/vault/test/foundry/VaultExplorer.t.sol
+++ b/pkg/vault/test/foundry/VaultExplorer.t.sol
@@ -62,7 +62,6 @@ contract VaultExplorerTest is BaseVaultTest {
     uint256 internal constant PROTOCOL_YIELD_FEE_AMOUNT = 50e18;
 
     VaultExplorer internal explorer;
-    IProtocolFeeController feeController;
     IAuthentication feeControllerAuth;
     ERC4626TestToken internal waDAI;
 
@@ -97,7 +96,6 @@ contract VaultExplorerTest is BaseVaultTest {
 
         _setComplexPoolData();
 
-        feeController = vault.getProtocolFeeController();
         feeControllerAuth = IAuthentication(address(feeController));
 
         waDAI = new ERC4626TestToken(dai, "Wrapped aDAI", "waDAI", 18);

--- a/pkg/vault/test/foundry/VaultLiquidityFees.t.sol
+++ b/pkg/vault/test/foundry/VaultLiquidityFees.t.sol
@@ -4,8 +4,6 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 
-import { IProtocolFeeController } from "@balancer-labs/v3-interfaces/contracts/vault/IProtocolFeeController.sol";
-
 import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/ArrayHelpers.sol";
 import { PoolConfig } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
@@ -17,16 +15,12 @@ contract VaultLiquidityWithFeesTest is BaseVaultTest {
     // `BaseVaultTest` defines the `protocolSwapFeePercentage`.
     uint64 poolCreatorFeePercentage = 50e16; // 50%
 
-    IProtocolFeeController feeController;
-
     // Track the indices for the standard dai/usdc pool.
     uint256 internal daiIdx;
     uint256 internal usdcIdx;
 
     function setUp() public virtual override {
         BaseVaultTest.setUp();
-
-        feeController = vault.getProtocolFeeController();
 
         setSwapFeePercentage(swapFeePercentage);
         vault.manualSetAggregateSwapFeePercentage(

--- a/pkg/vault/test/foundry/VaultLiquidityFees.t.sol
+++ b/pkg/vault/test/foundry/VaultLiquidityFees.t.sol
@@ -14,7 +14,8 @@ import { BaseVaultTest } from "./utils/BaseVaultTest.sol";
 contract VaultLiquidityWithFeesTest is BaseVaultTest {
     using ArrayHelpers for *;
 
-    uint64 poolCreatorFeePercentage = 5e17; // 50%
+    // `BaseVaultTest` defines the `protocolSwapFeePercentage`.
+    uint64 poolCreatorFeePercentage = 50e16; // 50%
 
     IProtocolFeeController feeController;
 

--- a/pkg/vault/test/foundry/VaultLiquidityFees.t.sol
+++ b/pkg/vault/test/foundry/VaultLiquidityFees.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 
+import { IProtocolFeeController } from "@balancer-labs/v3-interfaces/contracts/vault/IProtocolFeeController.sol";
+
 import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/ArrayHelpers.sol";
 import { PoolConfig } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
@@ -14,6 +16,8 @@ contract VaultLiquidityWithFeesTest is BaseVaultTest {
 
     uint64 poolCreatorFeePercentage = 5e17; // 50%
 
+    IProtocolFeeController feeController;
+
     // Track the indices for the standard dai/usdc pool.
     uint256 internal daiIdx;
     uint256 internal usdcIdx;
@@ -21,10 +25,12 @@ contract VaultLiquidityWithFeesTest is BaseVaultTest {
     function setUp() public virtual override {
         BaseVaultTest.setUp();
 
+        feeController = vault.getProtocolFeeController();
+
         setSwapFeePercentage(swapFeePercentage);
         vault.manualSetAggregateSwapFeePercentage(
             pool,
-            _getAggregateFeePercentage(protocolSwapFeePercentage, poolCreatorFeePercentage)
+            feeController.computeAggregateFeePercentage(protocolSwapFeePercentage, poolCreatorFeePercentage)
         );
 
         (daiIdx, usdcIdx) = getSortedIndexes(address(dai), address(usdc));
@@ -40,7 +46,7 @@ contract VaultLiquidityWithFeesTest is BaseVaultTest {
         assertEq(config.staticSwapFeePercentage, swapFeePercentage);
         assertEq(
             config.aggregateSwapFeePercentage,
-            _getAggregateFeePercentage(protocolSwapFeePercentage, poolCreatorFeePercentage)
+            feeController.computeAggregateFeePercentage(protocolSwapFeePercentage, poolCreatorFeePercentage)
         );
     }
 

--- a/pkg/vault/test/foundry/YieldFees.t.sol
+++ b/pkg/vault/test/foundry/YieldFees.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 
+import { IProtocolFeeController } from "@balancer-labs/v3-interfaces/contracts/vault/IProtocolFeeController.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import { IRateProvider } from "@balancer-labs/v3-interfaces/contracts/vault/IRateProvider.sol";
 import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
@@ -25,12 +26,16 @@ contract YieldFeesTest is BaseVaultTest {
     RateProviderMock wstETHRateProvider;
     RateProviderMock daiRateProvider;
 
+    IProtocolFeeController feeController;
+
     // Track the indices for the local dai/wsteth pool.
     uint256 internal wstethIdx;
     uint256 internal daiIdx;
 
     function setUp() public override {
         BaseVaultTest.setUp();
+
+        feeController = vault.getProtocolFeeController();
 
         (daiIdx, wstethIdx) = getSortedIndexes(address(dai), address(wsteth));
     }
@@ -94,17 +99,14 @@ contract YieldFeesTest is BaseVaultTest {
     function testNoYieldFeesIfExempt__Fuzz(
         uint256 wstethRate,
         uint256 daiRate,
-        uint256 protocolYieldFeePercentage,
-        uint256 poolCreatorFeePercentage,
+        uint256 aggregateYieldFeePercentage,
         bool roundUp
     ) public {
         wstethRate = bound(wstethRate, 1e18, 1.5e18);
         daiRate = bound(daiRate, 1e18, 1.5e18);
-
-        (protocolYieldFeePercentage, poolCreatorFeePercentage) = _initializeFees(
-            protocolYieldFeePercentage,
-            poolCreatorFeePercentage
-        );
+        aggregateYieldFeePercentage = bound(aggregateYieldFeePercentage, 1e12, 10e16);
+        // Prevent PrecisionTooHigh error.
+        aggregateYieldFeePercentage = (aggregateYieldFeePercentage / FEE_SCALING_FACTOR) * FEE_SCALING_FACTOR;
 
         pool = createPool();
         wstETHRateProvider.mockRate(wstethRate);
@@ -112,10 +114,6 @@ contract YieldFeesTest is BaseVaultTest {
 
         initPool();
 
-        uint256 aggregateYieldFeePercentage = _getAggregateFeePercentage(
-            protocolYieldFeePercentage,
-            poolCreatorFeePercentage
-        );
         // Set non-zero yield fee.
         vault.manualSetAggregateYieldFeePercentage(pool, aggregateYieldFeePercentage);
 
@@ -155,9 +153,7 @@ contract YieldFeesTest is BaseVaultTest {
             wstethRate
         );
         vars.liveBalanceBeforeRaw = vars.liveBalanceAfterRaw + actualProtocolFee;
-        vars.expectedProtocolFee = vars.liveBalanceBeforeRaw.mulDown(
-            _getAggregateFeePercentage(protocolYieldFeePercentage, poolCreatorFeePercentage)
-        );
+        vars.expectedProtocolFee = vars.liveBalanceBeforeRaw.mulDown(aggregateYieldFeePercentage);
 
         assertApproxEqAbs(actualProtocolFee, vars.expectedProtocolFee, 1e3, "Wrong protocol fee");
     }
@@ -228,18 +224,16 @@ contract YieldFeesTest is BaseVaultTest {
     function testYieldFeesOnSwap__Fuzz(
         uint256 wstethRate,
         uint256 daiRate,
-        uint256 protocolYieldFeePercentage,
-        uint256 poolCreatorFeePercentage
+        uint256 aggregateYieldFeePercentage
     ) public {
-        (protocolYieldFeePercentage, poolCreatorFeePercentage) = _initializeFees(
-            protocolYieldFeePercentage,
-            poolCreatorFeePercentage
-        );
+        aggregateYieldFeePercentage = bound(aggregateYieldFeePercentage, 1e12, 10e16);
+        // Prevent PrecisionTooHigh error.
+        aggregateYieldFeePercentage = (aggregateYieldFeePercentage / FEE_SCALING_FACTOR) * FEE_SCALING_FACTOR;
 
         wstethRate = bound(wstethRate, 1e18, 1.5e18);
         daiRate = bound(daiRate, 1e18, 1.5e18);
 
-        _testYieldFeesOnSwap(wstethRate, daiRate, protocolYieldFeePercentage, poolCreatorFeePercentage);
+        _testYieldFeesOnSwap(wstethRate, daiRate, aggregateYieldFeePercentage);
     }
 
     function testYieldFeesOnSwap() public {
@@ -247,18 +241,18 @@ contract YieldFeesTest is BaseVaultTest {
         uint256 protocolYieldFeePercentage = 20e16;
         uint256 poolCreatorFeePercentage = 1e18;
 
+        uint256 aggregateYieldFeePercentage = feeController.computeAggregateFeePercentage(
+            protocolYieldFeePercentage,
+            poolCreatorFeePercentage
+        );
+
         uint256 wstethRate = 1.3e18;
         uint256 daiRate = 1.3e18;
 
-        _testYieldFeesOnSwap(wstethRate, daiRate, protocolYieldFeePercentage, poolCreatorFeePercentage);
+        _testYieldFeesOnSwap(wstethRate, daiRate, aggregateYieldFeePercentage);
     }
 
-    function _testYieldFeesOnSwap(
-        uint256 wstethRate,
-        uint256 daiRate,
-        uint256 protocolYieldFeePercentage,
-        uint256 poolCreatorFeePercentage
-    ) private {
+    function _testYieldFeesOnSwap(uint256 wstethRate, uint256 daiRate, uint256 aggregateYieldFeePercentage) private {
         pool = createPool();
         wstETHRateProvider.mockRate(wstethRate);
         daiRateProvider.mockRate(daiRate);
@@ -267,11 +261,6 @@ contract YieldFeesTest is BaseVaultTest {
 
         require(vault.manualGetAggregateYieldFeeAmount(pool, dai) == 0, "Initial protocol fees for DAI not 0");
         require(vault.manualGetAggregateYieldFeeAmount(pool, wsteth) == 0, "Initial protocol fees for wstETH not 0");
-
-        uint256 aggregateYieldFeePercentage = _getAggregateFeePercentage(
-            protocolYieldFeePercentage,
-            poolCreatorFeePercentage
-        );
 
         vault.manualSetAggregateYieldFeePercentage(pool, aggregateYieldFeePercentage);
 

--- a/pkg/vault/test/foundry/YieldFees.t.sol
+++ b/pkg/vault/test/foundry/YieldFees.t.sol
@@ -239,7 +239,7 @@ contract YieldFeesTest is BaseVaultTest {
     function testYieldFeesOnSwap() public {
         // Protocol yield fee 20%, and pool creator yield fees 100%.
         uint256 protocolYieldFeePercentage = 20e16;
-        uint256 poolCreatorFeePercentage = 1e18;
+        uint256 poolCreatorFeePercentage = 100e16;
 
         uint256 aggregateYieldFeePercentage = feeController.computeAggregateFeePercentage(
             protocolYieldFeePercentage,

--- a/pkg/vault/test/foundry/YieldFees.t.sol
+++ b/pkg/vault/test/foundry/YieldFees.t.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 
-import { IProtocolFeeController } from "@balancer-labs/v3-interfaces/contracts/vault/IProtocolFeeController.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import { IRateProvider } from "@balancer-labs/v3-interfaces/contracts/vault/IRateProvider.sol";
 import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
@@ -26,16 +25,12 @@ contract YieldFeesTest is BaseVaultTest {
     RateProviderMock wstETHRateProvider;
     RateProviderMock daiRateProvider;
 
-    IProtocolFeeController feeController;
-
     // Track the indices for the local dai/wsteth pool.
     uint256 internal wstethIdx;
     uint256 internal daiIdx;
 
     function setUp() public override {
         BaseVaultTest.setUp();
-
-        feeController = vault.getProtocolFeeController();
 
         (daiIdx, wstethIdx) = getSortedIndexes(address(dai), address(wsteth));
     }

--- a/pkg/vault/test/foundry/unit/VaultUnitSwap.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultUnitSwap.t.sol
@@ -64,7 +64,7 @@ contract VaultUnitSwapTest is BaseTest {
         uint256 limitRaw = 1000e18;
         uint256 swapFeePercentage = 1e16;
         uint256 protocolFeePercentage = 20e16;
-        uint256 poolCreatorFeePercentage = 5e17;
+        uint256 poolCreatorFeePercentage = 50e16;
 
         (, SwapState memory state, PoolData memory poolData) = _makeParams(
             SwapKind.EXACT_IN,

--- a/pkg/vault/test/foundry/unit/VaultUnitSwap.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultUnitSwap.t.sol
@@ -6,6 +6,7 @@ import "forge-std/Test.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import { IProtocolFeeController } from "@balancer-labs/v3-interfaces/contracts/vault/IProtocolFeeController.sol";
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 import { IVaultMock } from "@balancer-labs/v3-interfaces/contracts/test/IVaultMock.sol";
 import { IBasePool } from "@balancer-labs/v3-interfaces/contracts/vault/IBasePool.sol";
@@ -43,9 +44,12 @@ contract VaultUnitSwapTest is BaseTest {
     uint256[] decimalScalingFactors = [uint256(1e18), 1e18];
     uint256[] tokenRates = [uint256(1e18), 2e18];
 
+    IProtocolFeeController feeController;
+
     function setUp() public virtual override {
         BaseTest.setUp();
         vault = IVaultMock(address(VaultMockDeployer.deploy()));
+        feeController = vault.getProtocolFeeController();
 
         swapTokens = [dai, usdc];
         // We don't care about last live balances, so we set them equal to the raw ones.
@@ -117,13 +121,6 @@ contract VaultUnitSwapTest is BaseTest {
             locals.swapState,
             locals.poolData
         );
-    }
-
-    function _getAggregateFeePercentage(
-        uint256 protocolFeePercentage,
-        uint256 creatorFeePercentage
-    ) internal pure returns (uint256) {
-        return protocolFeePercentage + protocolFeePercentage.complement().mulDown(creatorFeePercentage);
     }
 
     function testSwapExactInWithFee() public {
@@ -315,7 +312,9 @@ contract VaultUnitSwapTest is BaseTest {
         poolData.poolConfigBits = poolData
             .poolConfigBits
             .setStaticSwapFeePercentage(swapFeePercentage)
-            .setAggregateSwapFeePercentage(_getAggregateFeePercentage(protocolFeePercentage, poolCreatorFeePercentage));
+            .setAggregateSwapFeePercentage(
+                feeController.computeAggregateFeePercentage(protocolFeePercentage, poolCreatorFeePercentage)
+            );
 
         poolData.balancesLiveScaled18 = new uint256[](initialBalances.length);
     }

--- a/pkg/vault/test/foundry/utils/BaseVaultTest.sol
+++ b/pkg/vault/test/foundry/utils/BaseVaultTest.sol
@@ -250,16 +250,6 @@ abstract contract BaseVaultTest is VaultStorage, BaseTest, Permit2Helpers {
         return bytes32(uint256(uint160(addr)));
     }
 
-    function _getAggregateFeePercentage(
-        uint256 protocolFeePercentage,
-        uint256 creatorFeePercentage
-    ) internal pure returns (uint256) {
-        // Address precision issues with 24-bit fees.
-        return
-            ((protocolFeePercentage + protocolFeePercentage.complement().mulDown(creatorFeePercentage)) /
-                FEE_SCALING_FACTOR) * FEE_SCALING_FACTOR;
-    }
-
     function _prankStaticCall() internal {
         // Prank address 0x0 for both msg.sender and tx.origin (to identify as a staticcall)
         vm.prank(address(0), address(0));

--- a/pkg/vault/test/foundry/utils/BaseVaultTest.sol
+++ b/pkg/vault/test/foundry/utils/BaseVaultTest.sol
@@ -6,6 +6,7 @@ import "forge-std/Test.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import { IProtocolFeeController } from "@balancer-labs/v3-interfaces/contracts/vault/IProtocolFeeController.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import { IVaultAdmin } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultAdmin.sol";
 import { IVaultExtension } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultExtension.sol";
@@ -67,6 +68,8 @@ abstract contract BaseVaultTest is VaultStorage, BaseTest, Permit2Helpers {
     BatchRouterMock internal batchRouter;
     // Authorizer mock.
     BasicAuthorizerMock internal authorizer;
+    // Fee controller deployed with the Vault.
+    IProtocolFeeController internal feeController;
     // Pool for tests.
     address internal pool;
     // Rate provider mock.
@@ -117,6 +120,9 @@ abstract contract BaseVaultTest is VaultStorage, BaseTest, Permit2Helpers {
         vm.label(address(router), "router");
         batchRouter = new BatchRouterMock(IVault(address(vault)), weth, permit2);
         vm.label(address(batchRouter), "batch router");
+        feeController = vault.getProtocolFeeController();
+        vm.label(address(feeController), "fee controller");
+
         poolHooksContract = createHook();
         pool = createPool();
 


### PR DESCRIPTION
# Description

We had a legacy helper in `BaseVaultTest` (and a duplicate in one of the test files) that computed aggregate percentages from their components. It had (documented) precision issues, which were resolved in the latest `ProtocolFeeController` code.

This makes minimal changes to remove these helpers and use the `ProtocolFeeController` itself for aggregate computation, so that it's consistent with what the system does. For the fuzz tests, there were still precision issues trying to set each to its full range, so in that case I had to fuzz the aggregate fee directly (bounding it, then manually adjusting for precision).

A more extensive change would be to always use the aggregate percentage natively, and not try to compute it.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Resolves #823 .
