### PR TITLE
Use standard dai/usdc for e2e

### DIFF
--- a/pkg/vault/test/foundry/E2eSwap.t.sol
+++ b/pkg/vault/test/foundry/E2eSwap.t.sol
@@ -10,7 +10,6 @@ import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity
 import { IProtocolFeeController } from "@balancer-labs/v3-interfaces/contracts/vault/IProtocolFeeController.sol";
 
 import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/ArrayHelpers.sol";
-import { ERC20TestToken } from "@balancer-labs/v3-solidity-utils/contracts/test/ERC20TestToken.sol";
 
 import { PoolMock } from "../../contracts/test/PoolMock.sol";
 import { BaseVaultTest } from "./utils/BaseVaultTest.sol";
@@ -18,21 +17,20 @@ import { BaseVaultTest } from "./utils/BaseVaultTest.sol";
 contract E2eSwapTest is BaseVaultTest {
     using ArrayHelpers for *;
 
-    ERC20TestToken internal token1;
-    ERC20TestToken internal token2;
-    uint256 private _idxToken1;
-    uint256 private _idxToken2;
+    uint256 internal daiIdx;
+    uint256 internal usdcIdx;
+
     address internal sender;
     address internal poolCreator;
 
     uint256 internal minPoolSwapFeePercentage;
     uint256 internal maxPoolSwapFeePercentage;
 
-    uint256 internal minSwapAmountToken1;
-    uint256 internal maxSwapAmountToken1;
+    uint256 internal minSwapAmountDai;
+    uint256 internal maxSwapAmountDai;
 
-    uint256 internal minSwapAmountToken2;
-    uint256 internal maxSwapAmountToken2;
+    uint256 internal minSwapAmountUsdc;
+    uint256 internal maxSwapAmountUsdc;
 
     function setUp() public virtual override {
         BaseVaultTest.setUp();
@@ -55,14 +53,15 @@ contract E2eSwapTest is BaseVaultTest {
         // Set pool creator fee to 100%, so protocol + creator fees equals the total charged fees.
         feeController.setPoolCreatorSwapFeePercentage(pool, 1e18);
 
-        (_idxToken1, _idxToken2) = _getTokenIndexes();
+        (daiIdx, usdcIdx) = getSortedIndexes(address(dai), address(usdc));
 
         // Donate tokens to vault, so liquidity tests are possible.
-        token1.mint(address(vault), 100 * poolInitAmount);
-        token2.mint(address(vault), 100 * poolInitAmount);
+        dai.mint(address(vault), 100 * poolInitAmount);
+        usdc.mint(address(vault), 100 * poolInitAmount);
+
         // Override vault liquidity, to make sure the extra liquidity is registered.
-        vault.manualSetReservesOf(token1, 100 * poolInitAmount);
-        vault.manualSetReservesOf(token2, 100 * poolInitAmount);
+        vault.manualSetReservesOf(dai, 100 * poolInitAmount);
+        vault.manualSetReservesOf(usdc, 100 * poolInitAmount);
     }
 
     /**
@@ -70,18 +69,16 @@ contract E2eSwapTest is BaseVaultTest {
      * @dev When extending the test, override this function and set the same variables.
      */
     function _setUpVariables() internal virtual {
-        token1 = dai;
-        token2 = usdc;
         sender = lp;
         poolCreator = lp;
 
         // If there are swap fees, the amountCalculated may be lower than MIN_TRADE_AMOUNT. So, multiplying
         // MIN_TRADE_AMOUNT by 10 creates a margin.
-        minSwapAmountToken1 = 10 * MIN_TRADE_AMOUNT;
-        maxSwapAmountToken1 = poolInitAmount;
+        minSwapAmountDai = 10 * MIN_TRADE_AMOUNT;
+        maxSwapAmountDai = poolInitAmount;
 
-        minSwapAmountToken2 = 10 * MIN_TRADE_AMOUNT;
-        maxSwapAmountToken2 = poolInitAmount;
+        minSwapAmountUsdc = 10 * MIN_TRADE_AMOUNT;
+        maxSwapAmountUsdc = poolInitAmount;
 
         // 0.0001% min swap fee.
         minPoolSwapFeePercentage = 1e12;
@@ -90,7 +87,7 @@ contract E2eSwapTest is BaseVaultTest {
     }
 
     function testDoExactInUndoExactInNoFees__Fuzz(uint256 exactAmountIn) public {
-        exactAmountIn = bound(exactAmountIn, minSwapAmountToken1, maxSwapAmountToken1);
+        exactAmountIn = bound(exactAmountIn, minSwapAmountDai, maxSwapAmountDai);
 
         // Set swap fees to 0 (do not check pool fee percentage limits, some pool types do not accept 0 fees).
         vault.manualUnsafeSetStaticSwapFeePercentage(pool, 0);
@@ -100,8 +97,8 @@ contract E2eSwapTest is BaseVaultTest {
         vm.startPrank(sender);
         uint256 exactAmountOutDo = router.swapSingleTokenExactIn(
             pool,
-            token1,
-            token2,
+            dai,
+            usdc,
             exactAmountIn,
             0,
             MAX_UINT128,
@@ -110,8 +107,8 @@ contract E2eSwapTest is BaseVaultTest {
         );
         uint256 exactAmountOutUndo = router.swapSingleTokenExactIn(
             pool,
-            token2,
-            token1,
+            usdc,
+            dai,
             exactAmountOutDo,
             0,
             MAX_UINT128,
@@ -124,31 +121,23 @@ contract E2eSwapTest is BaseVaultTest {
 
         assertLe(exactAmountOutUndo, exactAmountIn, "Amount out undo should be <= exactAmountIn");
         // Since it was a do/undo operation, the user balance of each token cannot be greater than before.
-        assertLe(
-            balancesAfter.userTokens[_idxToken1],
-            balancesBefore.userTokens[_idxToken1],
-            "Wrong sender token1 balance"
-        );
-        assertLe(
-            balancesAfter.userTokens[_idxToken2],
-            balancesBefore.userTokens[_idxToken2],
-            "Wrong sender token2 balance"
-        );
+        assertLe(balancesAfter.userTokens[daiIdx], balancesBefore.userTokens[daiIdx], "Wrong sender dai balance");
+        assertLe(balancesAfter.userTokens[usdcIdx], balancesBefore.userTokens[usdcIdx], "Wrong sender usdc balance");
     }
 
-    function testDoExactInUndoExactInLiquidity__Fuzz(uint256 liquidityToken1, uint256 liquidityToken2) public {
-        liquidityToken1 = bound(liquidityToken1, poolInitAmount / 10, 10 * poolInitAmount);
-        liquidityToken2 = bound(liquidityToken2, poolInitAmount / 10, 10 * poolInitAmount);
+    function testDoExactInUndoExactInLiquidity__Fuzz(uint256 liquidityDai, uint256 liquidityUsdc) public {
+        liquidityDai = bound(liquidityDai, poolInitAmount / 10, 10 * poolInitAmount);
+        liquidityUsdc = bound(liquidityUsdc, poolInitAmount / 10, 10 * poolInitAmount);
 
-        // 25% of token1 or token2 liquidity, the lowest value, to make sure the swap is executed.
-        uint256 exactAmountIn = (liquidityToken1 > liquidityToken2 ? liquidityToken2 : liquidityToken1) / 4;
+        // 25% of dai or usdc liquidity, the lowest value, to make sure the swap is executed.
+        uint256 exactAmountIn = (liquidityDai > liquidityUsdc ? liquidityUsdc : liquidityDai) / 4;
 
         // Set swap fees to 0 (do not check pool fee percentage limits, some pool types do not accept 0 fees).
         vault.manualUnsafeSetStaticSwapFeePercentage(pool, 0);
 
         // Set liquidity of pool.
         (IERC20[] memory tokens, , , ) = vault.getPoolTokenInfo(pool);
-        uint256[] memory newPoolBalance = [liquidityToken1, liquidityToken2].toMemoryArray();
+        uint256[] memory newPoolBalance = [liquidityDai, liquidityUsdc].toMemoryArray();
         vault.manualSetPoolTokensAndBalances(pool, tokens, newPoolBalance, newPoolBalance);
 
         BaseVaultTest.Balances memory balancesBefore = getBalances(sender);
@@ -156,8 +145,8 @@ contract E2eSwapTest is BaseVaultTest {
         vm.startPrank(sender);
         uint256 exactAmountOutDo = router.swapSingleTokenExactIn(
             pool,
-            token1,
-            token2,
+            dai,
+            usdc,
             exactAmountIn,
             0,
             MAX_UINT128,
@@ -166,8 +155,8 @@ contract E2eSwapTest is BaseVaultTest {
         );
         uint256 exactAmountOutUndo = router.swapSingleTokenExactIn(
             pool,
-            token2,
-            token1,
+            usdc,
+            dai,
             exactAmountOutDo,
             0,
             MAX_UINT128,
@@ -180,20 +169,12 @@ contract E2eSwapTest is BaseVaultTest {
 
         assertLe(exactAmountOutUndo, exactAmountIn, "Amount out undo should be <= exactAmountIn");
         // Since it was a do/undo operation, the user balance of each token cannot be greater than before.
-        assertLe(
-            balancesAfter.userTokens[_idxToken1],
-            balancesBefore.userTokens[_idxToken1],
-            "Wrong sender token1 balance"
-        );
-        assertLe(
-            balancesAfter.userTokens[_idxToken2],
-            balancesBefore.userTokens[_idxToken2],
-            "Wrong sender token2 balance"
-        );
+        assertLe(balancesAfter.userTokens[daiIdx], balancesBefore.userTokens[daiIdx], "Wrong sender dai balance");
+        assertLe(balancesAfter.userTokens[usdcIdx], balancesBefore.userTokens[usdcIdx], "Wrong sender usdc balance");
     }
 
     function testDoExactInUndoExactInVariableFees__Fuzz(uint256 poolSwapFeePercentage) public {
-        uint256 exactAmountIn = maxSwapAmountToken1;
+        uint256 exactAmountIn = maxSwapAmountDai;
         poolSwapFeePercentage = bound(poolSwapFeePercentage, minPoolSwapFeePercentage, maxPoolSwapFeePercentage);
 
         vault.manualSetStaticSwapFeePercentage(pool, poolSwapFeePercentage);
@@ -203,8 +184,8 @@ contract E2eSwapTest is BaseVaultTest {
         vm.startPrank(sender);
         uint256 exactAmountOutDo = router.swapSingleTokenExactIn(
             pool,
-            token1,
-            token2,
+            dai,
+            usdc,
             exactAmountIn,
             0,
             MAX_UINT128,
@@ -212,61 +193,61 @@ contract E2eSwapTest is BaseVaultTest {
             bytes("")
         );
 
-        uint256 feesToken2 = vault.getAggregateSwapFeeAmount(pool, token2);
+        uint256 feesUsdc = vault.getAggregateSwapFeeAmount(pool, usdc);
 
-        // In the first swap, the trade was exactAmountIn => exactAmountOutDo + feesToken2. So, if
-        // there were no fees, trading `exactAmountOutDo + feesToken2` would get exactAmountIn. Therefore, a swap
-        // with exact_in `exactAmountOutDo + feesToken2` is comparable with `exactAmountIn`, given that the fees are
+        // In the first swap, the trade was exactAmountIn => exactAmountOutDo + feesUsdc. So, if
+        // there were no fees, trading `exactAmountOutDo + feesUsdc` would get exactAmountIn. Therefore, a swap
+        // with exact_in `exactAmountOutDo + feesUsdc` is comparable with `exactAmountIn`, given that the fees are
         // known.
         uint256 exactAmountOutUndo = router.swapSingleTokenExactIn(
             pool,
-            token2,
-            token1,
-            exactAmountOutDo + feesToken2,
+            usdc,
+            dai,
+            exactAmountOutDo + feesUsdc,
             0,
             MAX_UINT128,
             false,
             bytes("")
         );
-        uint256 feesToken1 = vault.getAggregateSwapFeeAmount(pool, token1);
+        uint256 feesDai = vault.getAggregateSwapFeeAmount(pool, dai);
         vm.stopPrank();
 
         BaseVaultTest.Balances memory balancesAfter = getBalances(sender);
 
-        assertLe(exactAmountOutUndo, exactAmountIn - feesToken1, "Amount out undo should be <= exactAmountIn");
+        assertLe(exactAmountOutUndo, exactAmountIn - feesDai, "Amount out undo should be <= exactAmountIn");
         // Since it was a do/undo operation, the user balance of each token cannot be greater than before.
         assertLe(
-            balancesAfter.userTokens[_idxToken1],
-            balancesBefore.userTokens[_idxToken1] - feesToken1,
-            "Wrong sender token1 balance"
+            balancesAfter.userTokens[daiIdx],
+            balancesBefore.userTokens[daiIdx] - feesDai,
+            "Wrong sender dai balance"
         );
         assertLe(
-            balancesAfter.userTokens[_idxToken2],
-            balancesBefore.userTokens[_idxToken2] - feesToken2,
-            "Wrong sender token2 balance"
+            balancesAfter.userTokens[usdcIdx],
+            balancesBefore.userTokens[usdcIdx] - feesUsdc,
+            "Wrong sender usdc balance"
         );
     }
 
     function testDoExactInUndoExactInVariableFeesAmountInAndLiquidity__Fuzz(
         uint256 exactAmountIn,
         uint256 poolSwapFeePercentage,
-        uint256 liquidityToken1,
-        uint256 liquidityToken2
+        uint256 liquidityDai,
+        uint256 liquidityUsdc
     ) public {
-        liquidityToken1 = bound(liquidityToken1, poolInitAmount / 10, 10 * poolInitAmount);
-        liquidityToken2 = bound(liquidityToken2, poolInitAmount / 10, 10 * poolInitAmount);
+        liquidityDai = bound(liquidityDai, poolInitAmount / 10, 10 * poolInitAmount);
+        liquidityUsdc = bound(liquidityUsdc, poolInitAmount / 10, 10 * poolInitAmount);
 
-        // 25% of token1 or token2 liquidity, the lowest value, to make sure the swap is executed.
-        uint256 maxAmountIn = (liquidityToken1 > liquidityToken2 ? liquidityToken2 : liquidityToken1) / 4;
+        // 25% of dai or usdc liquidity, the lowest value, to make sure the swap is executed.
+        uint256 maxAmountIn = (liquidityDai > liquidityUsdc ? liquidityUsdc : liquidityDai) / 4;
 
-        exactAmountIn = bound(exactAmountIn, minSwapAmountToken1, maxAmountIn);
+        exactAmountIn = bound(exactAmountIn, minSwapAmountDai, maxAmountIn);
         poolSwapFeePercentage = bound(poolSwapFeePercentage, minPoolSwapFeePercentage, maxPoolSwapFeePercentage);
 
         vault.manualSetStaticSwapFeePercentage(pool, poolSwapFeePercentage);
 
         // Set liquidity of pool.
         (IERC20[] memory tokens, , , ) = vault.getPoolTokenInfo(pool);
-        uint256[] memory newPoolBalance = [liquidityToken1, liquidityToken2].toMemoryArray();
+        uint256[] memory newPoolBalance = [liquidityDai, liquidityUsdc].toMemoryArray();
         vault.manualSetPoolTokensAndBalances(pool, tokens, newPoolBalance, newPoolBalance);
 
         BaseVaultTest.Balances memory balancesBefore = getBalances(sender);
@@ -274,8 +255,8 @@ contract E2eSwapTest is BaseVaultTest {
         vm.startPrank(sender);
         uint256 exactAmountOutDo = router.swapSingleTokenExactIn(
             pool,
-            token1,
-            token2,
+            dai,
+            usdc,
             exactAmountIn,
             0,
             MAX_UINT128,
@@ -283,43 +264,43 @@ contract E2eSwapTest is BaseVaultTest {
             bytes("")
         );
 
-        uint256 feesToken2 = vault.getAggregateSwapFeeAmount(pool, token2);
+        uint256 feesUsdc = vault.getAggregateSwapFeeAmount(pool, usdc);
 
-        // In the first swap, the trade was exactAmountIn => exactAmountOutDo + feesToken2. So, if
-        // there were no fees, trading `exactAmountOutDo + feesToken2` would get exactAmountIn. Therefore, a swap
-        // with exact_in `exactAmountOutDo + feesToken2` is comparable with `exactAmountIn`, given that the fees are
+        // In the first swap, the trade was exactAmountIn => exactAmountOutDo + feesUsdc. So, if
+        // there were no fees, trading `exactAmountOutDo + feesUsdc` would get exactAmountIn. Therefore, a swap
+        // with exact_in `exactAmountOutDo + feesUsdc` is comparable with `exactAmountIn`, given that the fees are
         // known.
         uint256 exactAmountOutUndo = router.swapSingleTokenExactIn(
             pool,
-            token2,
-            token1,
-            exactAmountOutDo + feesToken2,
+            usdc,
+            dai,
+            exactAmountOutDo + feesUsdc,
             0,
             MAX_UINT128,
             false,
             bytes("")
         );
-        uint256 feesToken1 = vault.getAggregateSwapFeeAmount(pool, token1);
+        uint256 feesDai = vault.getAggregateSwapFeeAmount(pool, dai);
         vm.stopPrank();
 
         BaseVaultTest.Balances memory balancesAfter = getBalances(sender);
 
-        assertLe(exactAmountOutUndo, exactAmountIn - feesToken1, "Amount out undo should be <= exactAmountIn");
+        assertLe(exactAmountOutUndo, exactAmountIn - feesDai, "Amount out undo should be <= exactAmountIn");
         // Since it was a do/undo operation, the user balance of each token cannot be greater than before.
         assertLe(
-            balancesAfter.userTokens[_idxToken1],
-            balancesBefore.userTokens[_idxToken1] - feesToken1,
-            "Wrong sender token1 balance"
+            balancesAfter.userTokens[daiIdx],
+            balancesBefore.userTokens[daiIdx] - feesDai,
+            "Wrong sender dai balance"
         );
         assertLe(
-            balancesAfter.userTokens[_idxToken2],
-            balancesBefore.userTokens[_idxToken2] - feesToken2,
-            "Wrong sender token2 balance"
+            balancesAfter.userTokens[usdcIdx],
+            balancesBefore.userTokens[usdcIdx] - feesUsdc,
+            "Wrong sender usdc balance"
         );
     }
 
     function testDoExactOutUndoExactOutNoFees__Fuzz(uint256 exactAmountOut) public {
-        exactAmountOut = bound(exactAmountOut, minSwapAmountToken2, maxSwapAmountToken2);
+        exactAmountOut = bound(exactAmountOut, minSwapAmountUsdc, maxSwapAmountUsdc);
 
         // Set swap fees to 0 (do not check pool fee percentage limits, some pool types do not accept 0 fees).
         vault.manualUnsafeSetStaticSwapFeePercentage(pool, 0);
@@ -329,8 +310,8 @@ contract E2eSwapTest is BaseVaultTest {
         vm.startPrank(sender);
         uint256 exactAmountInDo = router.swapSingleTokenExactOut(
             pool,
-            token1,
-            token2,
+            dai,
+            usdc,
             exactAmountOut,
             MAX_UINT128,
             MAX_UINT128,
@@ -340,8 +321,8 @@ contract E2eSwapTest is BaseVaultTest {
 
         uint256 exactAmountInUndo = router.swapSingleTokenExactOut(
             pool,
-            token2,
-            token1,
+            usdc,
+            dai,
             exactAmountInDo,
             MAX_UINT128,
             MAX_UINT128,
@@ -354,31 +335,23 @@ contract E2eSwapTest is BaseVaultTest {
 
         assertGe(exactAmountInUndo, exactAmountOut, "Amount in undo should be >= exactAmountOut");
         // Since it was a do/undo operation, the user balance of each token cannot be greater than before.
-        assertLe(
-            balancesAfter.userTokens[_idxToken1],
-            balancesBefore.userTokens[_idxToken1],
-            "Wrong sender token1 balance"
-        );
-        assertLe(
-            balancesAfter.userTokens[_idxToken2],
-            balancesBefore.userTokens[_idxToken2],
-            "Wrong sender token2 balance"
-        );
+        assertLe(balancesAfter.userTokens[daiIdx], balancesBefore.userTokens[daiIdx], "Wrong sender dai balance");
+        assertLe(balancesAfter.userTokens[usdcIdx], balancesBefore.userTokens[usdcIdx], "Wrong sender usdc balance");
     }
 
-    function testDoExactOutUndoExactOutLiquidity__Fuzz(uint256 liquidityToken1, uint256 liquidityToken2) public {
-        liquidityToken1 = bound(liquidityToken1, poolInitAmount / 10, 10 * poolInitAmount);
-        liquidityToken2 = bound(liquidityToken2, poolInitAmount / 10, 10 * poolInitAmount);
+    function testDoExactOutUndoExactOutLiquidity__Fuzz(uint256 liquidityDai, uint256 liquidityUsdc) public {
+        liquidityDai = bound(liquidityDai, poolInitAmount / 10, 10 * poolInitAmount);
+        liquidityUsdc = bound(liquidityUsdc, poolInitAmount / 10, 10 * poolInitAmount);
 
-        // 25% of token1 or token2 liquidity, the lowest value, to make sure the swap is executed.
-        uint256 exactAmountOut = (liquidityToken1 > liquidityToken2 ? liquidityToken2 : liquidityToken1) / 4;
+        // 25% of dai or usdc liquidity, the lowest value, to make sure the swap is executed.
+        uint256 exactAmountOut = (liquidityDai > liquidityUsdc ? liquidityUsdc : liquidityDai) / 4;
 
         // Set swap fees to 0 (do not check pool fee percentage limits, some pool types do not accept 0 fees).
         vault.manualUnsafeSetStaticSwapFeePercentage(pool, 0);
 
         // Set liquidity of pool.
         (IERC20[] memory tokens, , , ) = vault.getPoolTokenInfo(pool);
-        uint256[] memory newPoolBalance = [liquidityToken1, liquidityToken2].toMemoryArray();
+        uint256[] memory newPoolBalance = [liquidityDai, liquidityUsdc].toMemoryArray();
         vault.manualSetPoolTokensAndBalances(pool, tokens, newPoolBalance, newPoolBalance);
 
         BaseVaultTest.Balances memory balancesBefore = getBalances(sender);
@@ -386,8 +359,8 @@ contract E2eSwapTest is BaseVaultTest {
         vm.startPrank(sender);
         uint256 exactAmountInDo = router.swapSingleTokenExactOut(
             pool,
-            token1,
-            token2,
+            dai,
+            usdc,
             exactAmountOut,
             MAX_UINT128,
             MAX_UINT128,
@@ -397,8 +370,8 @@ contract E2eSwapTest is BaseVaultTest {
 
         uint256 exactAmountInUndo = router.swapSingleTokenExactOut(
             pool,
-            token2,
-            token1,
+            usdc,
+            dai,
             exactAmountInDo,
             MAX_UINT128,
             MAX_UINT128,
@@ -411,20 +384,12 @@ contract E2eSwapTest is BaseVaultTest {
 
         assertGe(exactAmountInUndo, exactAmountOut, "Amount in undo should be >= exactAmountOut");
         // Since it was a do/undo operation, the user balance of each token cannot be greater than before.
-        assertLe(
-            balancesAfter.userTokens[_idxToken1],
-            balancesBefore.userTokens[_idxToken1],
-            "Wrong sender token1 balance"
-        );
-        assertLe(
-            balancesAfter.userTokens[_idxToken2],
-            balancesBefore.userTokens[_idxToken2],
-            "Wrong sender token2 balance"
-        );
+        assertLe(balancesAfter.userTokens[daiIdx], balancesBefore.userTokens[daiIdx], "Wrong sender dai balance");
+        assertLe(balancesAfter.userTokens[usdcIdx], balancesBefore.userTokens[usdcIdx], "Wrong sender usdc balance");
     }
 
     function testDoExactOutUndoExactOutVariableFees__Fuzz(uint256 poolSwapFeePercentage) public {
-        uint256 exactAmountOut = maxSwapAmountToken2;
+        uint256 exactAmountOut = maxSwapAmountUsdc;
         poolSwapFeePercentage = bound(poolSwapFeePercentage, minPoolSwapFeePercentage, maxPoolSwapFeePercentage);
 
         vault.manualSetStaticSwapFeePercentage(pool, poolSwapFeePercentage);
@@ -434,8 +399,8 @@ contract E2eSwapTest is BaseVaultTest {
         vm.startPrank(sender);
         uint256 exactAmountInDo = router.swapSingleTokenExactOut(
             pool,
-            token1,
-            token2,
+            dai,
+            usdc,
             exactAmountOut,
             MAX_UINT128,
             MAX_UINT128,
@@ -443,61 +408,61 @@ contract E2eSwapTest is BaseVaultTest {
             bytes("")
         );
 
-        uint256 feesToken1 = vault.getAggregateSwapFeeAmount(pool, token1);
+        uint256 feesDai = vault.getAggregateSwapFeeAmount(pool, dai);
 
-        // In the first swap, the trade was exactAmountInDo => exactAmountOut (token2) + feesToken1 (token1). So, if
-        // there were no fees, trading `exactAmountInDo - feesToken1` would get exactAmountOut. Therefore, a swap
-        // with exact_out `exactAmountInDo - feesToken1` is comparable with `exactAmountOut`, given that the fees are
+        // In the first swap, the trade was exactAmountInDo => exactAmountOut (usdc) + feesDai (dai). So, if
+        // there were no fees, trading `exactAmountInDo - feesDai` would get exactAmountOut. Therefore, a swap
+        // with exact_out `exactAmountInDo - feesDai` is comparable with `exactAmountOut`, given that the fees are
         // known.
         uint256 exactAmountInUndo = router.swapSingleTokenExactOut(
             pool,
-            token2,
-            token1,
-            exactAmountInDo - feesToken1,
+            usdc,
+            dai,
+            exactAmountInDo - feesDai,
             MAX_UINT128,
             MAX_UINT128,
             false,
             bytes("")
         );
-        uint256 feesToken2 = vault.getAggregateSwapFeeAmount(pool, token2);
+        uint256 feesUsdc = vault.getAggregateSwapFeeAmount(pool, usdc);
         vm.stopPrank();
 
         BaseVaultTest.Balances memory balancesAfter = getBalances(sender);
 
-        assertGe(exactAmountInUndo, exactAmountOut + feesToken2, "Amount in undo should be >= exactAmountOut");
+        assertGe(exactAmountInUndo, exactAmountOut + feesUsdc, "Amount in undo should be >= exactAmountOut");
         // Since it was a do/undo operation, the user balance of each token cannot be greater than before.
         assertLe(
-            balancesAfter.userTokens[_idxToken1],
-            balancesBefore.userTokens[_idxToken1] - feesToken1,
-            "Wrong sender token1 balance"
+            balancesAfter.userTokens[daiIdx],
+            balancesBefore.userTokens[daiIdx] - feesDai,
+            "Wrong sender dai balance"
         );
         assertLe(
-            balancesAfter.userTokens[_idxToken2],
-            balancesBefore.userTokens[_idxToken2] - feesToken2,
-            "Wrong sender token2 balance"
+            balancesAfter.userTokens[usdcIdx],
+            balancesBefore.userTokens[usdcIdx] - feesUsdc,
+            "Wrong sender usdc balance"
         );
     }
 
     function testDoExactOutUndoExactOutVariableFeesAmountOutAndLiquidity__Fuzz(
         uint256 exactAmountOut,
         uint256 poolSwapFeePercentage,
-        uint256 liquidityToken1,
-        uint256 liquidityToken2
+        uint256 liquidityDai,
+        uint256 liquidityUsdc
     ) public {
-        liquidityToken1 = bound(liquidityToken1, poolInitAmount / 10, 10 * poolInitAmount);
-        liquidityToken2 = bound(liquidityToken2, poolInitAmount / 10, 10 * poolInitAmount);
+        liquidityDai = bound(liquidityDai, poolInitAmount / 10, 10 * poolInitAmount);
+        liquidityUsdc = bound(liquidityUsdc, poolInitAmount / 10, 10 * poolInitAmount);
 
-        // 25% of token1 or token2 liquidity, the lowest value, to make sure the swap is executed.
-        uint256 maxAmountOut = (liquidityToken1 > liquidityToken2 ? liquidityToken2 : liquidityToken1) / 4;
+        // 25% of dai or usdc liquidity, the lowest value, to make sure the swap is executed.
+        uint256 maxAmountOut = (liquidityDai > liquidityUsdc ? liquidityUsdc : liquidityDai) / 4;
 
-        exactAmountOut = bound(exactAmountOut, minSwapAmountToken2, maxAmountOut);
+        exactAmountOut = bound(exactAmountOut, minSwapAmountUsdc, maxAmountOut);
         poolSwapFeePercentage = bound(poolSwapFeePercentage, minPoolSwapFeePercentage, maxPoolSwapFeePercentage);
 
         vault.manualSetStaticSwapFeePercentage(pool, poolSwapFeePercentage);
 
         // Set liquidity of pool.
         (IERC20[] memory tokens, , , ) = vault.getPoolTokenInfo(pool);
-        uint256[] memory newPoolBalance = [liquidityToken1, liquidityToken2].toMemoryArray();
+        uint256[] memory newPoolBalance = [liquidityDai, liquidityUsdc].toMemoryArray();
         vault.manualSetPoolTokensAndBalances(pool, tokens, newPoolBalance, newPoolBalance);
 
         BaseVaultTest.Balances memory balancesBefore = getBalances(sender);
@@ -505,8 +470,8 @@ contract E2eSwapTest is BaseVaultTest {
         vm.startPrank(sender);
         uint256 exactAmountInDo = router.swapSingleTokenExactOut(
             pool,
-            token1,
-            token2,
+            dai,
+            usdc,
             exactAmountOut,
             MAX_UINT128,
             MAX_UINT128,
@@ -514,51 +479,38 @@ contract E2eSwapTest is BaseVaultTest {
             bytes("")
         );
 
-        uint256 feesToken1 = vault.getAggregateSwapFeeAmount(pool, token1);
+        uint256 feesDai = vault.getAggregateSwapFeeAmount(pool, dai);
 
-        // In the first swap, the trade was exactAmountInDo => exactAmountOut (token2) + feesToken1 (token1). So, if
-        // there were no fees, trading `exactAmountInDo - feesToken1` would get exactAmountOut. Therefore, a swap
-        // with exact_out `exactAmountInDo - feesToken1` is comparable with `exactAmountOut`, given that the fees are
+        // In the first swap, the trade was exactAmountInDo => exactAmountOut (usdc) + feesDai (dai). So, if
+        // there were no fees, trading `exactAmountInDo - feesDai` would get exactAmountOut. Therefore, a swap
+        // with exact_out `exactAmountInDo - feesDai` is comparable with `exactAmountOut`, given that the fees are
         // known.
         uint256 exactAmountInUndo = router.swapSingleTokenExactOut(
             pool,
-            token2,
-            token1,
-            exactAmountInDo - feesToken1,
+            usdc,
+            dai,
+            exactAmountInDo - feesDai,
             MAX_UINT128,
             MAX_UINT128,
             false,
             bytes("")
         );
-        uint256 feesToken2 = vault.getAggregateSwapFeeAmount(pool, token2);
+        uint256 feesUsdc = vault.getAggregateSwapFeeAmount(pool, usdc);
         vm.stopPrank();
 
         BaseVaultTest.Balances memory balancesAfter = getBalances(sender);
 
-        assertGe(exactAmountInUndo, exactAmountOut + feesToken2, "Amount in undo should be >= exactAmountOut");
+        assertGe(exactAmountInUndo, exactAmountOut + feesUsdc, "Amount in undo should be >= exactAmountOut");
         // Since it was a do/undo operation, the user balance of each token cannot be greater than before.
         assertLe(
-            balancesAfter.userTokens[_idxToken1],
-            balancesBefore.userTokens[_idxToken1] - feesToken1,
-            "Wrong sender token1 balance"
+            balancesAfter.userTokens[daiIdx],
+            balancesBefore.userTokens[daiIdx] - feesDai,
+            "Wrong sender dai balance"
         );
         assertLe(
-            balancesAfter.userTokens[_idxToken2],
-            balancesBefore.userTokens[_idxToken2] - feesToken2,
-            "Wrong sender token2 balance"
+            balancesAfter.userTokens[usdcIdx],
+            balancesBefore.userTokens[usdcIdx] - feesUsdc,
+            "Wrong sender usdc balance"
         );
-    }
-
-    function _getTokenIndexes() private view returns (uint256 idxToken1, uint256 idxToken2) {
-        (IERC20[] memory tokens, , , ) = vault.getPoolTokenInfo(pool);
-        // Iterate over token list because the pool may have more tokens than the 2 swapped.
-        for (uint256 i = 0; i < tokens.length; i++) {
-            if (tokens[i] == token1) {
-                idxToken1 = i;
-            }
-            if (tokens[i] == token2) {
-                idxToken2 = i;
-            }
-        }
     }
 }


### PR DESCRIPTION
# Description

This uses token1/2 and has a custom sort. I wondered if there was a reason to do this vs. just using dai/usdc and the common sort like other tests, and there doesn't seem to be.

Merge into #801 if I'm not missing something.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
