### PR TITLE
Move extension storage

### DIFF
--- a/pkg/vault/contracts/Vault.sol
+++ b/pkg/vault/contracts/Vault.sol
@@ -53,7 +53,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
     using StorageSlotExtension for *;
     using PoolDataLib for PoolData;
 
-    IVaultExtension internal immutable _vaultExtension;
+    IVaultExtension private immutable _vaultExtension;
 
     constructor(IVaultExtension vaultExtension, IAuthorizer authorizer, IProtocolFeeController protocolFeeController) {
         if (address(vaultExtension.vault()) != address(this)) {

--- a/pkg/vault/contracts/Vault.sol
+++ b/pkg/vault/contracts/Vault.sol
@@ -53,6 +53,8 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
     using StorageSlotExtension for *;
     using PoolDataLib for PoolData;
 
+    IVaultExtension internal immutable _vaultExtension;
+
     constructor(IVaultExtension vaultExtension, IAuthorizer authorizer, IProtocolFeeController protocolFeeController) {
         if (address(vaultExtension.vault()) != address(this)) {
             revert WrongVaultExtensionDeployment();

--- a/pkg/vault/contracts/VaultStorage.sol
+++ b/pkg/vault/contracts/VaultStorage.sol
@@ -62,9 +62,6 @@ contract VaultStorage {
     uint256 internal constant _MAX_PAUSE_WINDOW_DURATION = 356 days * 4;
     uint256 internal constant _MAX_BUFFER_PERIOD_DURATION = 90 days;
 
-    // Code extension for the Vault.
-    IVaultExtension internal immutable _vaultExtension;
-
     // Registry of pool configs.
     mapping(address => PoolConfigBits) internal _poolConfigBits;
 

--- a/pkg/vault/test/.contract-sizes/Vault
+++ b/pkg/vault/test/.contract-sizes/Vault
@@ -1,2 +1,2 @@
 Bytecode	23.816
-InitCode	25.092
+InitCode	25.084

--- a/pkg/vault/test/.contract-sizes/VaultAdmin
+++ b/pkg/vault/test/.contract-sizes/VaultAdmin
@@ -1,2 +1,2 @@
 Bytecode	12.354
-InitCode	13.391
+InitCode	13.386

--- a/pkg/vault/test/.contract-sizes/VaultExtension
+++ b/pkg/vault/test/.contract-sizes/VaultExtension
@@ -1,2 +1,2 @@
 Bytecode	20.168
-InitCode	21.356
+InitCode	21.338


### PR DESCRIPTION
# Description

Writing documentation is a great way to find stuff. We do not need to keep the `VaultExtension` pointer in shared storage; this PR does it like the other references in extension contracts. Preserves consistency, and saves a few bytes.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
