### PR TITLE
Use IERC4626 for dedicated buffer functions

### DIFF
--- a/pkg/interfaces/contracts/vault/IVaultAdmin.sol
+++ b/pkg/interfaces/contracts/vault/IVaultAdmin.sol
@@ -244,7 +244,7 @@ interface IVaultAdmin {
      * @return ownerShares Amount of shares allocated to the liquidity owner
      */
     function getBufferOwnerShares(
-        IERC20 wrappedToken,
+        IERC4626 wrappedToken,
         address liquidityOwner
     ) external view returns (uint256 ownerShares);
 
@@ -253,7 +253,7 @@ interface IVaultAdmin {
      * @param wrappedToken Address of the wrapped token that implements IERC4626
      * @return bufferShares Amount of supply shares of the buffer
      */
-    function getBufferTotalShares(IERC20 wrappedToken) external view returns (uint256 bufferShares);
+    function getBufferTotalShares(IERC4626 wrappedToken) external view returns (uint256 bufferShares);
 
     /**
      * @notice Returns the amount of underlying and wrapped tokens deposited in the internal buffer of the vault.
@@ -262,7 +262,7 @@ interface IVaultAdmin {
      * @return wrappedBalanceRaw Amount of wrapped tokens deposited into the buffer
      */
     function getBufferBalance(
-        IERC20 wrappedToken
+        IERC4626 wrappedToken
     ) external view returns (uint256 underlyingBalanceRaw, uint256 wrappedBalanceRaw);
 
     /*******************************************************************************

--- a/pkg/interfaces/contracts/vault/IVaultExplorer.sol
+++ b/pkg/interfaces/contracts/vault/IVaultExplorer.sol
@@ -2,7 +2,9 @@
 
 pragma solidity ^0.8.24;
 
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 import { TokenInfo, PoolRoleAccounts, PoolData, PoolConfig, PoolSwapParams, HooksConfig } from "./VaultTypes.sol";
 
 interface IVaultExplorer {
@@ -393,7 +395,7 @@ interface IVaultExplorer {
      * @return ownerShares Amount of shares allocated to the liquidity owner
      */
     function getBufferOwnerShares(
-        IERC20 wrappedToken,
+        IERC4626 wrappedToken,
         address liquidityOwner
     ) external view returns (uint256 ownerShares);
 
@@ -403,7 +405,7 @@ interface IVaultExplorer {
      * @param wrappedToken Address of the wrapped token that implements IERC4626
      * @return bufferShares Amount of supply shares of the buffer
      */
-    function getBufferTotalShares(IERC20 wrappedToken) external view returns (uint256 bufferShares);
+    function getBufferTotalShares(IERC4626 wrappedToken) external view returns (uint256 bufferShares);
 
     /**
      * @notice Returns the amount of underlying and wrapped tokens deposited in the internal buffer of the vault.
@@ -412,6 +414,6 @@ interface IVaultExplorer {
      * @return wrappedBalanceRaw Amount of wrapped tokens deposited into the buffer
      */
     function getBufferBalance(
-        IERC20 wrappedToken
+        IERC4626 wrappedToken
     ) external view returns (uint256 underlyingBalanceRaw, uint256 wrappedBalanceRaw);
 }

--- a/pkg/vault/contracts/Vault.sol
+++ b/pkg/vault/contracts/Vault.sol
@@ -1056,7 +1056,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
     {
         IERC20 underlyingToken = IERC20(params.wrappedToken.asset());
 
-        address bufferAsset = _bufferAssets[IERC20(params.wrappedToken)];
+        address bufferAsset = _bufferAssets[params.wrappedToken];
 
         if (bufferAsset != address(0) && bufferAsset != address(underlyingToken)) {
             // Asset was changed since the first addLiquidityToBuffer call.
@@ -1132,7 +1132,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
             (amountInUnderlying, amountOutWrapped) = (wrappedToken.convertToAssets(amountGiven), amountGiven);
         }
 
-        bytes32 bufferBalances = _bufferTokenBalances[IERC20(wrappedToken)];
+        bytes32 bufferBalances = _bufferTokenBalances[wrappedToken];
 
         if (bufferBalances.getBalanceDerived() >= amountOutWrapped) {
             // The buffer has enough liquidity to facilitate the wrap without making an external call.
@@ -1146,7 +1146,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
                 bufferBalances.getBalanceRaw() + amountInUnderlying,
                 newDerivedBalance
             );
-            _bufferTokenBalances[IERC20(wrappedToken)] = bufferBalances;
+            _bufferTokenBalances[wrappedToken] = bufferBalances;
         } else {
             // The buffer does not have enough liquidity to facilitate the wrap without making an external call.
             // We wrap the user's tokens via an external call and additionally rebalance the buffer if it has a
@@ -1220,7 +1220,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
                     bufferBalances.getBalanceRaw() - bufferUnderlyingSurplus,
                     bufferBalances.getBalanceDerived() + bufferWrappedSurplus
                 );
-                _bufferTokenBalances[IERC20(wrappedToken)] = bufferBalances;
+                _bufferTokenBalances[wrappedToken] = bufferBalances;
             } else {
                 amountInUnderlying = vaultUnderlyingDelta;
                 amountOutWrapped = vaultWrappedDelta;
@@ -1260,7 +1260,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
             (amountOutUnderlying, amountInWrapped) = (amountGiven, wrappedToken.convertToShares(amountGiven));
         }
 
-        bytes32 bufferBalances = _bufferTokenBalances[IERC20(wrappedToken)];
+        bytes32 bufferBalances = _bufferTokenBalances[wrappedToken];
 
         if (bufferBalances.getBalanceRaw() >= amountOutUnderlying) {
             // The buffer has enough liquidity to facilitate the wrap without making an external call.
@@ -1273,7 +1273,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
                 newRawBalance,
                 bufferBalances.getBalanceDerived() + amountInWrapped
             );
-            _bufferTokenBalances[IERC20(wrappedToken)] = bufferBalances;
+            _bufferTokenBalances[wrappedToken] = bufferBalances;
         } else {
             // The buffer does not have enough liquidity to facilitate the unwrap without making an external call.
             // We unwrap the user's tokens via an external call and additionally rebalance the buffer if it has a
@@ -1338,7 +1338,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
                     bufferBalances.getBalanceRaw() + bufferUnderlyingSurplus,
                     bufferBalances.getBalanceDerived() - bufferWrappedSurplus
                 );
-                _bufferTokenBalances[IERC20(wrappedToken)] = bufferBalances;
+                _bufferTokenBalances[wrappedToken] = bufferBalances;
             } else {
                 amountOutUnderlying = vaultUnderlyingDelta;
                 amountInWrapped = vaultWrappedDelta;
@@ -1366,7 +1366,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
         uint256 vaultUnderlyingAfter = underlyingToken.balanceOf(address(this));
         _reservesOf[underlyingToken] = vaultUnderlyingAfter;
 
-        uint256 vaultWrappedBefore = _reservesOf[IERC20(wrappedToken)];
+        uint256 vaultWrappedBefore = _reservesOf[wrappedToken];
         uint256 vaultWrappedAfter = wrappedToken.balanceOf(address(this));
         _reservesOf[wrappedToken] = vaultWrappedAfter;
 

--- a/pkg/vault/contracts/VaultAdmin.sol
+++ b/pkg/vault/contracts/VaultAdmin.sol
@@ -430,33 +430,33 @@ contract VaultAdmin is IVaultAdmin, VaultCommon, Authentication {
         // Amount of shares to issue is the total underlying token that the user is depositing.
         issuedShares = wrappedToken.convertToAssets(amountWrapped) + amountUnderlying;
 
-        if (_bufferAssets[IERC20(address(wrappedToken))] == address(0)) {
+        if (_bufferAssets[wrappedToken] == address(0)) {
             // Buffer is not initialized yet, so we initialize it.
 
             // Register asset of wrapper, so it cannot change.
-            _bufferAssets[IERC20(address(wrappedToken))] = underlyingToken;
+            _bufferAssets[wrappedToken] = underlyingToken;
 
             // Burn MINIMUM_TOTAL_SUPPLY shares, so the buffer can never go back to zero liquidity
             // (avoids rounding issues with low liquidity).
-            _bufferTotalShares[IERC20(wrappedToken)] = _MINIMUM_TOTAL_SUPPLY;
+            _bufferTotalShares[wrappedToken] = _MINIMUM_TOTAL_SUPPLY;
             issuedShares -= _MINIMUM_TOTAL_SUPPLY;
-        } else if (_bufferAssets[IERC20(address(wrappedToken))] != underlyingToken) {
+        } else if (_bufferAssets[wrappedToken] != underlyingToken) {
             // Asset was changed since the first bufferAddLiquidity call.
             revert WrongWrappedTokenAsset(address(wrappedToken));
         }
 
-        bytes32 bufferBalances = _bufferTokenBalances[IERC20(wrappedToken)];
+        bytes32 bufferBalances = _bufferTokenBalances[wrappedToken];
 
         // Adds the issued shares to the total shares of the liquidity pool.
-        _bufferLpShares[IERC20(wrappedToken)][sharesOwner] += issuedShares;
-        _bufferTotalShares[IERC20(wrappedToken)] += issuedShares;
+        _bufferLpShares[wrappedToken][sharesOwner] += issuedShares;
+        _bufferTotalShares[wrappedToken] += issuedShares;
 
         bufferBalances = PackedTokenBalance.toPackedBalance(
             bufferBalances.getBalanceRaw() + amountUnderlying,
             bufferBalances.getBalanceDerived() + amountWrapped
         );
 
-        _bufferTokenBalances[IERC20(wrappedToken)] = bufferBalances;
+        _bufferTokenBalances[wrappedToken] = bufferBalances;
 
         _takeDebt(IERC20(underlyingToken), amountUnderlying);
         _takeDebt(wrappedToken, amountWrapped);
@@ -477,27 +477,27 @@ contract VaultAdmin is IVaultAdmin, VaultCommon, Authentication {
         nonReentrant
         returns (uint256 removedUnderlyingBalance, uint256 removedWrappedBalance)
     {
-        bytes32 bufferBalances = _bufferTokenBalances[IERC20(wrappedToken)];
+        bytes32 bufferBalances = _bufferTokenBalances[wrappedToken];
 
-        if (sharesToRemove > _bufferLpShares[IERC20(wrappedToken)][sharesOwner]) {
+        if (sharesToRemove > _bufferLpShares[wrappedToken][sharesOwner]) {
             revert NotEnoughBufferShares();
         }
-        uint256 totalShares = _bufferTotalShares[IERC20(wrappedToken)];
+        uint256 totalShares = _bufferTotalShares[wrappedToken];
 
         removedUnderlyingBalance = (bufferBalances.getBalanceRaw() * sharesToRemove) / totalShares;
         removedWrappedBalance = (bufferBalances.getBalanceDerived() * sharesToRemove) / totalShares;
 
-        _bufferLpShares[IERC20(wrappedToken)][sharesOwner] -= sharesToRemove;
-        _bufferTotalShares[IERC20(wrappedToken)] -= sharesToRemove;
+        _bufferLpShares[wrappedToken][sharesOwner] -= sharesToRemove;
+        _bufferTotalShares[wrappedToken] -= sharesToRemove;
 
         bufferBalances = PackedTokenBalance.toPackedBalance(
             bufferBalances.getBalanceRaw() - removedUnderlyingBalance,
             bufferBalances.getBalanceDerived() - removedWrappedBalance
         );
 
-        _bufferTokenBalances[IERC20(wrappedToken)] = bufferBalances;
+        _bufferTokenBalances[wrappedToken] = bufferBalances;
 
-        _supplyCredit(IERC20(_bufferAssets[IERC20(address(wrappedToken))]), removedUnderlyingBalance);
+        _supplyCredit(IERC20(_bufferAssets[wrappedToken]), removedUnderlyingBalance);
         _supplyCredit(wrappedToken, removedWrappedBalance);
 
         emit LiquidityRemovedFromBuffer(
@@ -511,19 +511,19 @@ contract VaultAdmin is IVaultAdmin, VaultCommon, Authentication {
 
     /// @inheritdoc IVaultAdmin
     function getBufferOwnerShares(
-        IERC20 token,
+        IERC4626 token,
         address user
     ) external view onlyVaultDelegateCall returns (uint256 shares) {
         return _bufferLpShares[token][user];
     }
 
     /// @inheritdoc IVaultAdmin
-    function getBufferTotalShares(IERC20 token) external view onlyVaultDelegateCall returns (uint256 shares) {
+    function getBufferTotalShares(IERC4626 token) external view onlyVaultDelegateCall returns (uint256 shares) {
         return _bufferTotalShares[token];
     }
 
     /// @inheritdoc IVaultAdmin
-    function getBufferBalance(IERC20 token) external view onlyVaultDelegateCall returns (uint256, uint256) {
+    function getBufferBalance(IERC4626 token) external view onlyVaultDelegateCall returns (uint256, uint256) {
         // The first balance is underlying, and the last is wrapped balance.
         return (_bufferTokenBalances[token].getBalanceRaw(), _bufferTokenBalances[token].getBalanceDerived());
     }

--- a/pkg/vault/contracts/VaultExplorer.sol
+++ b/pkg/vault/contracts/VaultExplorer.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.24;
 
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { IVaultExplorer } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultExplorer.sol";
@@ -300,17 +301,17 @@ contract VaultExplorer is IVaultExplorer {
     *******************************************************************************/
 
     /// @inheritdoc IVaultExplorer
-    function getBufferOwnerShares(IERC20 token, address user) external view returns (uint256 shares) {
+    function getBufferOwnerShares(IERC4626 token, address user) external view returns (uint256 shares) {
         return _vault.getBufferOwnerShares(token, user);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getBufferTotalShares(IERC20 token) external view returns (uint256) {
+    function getBufferTotalShares(IERC4626 token) external view returns (uint256) {
         return _vault.getBufferTotalShares(token);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getBufferBalance(IERC20 token) external view returns (uint256, uint256) {
+    function getBufferBalance(IERC4626 token) external view returns (uint256, uint256) {
         return _vault.getBufferBalance(token);
     }
 }

--- a/pkg/vault/contracts/VaultStorage.sol
+++ b/pkg/vault/contracts/VaultStorage.sol
@@ -121,18 +121,18 @@ contract VaultStorage {
     // A buffer will only ever have two tokens: wrapped and underlying
     // we pack the wrapped and underlying balance into a single bytes32
     // wrapped token address -> PackedTokenBalance.
-    mapping(IERC20 => bytes32) internal _bufferTokenBalances;
+    mapping(IERC4626 => bytes32) internal _bufferTokenBalances;
 
     // The LP balances for buffers. To start, LP balances will not be represented as ERC20 shares.
     // If we end up with a need to incentivize buffers, we can wrap this in an ERC20 wrapper without
     // introducing more complexity to the vault.
     // wrapped token address -> user address -> LP balance.
-    mapping(IERC20 => mapping(address => uint256)) internal _bufferLpShares;
+    mapping(IERC4626 => mapping(address => uint256)) internal _bufferLpShares;
     // total LP shares
-    mapping(IERC20 => uint256) internal _bufferTotalShares;
+    mapping(IERC4626 => uint256) internal _bufferTotalShares;
 
     // Prevents a malicious ERC4626 from changing the asset after the buffer was initialized.
-    mapping(IERC20 => address) internal _bufferAssets;
+    mapping(IERC4626 => address) internal _bufferAssets;
 
     function _isUnlocked() internal view returns (StorageSlotExtension.BooleanSlotType slot) {
         return _IS_UNLOCKED_SLOT.asBoolean();

--- a/pkg/vault/contracts/test/VaultMock.sol
+++ b/pkg/vault/contracts/test/VaultMock.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.24;
 
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
@@ -587,17 +588,17 @@ contract VaultMock is IVaultMainMock, Vault {
     }
 
     function internalGetBufferUnderlyingSurplus(IERC4626 wrappedToken) external view returns (uint256) {
-        bytes32 bufferBalance = _bufferTokenBalances[IERC20(address(wrappedToken))];
+        bytes32 bufferBalance = _bufferTokenBalances[wrappedToken];
         return bufferBalance.getBufferUnderlyingSurplus(wrappedToken);
     }
 
     function internalGetBufferWrappedSurplus(IERC4626 wrappedToken) external view returns (uint256) {
-        bytes32 bufferBalance = _bufferTokenBalances[IERC20(address(wrappedToken))];
+        bytes32 bufferBalance = _bufferTokenBalances[wrappedToken];
         return bufferBalance.getBufferWrappedSurplus(wrappedToken);
     }
 
     function getBufferTokenBalancesBytes(IERC4626 wrappedToken) external view returns (bytes32) {
-        return _bufferTokenBalances[IERC20(address(wrappedToken))];
+        return _bufferTokenBalances[wrappedToken];
     }
 
     function manualUpdateReservesAfterWrapping(

--- a/pkg/vault/test/.contract-sizes/Vault
+++ b/pkg/vault/test/.contract-sizes/Vault
@@ -1,2 +1,2 @@
-Bytecode	23.816
-InitCode	25.092
+Bytecode	23.951
+InitCode	25.227

--- a/pkg/vault/test/foundry/BufferVaultPrimitive.t.sol
+++ b/pkg/vault/test/foundry/BufferVaultPrimitive.t.sol
@@ -338,7 +338,7 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
         assertEq(afterBalances.lp.dai, beforeBalances.lp.dai - underlyingAmountIn, "LP DAI balance is wrong");
         assertEq(afterBalances.lp.waDai, beforeBalances.lp.waDai - wrappedAmountIn, "LP waDAI balance is wrong");
 
-        assertEq(lpShares, vault.getBufferOwnerShares(IERC20(address(waDAI)), lp), "LP Buffer shares is wrong");
+        assertEq(lpShares, vault.getBufferOwnerShares(IERC4626(address(waDAI)), lp), "LP Buffer shares is wrong");
         assertEq(
             lpShares,
             underlyingAmountIn + waDAI.convertToAssets(wrappedAmountIn) - MIN_BPT,
@@ -407,7 +407,7 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
         assertEq(afterBalances.lp.dai, beforeBalances.lp.dai + underlyingRemoved, "LP DAI balance is wrong");
         assertEq(afterBalances.lp.waDai, beforeBalances.lp.waDai + wrappedRemoved, "LP waDAI balance is wrong");
 
-        assertEq(vault.getBufferOwnerShares(IERC20(address(waDAI)), lp), 0, "LP Buffer shares is wrong");
+        assertEq(vault.getBufferOwnerShares(IERC4626(address(waDAI)), lp), 0, "LP Buffer shares is wrong");
         // If math has rounding issues, the rounding occurs in favor of the vault with a max of 1 wei error.
         assertApproxEqAbs(
             lpShares,
@@ -433,7 +433,7 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
         vars.lp.dai = dai.balanceOf(lp);
         vars.lp.waDai = waDAI.balanceOf(lp);
 
-        (vars.buffer.dai, vars.buffer.waDai) = vault.getBufferBalance(IERC20(address(waDAI)));
+        (vars.buffer.dai, vars.buffer.waDai) = vault.getBufferBalance(IERC4626(address(waDAI)));
 
         vars.vault.dai = dai.balanceOf(address(vault));
         vars.vault.waDai = waDAI.balanceOf(address(vault));

--- a/pkg/vault/test/foundry/QueryERC4626Buffer.t.sol
+++ b/pkg/vault/test/foundry/QueryERC4626Buffer.t.sol
@@ -84,7 +84,11 @@ contract QueryERC4626BufferTest is BaseVaultTest {
 
         // Buffer should have the correct amount of issued shares.
         assertEq(vault.getBufferTotalShares(IERC4626(waDAI)), bufferAmount * 2, "Wrong issued shares of waDAI buffer");
-        assertEq(vault.getBufferTotalShares(IERC4626(waUSDC)), bufferAmount * 2, "Wrong issued shares of waUSDC buffer");
+        assertEq(
+            vault.getBufferTotalShares(IERC4626(waUSDC)),
+            bufferAmount * 2,
+            "Wrong issued shares of waUSDC buffer"
+        );
 
         uint256 baseBalance;
         uint256 wrappedBalance;

--- a/pkg/vault/test/foundry/QueryERC4626Buffer.t.sol
+++ b/pkg/vault/test/foundry/QueryERC4626Buffer.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { TokenConfig, TokenType } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
@@ -71,29 +72,29 @@ contract QueryERC4626BufferTest is BaseVaultTest {
 
         // LP should have correct amount of shares from buffer (invested amount in underlying minus burned "BPTs").
         assertEq(
-            vault.getBufferOwnerShares(IERC20(waDAI), lp),
+            vault.getBufferOwnerShares(IERC4626(waDAI), lp),
             bufferAmount * 2 - MIN_BPT,
             "Wrong share of waDAI buffer belonging to LP"
         );
         assertEq(
-            vault.getBufferOwnerShares(IERC20(waUSDC), lp),
+            vault.getBufferOwnerShares(IERC4626(waUSDC), lp),
             bufferAmount * 2 - MIN_BPT,
             "Wrong share of waUSDC buffer belonging to LP"
         );
 
         // Buffer should have the correct amount of issued shares.
-        assertEq(vault.getBufferTotalShares(IERC20(waDAI)), bufferAmount * 2, "Wrong issued shares of waDAI buffer");
-        assertEq(vault.getBufferTotalShares(IERC20(waUSDC)), bufferAmount * 2, "Wrong issued shares of waUSDC buffer");
+        assertEq(vault.getBufferTotalShares(IERC4626(waDAI)), bufferAmount * 2, "Wrong issued shares of waDAI buffer");
+        assertEq(vault.getBufferTotalShares(IERC4626(waUSDC)), bufferAmount * 2, "Wrong issued shares of waUSDC buffer");
 
         uint256 baseBalance;
         uint256 wrappedBalance;
 
         // The vault buffers should each have `bufferAmount` of their respective tokens.
-        (baseBalance, wrappedBalance) = vault.getBufferBalance(IERC20(waDAI));
+        (baseBalance, wrappedBalance) = vault.getBufferBalance(IERC4626(waDAI));
         assertEq(baseBalance, bufferAmount, "Wrong waDAI buffer balance for base token");
         assertEq(wrappedBalance, bufferAmount, "Wrong waDAI buffer balance for wrapped token");
 
-        (baseBalance, wrappedBalance) = vault.getBufferBalance(IERC20(waUSDC));
+        (baseBalance, wrappedBalance) = vault.getBufferBalance(IERC4626(waUSDC));
         assertEq(baseBalance, bufferAmount, "Wrong waUSDC buffer balance for base token");
         assertEq(wrappedBalance, bufferAmount, "Wrong waUSDC buffer balance for wrapped token");
     }

--- a/pkg/vault/test/foundry/SwapWithNonExistentBuffer.t.sol
+++ b/pkg/vault/test/foundry/SwapWithNonExistentBuffer.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { TokenConfig, TokenType, SwapKind } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
@@ -111,11 +112,11 @@ contract SwapWithNonExistentBufferTest is BaseVaultTest {
         uint256 wrappedBalance;
 
         // The vault buffers should each have `bufferAmount` of their respective tokens.
-        (baseBalance, wrappedBalance) = vault.getBufferBalance(IERC20(waDAI));
+        (baseBalance, wrappedBalance) = vault.getBufferBalance(IERC4626(waDAI));
         assertEq(baseBalance, 0, "Wrong waDAI buffer balance for base token");
         assertEq(wrappedBalance, 0, "Wrong waDAI buffer balance for wrapped token");
 
-        (baseBalance, wrappedBalance) = vault.getBufferBalance(IERC20(waUSDC));
+        (baseBalance, wrappedBalance) = vault.getBufferBalance(IERC4626(waUSDC));
         assertEq(baseBalance, 0, "Wrong waUSDC buffer balance for base token");
         assertEq(wrappedBalance, 0, "Wrong waUSDC buffer balance for wrapped token");
     }
@@ -215,11 +216,11 @@ contract SwapWithNonExistentBufferTest is BaseVaultTest {
         // Buffers should have 0 liquidity, since they were not initialized.
         uint256 baseBalance;
         uint256 wrappedBalance;
-        (baseBalance, wrappedBalance) = vault.getBufferBalance(IERC20(waDAI));
+        (baseBalance, wrappedBalance) = vault.getBufferBalance(IERC4626(waDAI));
         assertEq(baseBalance, 0, "DAI buffer pool base balance is not 0");
         assertEq(wrappedBalance, 0, "DAI buffer pool wrapped balance is not 0");
 
-        (baseBalance, wrappedBalance) = vault.getBufferBalance(IERC20(waUSDC));
+        (baseBalance, wrappedBalance) = vault.getBufferBalance(IERC4626(waUSDC));
         assertEq(baseBalance, 0, "USDC buffer pool base balance is not 0");
         assertEq(wrappedBalance, 0, "USDC buffer pool wrapped balance is not 0");
     }

--- a/pkg/vault/test/foundry/YieldBearingPoolBufferAsVaultPrimitive.t.sol
+++ b/pkg/vault/test/foundry/YieldBearingPoolBufferAsVaultPrimitive.t.sol
@@ -183,7 +183,11 @@ contract YieldBearingPoolBufferAsVaultPrimitiveTest is BaseVaultTest {
 
         // Buffer should have the correct amount of issued shares
         assertEq(vault.getBufferTotalShares(IERC4626(waDAI)), bufferAmount * 2, "Wrong issued shares of waDAI buffer");
-        assertEq(vault.getBufferTotalShares(IERC4626(waUSDC)), bufferAmount * 2, "Wrong issued shares of waUSDC buffer");
+        assertEq(
+            vault.getBufferTotalShares(IERC4626(waUSDC)),
+            bufferAmount * 2,
+            "Wrong issued shares of waUSDC buffer"
+        );
 
         uint256 baseBalance;
         uint256 wrappedBalance;

--- a/pkg/vault/test/foundry/YieldBearingPoolBufferAsVaultPrimitive.t.sol
+++ b/pkg/vault/test/foundry/YieldBearingPoolBufferAsVaultPrimitive.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { TokenConfig, TokenType, SwapKind } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
@@ -170,29 +171,29 @@ contract YieldBearingPoolBufferAsVaultPrimitiveTest is BaseVaultTest {
 
         // LP should have correct amount of shares from buffer (invested amount in underlying minus burned "BPTs")
         assertEq(
-            vault.getBufferOwnerShares(IERC20(waDAI), lp),
+            vault.getBufferOwnerShares(IERC4626(waDAI), lp),
             bufferAmount * 2 - MIN_BPT,
             "Wrong share of waDAI buffer belonging to LP"
         );
         assertEq(
-            vault.getBufferOwnerShares(IERC20(waUSDC), lp),
+            vault.getBufferOwnerShares(IERC4626(waUSDC), lp),
             bufferAmount * 2 - MIN_BPT,
             "Wrong share of waUSDC buffer belonging to LP"
         );
 
         // Buffer should have the correct amount of issued shares
-        assertEq(vault.getBufferTotalShares(IERC20(waDAI)), bufferAmount * 2, "Wrong issued shares of waDAI buffer");
-        assertEq(vault.getBufferTotalShares(IERC20(waUSDC)), bufferAmount * 2, "Wrong issued shares of waUSDC buffer");
+        assertEq(vault.getBufferTotalShares(IERC4626(waDAI)), bufferAmount * 2, "Wrong issued shares of waDAI buffer");
+        assertEq(vault.getBufferTotalShares(IERC4626(waUSDC)), bufferAmount * 2, "Wrong issued shares of waUSDC buffer");
 
         uint256 baseBalance;
         uint256 wrappedBalance;
 
         // The vault buffers should each have `bufferAmount` of their respective tokens.
-        (baseBalance, wrappedBalance) = vault.getBufferBalance(IERC20(waDAI));
+        (baseBalance, wrappedBalance) = vault.getBufferBalance(IERC4626(waDAI));
         assertEq(baseBalance, bufferAmount, "Wrong waDAI buffer balance for base token");
         assertEq(wrappedBalance, bufferAmount, "Wrong waDAI buffer balance for wrapped token");
 
-        (baseBalance, wrappedBalance) = vault.getBufferBalance(IERC20(waUSDC));
+        (baseBalance, wrappedBalance) = vault.getBufferBalance(IERC4626(waUSDC));
         assertEq(baseBalance, bufferAmount, "Wrong waUSDC buffer balance for base token");
         assertEq(wrappedBalance, bufferAmount, "Wrong waUSDC buffer balance for wrapped token");
     }
@@ -411,10 +412,10 @@ contract YieldBearingPoolBufferAsVaultPrimitiveTest is BaseVaultTest {
 
         uint256 underlyingBalance;
         uint256 wrappedBalance;
-        (underlyingBalance, wrappedBalance) = vault.getBufferBalance(IERC20(waDAI));
+        (underlyingBalance, wrappedBalance) = vault.getBufferBalance(IERC4626(waDAI));
         vars.bufferBalanceBeforeSwapDai = underlyingBalance;
         vars.bufferBalanceBeforeSwapWaDai = wrappedBalance;
-        (underlyingBalance, wrappedBalance) = vault.getBufferBalance(IERC20(waUSDC));
+        (underlyingBalance, wrappedBalance) = vault.getBufferBalance(IERC4626(waUSDC));
         vars.bufferBalanceBeforeSwapUsdc = underlyingBalance;
         vars.bufferBalanceBeforeSwapWaUsdc = wrappedBalance;
 
@@ -496,7 +497,7 @@ contract YieldBearingPoolBufferAsVaultPrimitiveTest is BaseVaultTest {
 
         uint256 underlyingBalance;
         uint256 wrappedBalance;
-        (underlyingBalance, wrappedBalance) = vault.getBufferBalance(IERC20(waDAI));
+        (underlyingBalance, wrappedBalance) = vault.getBufferBalance(IERC4626(waDAI));
         assertApproxEqAbs(
             underlyingBalance,
             vars.expectedBufferBalanceAfterSwapDai,
@@ -510,7 +511,7 @@ contract YieldBearingPoolBufferAsVaultPrimitiveTest is BaseVaultTest {
             "Wrong DAI buffer pool wrapped balance"
         );
 
-        (underlyingBalance, wrappedBalance) = vault.getBufferBalance(IERC20(waUSDC));
+        (underlyingBalance, wrappedBalance) = vault.getBufferBalance(IERC4626(waUSDC));
         assertApproxEqAbs(
             underlyingBalance,
             vars.expectedBufferBalanceAfterSwapUsdc,

--- a/pkg/vault/test/foundry/fork/YieldBearingPoolSwapBase.t.sol
+++ b/pkg/vault/test/foundry/fork/YieldBearingPoolSwapBase.t.sol
@@ -108,13 +108,13 @@ abstract contract YieldBearingPoolSwapBase is BaseVaultTest {
 
         // LP should have correct amount of shares from buffer (invested amount in underlying minus burned "BPTs")
         assertApproxEqAbs(
-            vault.getBufferOwnerShares(IERC20(ybToken1), lp),
+            vault.getBufferOwnerShares(ybToken1, lp),
             _token1BufferInitAmount * 2 - MIN_BPT,
             1,
             "Wrong share of ybToken1 buffer belonging to LP"
         );
         assertApproxEqAbs(
-            vault.getBufferOwnerShares(IERC20(ybToken2), lp),
+            vault.getBufferOwnerShares(ybToken2, lp),
             (_token2BufferInitAmount * 2) - MIN_BPT,
             1,
             "Wrong share of ybToken2 buffer belonging to LP"
@@ -122,13 +122,13 @@ abstract contract YieldBearingPoolSwapBase is BaseVaultTest {
 
         // Buffer should have the correct amount of issued shares
         assertApproxEqAbs(
-            vault.getBufferTotalShares(IERC20(ybToken1)),
+            vault.getBufferTotalShares(ybToken1),
             _token1BufferInitAmount * 2,
             1,
             "Wrong issued shares of ybToken1 buffer"
         );
         assertApproxEqAbs(
-            vault.getBufferTotalShares(IERC20(ybToken2)),
+            vault.getBufferTotalShares(ybToken2),
             (_token2BufferInitAmount * 2),
             1,
             "Wrong issued shares of ybToken2 buffer"
@@ -138,7 +138,7 @@ abstract contract YieldBearingPoolSwapBase is BaseVaultTest {
         uint256 wrappedBalance;
 
         // The vault buffers should each have `bufferAmount` of their respective tokens.
-        (underlyingBalance, wrappedBalance) = vault.getBufferBalance(IERC20(ybToken1));
+        (underlyingBalance, wrappedBalance) = vault.getBufferBalance(ybToken1);
         assertEq(underlyingBalance, _token1BufferInitAmount, "Wrong ybToken1 buffer balance for underlying token");
         assertEq(
             wrappedBalance,
@@ -146,7 +146,7 @@ abstract contract YieldBearingPoolSwapBase is BaseVaultTest {
             "Wrong ybToken1 buffer balance for wrapped token"
         );
 
-        (underlyingBalance, wrappedBalance) = vault.getBufferBalance(IERC20(ybToken2));
+        (underlyingBalance, wrappedBalance) = vault.getBufferBalance(ybToken2);
         assertEq(underlyingBalance, _token2BufferInitAmount, "Wrong ybToken2 buffer balance for underlying token");
         assertEq(
             wrappedBalance,
@@ -808,10 +808,10 @@ abstract contract YieldBearingPoolSwapBase is BaseVaultTest {
 
         uint256 underlyingBalance;
         uint256 wrappedBalance;
-        (underlyingBalance, wrappedBalance) = vault.getBufferBalance(IERC20(address(ybTokenIn)));
+        (underlyingBalance, wrappedBalance) = vault.getBufferBalance(ybTokenIn);
         vars.bufferBeforeSwapTokenIn = underlyingBalance;
         vars.bufferBeforeSwapYbTokenIn = wrappedBalance;
-        (underlyingBalance, wrappedBalance) = vault.getBufferBalance(IERC20(address(ybTokenOut)));
+        (underlyingBalance, wrappedBalance) = vault.getBufferBalance(ybTokenOut);
         vars.bufferBeforeSwapTokenOut = underlyingBalance;
         vars.bufferBeforeSwapYbTokenOut = wrappedBalance;
 

--- a/pkg/vault/test/foundry/mutation/vault/VaultAdmin.t.sol
+++ b/pkg/vault/test/foundry/mutation/vault/VaultAdmin.t.sol
@@ -296,17 +296,17 @@ contract VaultAdminMutationTest is BaseVaultTest {
 
     function testGetBufferOwnerSharesWhenNotVault() public {
         vm.expectRevert(IVaultErrors.NotVaultDelegateCall.selector);
-        vaultAdmin.getBufferOwnerShares(dai, alice);
+        vaultAdmin.getBufferOwnerShares(IERC4626(address(dai)), alice);
     }
 
     function testGetBufferTotalSharesWhenNotVault() public {
         vm.expectRevert(IVaultErrors.NotVaultDelegateCall.selector);
-        vaultAdmin.getBufferTotalShares(dai);
+        vaultAdmin.getBufferTotalShares(IERC4626(address(dai)));
     }
 
     function testGetBufferBalanceWhenNotVault() public {
         vm.expectRevert(IVaultErrors.NotVaultDelegateCall.selector);
-        vaultAdmin.getBufferBalance(dai);
+        vaultAdmin.getBufferBalance(IERC4626(address(dai)));
     }
 
     function testSetAuthorizerWhenNotAuthenticated() public {


### PR DESCRIPTION
# Description

We definitely require IERC4626 (at least our subset of it), so not using the type leads to a lot of unnecessary casting, and potential confusion. This changes it to use consistent types. Should have no effect on the actual code (casting is all just compiler syntax); not sure why the size apparently changed?

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
