### PR TITLE
Fix flaky weighted pool test

### DIFF
--- a/pkg/pool-weighted/test/foundry/WeightedPoolLimits.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedPoolLimits.t.sol
@@ -201,7 +201,7 @@ contract WeightedPoolLimitsTest is BaseVaultTest {
         vm.prank(bob);
         uint256[] memory actualAmountsIn = router.addLiquidityProportional(
             pool,
-            newAmountsIn,
+            [newAmountsIn[0] + DELTA, newAmountsIn[1] + DELTA].toMemoryArray(),
             expectedBptAmountOut,
             false,
             bytes("")


### PR DESCRIPTION
# Description

In some cases the amounts in is above the limits by a few wei; just bump the limit a bit.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A