### PR TITLE
Add VaultExplorer support for `getAggregateFeePercentages`

### DIFF
--- a/pkg/interfaces/contracts/vault/IVaultExplorer.sol
+++ b/pkg/interfaces/contracts/vault/IVaultExplorer.sol
@@ -358,6 +358,23 @@ interface IVaultExplorer {
     *******************************************************************************/
 
     /**
+     * @notice Gets the aggregate swap and yield fee percentages for a pool.
+     * @dev These are determined by the current protocol and pool creator fees, set in the `ProtocolFeeController`.
+     * These data are accessible as part of the `PoolConfig` (accessible through `getPoolConfig`), and also through
+     * the `IPoolInfo` on the pool itself. Standard Balancer pools implement this interface, but custom pools are not
+     * required to. We add this as a convenience function with the same interface, but it will fetch from the Vault
+     * directly to ensure it is always supported.
+     *
+     * @param pool Address of the pool
+     * @return aggregateSwapFeePercentage The aggregate percentage fee applied to swaps
+     * @return aggregateYieldFeePercentage The aggregate percentage fee applied to yield
+     */
+    function getAggregateFeePercentages(address pool)
+        external
+        view
+        returns (uint256 aggregateSwapFeePercentage, uint256 aggregateYieldFeePercentage);
+
+    /**
      * @notice Collects accumulated aggregate swap and yield fees for the specified pool.
      * @dev Fees are sent to the ProtocolFeeController address.
      * @param pool The pool on which all aggregate fees should be collected

--- a/pkg/interfaces/contracts/vault/IVaultExplorer.sol
+++ b/pkg/interfaces/contracts/vault/IVaultExplorer.sol
@@ -369,10 +369,9 @@ interface IVaultExplorer {
      * @return aggregateSwapFeePercentage The aggregate percentage fee applied to swaps
      * @return aggregateYieldFeePercentage The aggregate percentage fee applied to yield
      */
-    function getAggregateFeePercentages(address pool)
-        external
-        view
-        returns (uint256 aggregateSwapFeePercentage, uint256 aggregateYieldFeePercentage);
+    function getAggregateFeePercentages(
+        address pool
+    ) external view returns (uint256 aggregateSwapFeePercentage, uint256 aggregateYieldFeePercentage);
 
     /**
      * @notice Collects accumulated aggregate swap and yield fees for the specified pool.

--- a/pkg/vault/contracts/VaultExplorer.sol
+++ b/pkg/vault/contracts/VaultExplorer.sol
@@ -282,6 +282,15 @@ contract VaultExplorer is IVaultExplorer {
     *******************************************************************************/
 
     /// @inheritdoc IVaultExplorer
+    function getAggregateFeePercentages(
+        address pool
+    ) external view returns (uint256 aggregateSwapFeePercentage, uint256 aggregateYieldFeePercentage) {
+        PoolConfig memory poolConfig = _vault.getPoolConfig(pool);
+
+        return (poolConfig.aggregateSwapFeePercentage, poolConfig.aggregateYieldFeePercentage);
+    }
+
+    /// @inheritdoc IVaultExplorer
     function collectAggregateFees(address pool) external {
         return _vault.collectAggregateFees(pool);
     }

--- a/pkg/vault/test/foundry/VaultExplorer.t.sol
+++ b/pkg/vault/test/foundry/VaultExplorer.t.sol
@@ -626,24 +626,19 @@ contract VaultExplorerTest is BaseVaultTest {
         assertTrue(explorerIsPaused, "Explorer says Vault is not paused");
     }
 
+    function testGetAggregateFeePercentages() public {
+        _setProtocolFees();
+
+        (uint256 aggregateSwapFeePercentage, uint256 aggregateYieldFeePercentage) = explorer.getAggregateFeePercentages(
+            pool
+        );
+
+        assertEq(aggregateSwapFeePercentage, PROTOCOL_SWAP_FEE, "Wrong aggregate swap fee");
+        assertEq(aggregateYieldFeePercentage, PROTOCOL_YIELD_FEE, "Wrong aggregate yield fee");
+    }
+
     function testCollectAggregateFees() public {
-        authorizer.grantRole(
-            feeControllerAuth.getActionId(IProtocolFeeController.setGlobalProtocolSwapFeePercentage.selector),
-            admin
-        );
-        authorizer.grantRole(
-            feeControllerAuth.getActionId(IProtocolFeeController.setGlobalProtocolYieldFeePercentage.selector),
-            admin
-        );
-
-        vm.startPrank(admin);
-        feeController.setGlobalProtocolSwapFeePercentage(PROTOCOL_SWAP_FEE);
-        feeController.setGlobalProtocolYieldFeePercentage(PROTOCOL_YIELD_FEE);
-        vm.stopPrank();
-
-        // Permissionlessly update the pool's fee percentages.
-        feeController.updateProtocolSwapFeePercentage(pool);
-        feeController.updateProtocolYieldFeePercentage(pool);
+        _setProtocolFees();
 
         // Check that the fee percentages are set in the pool.
         PoolConfig memory poolConfig = vault.getPoolConfig(pool);
@@ -667,6 +662,26 @@ contract VaultExplorerTest is BaseVaultTest {
         feeAmounts = feeController.getProtocolFeeAmounts(pool);
         assertTrue(feeAmounts[daiIdx] > 0, "Zero DAI fees");
         assertTrue(feeAmounts[usdcIdx] > 0, "Zero USDC fees");
+    }
+
+    function _setProtocolFees() private {
+        authorizer.grantRole(
+            feeControllerAuth.getActionId(IProtocolFeeController.setGlobalProtocolSwapFeePercentage.selector),
+            admin
+        );
+        authorizer.grantRole(
+            feeControllerAuth.getActionId(IProtocolFeeController.setGlobalProtocolYieldFeePercentage.selector),
+            admin
+        );
+
+        vm.startPrank(admin);
+        feeController.setGlobalProtocolSwapFeePercentage(PROTOCOL_SWAP_FEE);
+        feeController.setGlobalProtocolYieldFeePercentage(PROTOCOL_YIELD_FEE);
+        vm.stopPrank();
+
+        // Permissionlessly update the pool's fee percentages.
+        feeController.updateProtocolSwapFeePercentage(pool);
+        feeController.updateProtocolYieldFeePercentage(pool);
     }
 
     function testGetBufferOwnerShares() public {


### PR DESCRIPTION
# Description

We added a new function to `IPoolInfo`, so not technically "the Vault," but it's a permissionless getter for pool info, so I think it should be supported here as well. Also works for every pool, even custom ones that don't implement `IPoolInfo`, so it's an equivalent/safer path for offchain processes who don't want to keep track of which pools support `IPoolInfo`.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
