### PR TITLE
Use forceApprove for arbitrary token fee collection

### DIFF
--- a/pkg/vault/contracts/VaultAdmin.sol
+++ b/pkg/vault/contracts/VaultAdmin.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import { IAuthorizer } from "@balancer-labs/v3-interfaces/contracts/vault/IAuthorizer.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
@@ -35,6 +36,7 @@ contract VaultAdmin is IVaultAdmin, VaultCommon, Authentication {
     using PoolConfigLib for PoolConfigBits;
     using VaultStateLib for VaultStateBits;
     using VaultExtensionsLib for IVault;
+    using SafeERC20 for IERC20;
 
     IVault private immutable _vault;
 
@@ -283,7 +285,7 @@ contract VaultAdmin is IVaultAdmin, VaultCommon, Authentication {
 
             if (totalSwapFees[i] > 0 || totalYieldFees[i] > 0) {
                 // The ProtocolFeeController will pull tokens from the Vault.
-                token.approve(feeController, totalSwapFees[i] + totalYieldFees[i]);
+                token.forceApprove(feeController, totalSwapFees[i] + totalYieldFees[i]);
 
                 _aggregateFeeAmounts[pool][token] = 0;
             }

--- a/pkg/vault/test/.contract-sizes/VaultAdmin
+++ b/pkg/vault/test/.contract-sizes/VaultAdmin
@@ -1,2 +1,2 @@
-Bytecode	11.813
-InitCode	12.851
+Bytecode	12.354
+InitCode	13.391


### PR DESCRIPTION
# Description

Inspired to check our own code to ensure we were always using `forceApprove` where necessary, and it seems like we missed one. (Probably redundant in this case, as the approval would almost certainly be 0 to start with, but doesn't hurt.)

Good thing this is the VaultAdmin - seems to have added 500 bytes?!

## Type of change

- [X] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
