### PR TITLE
Fix query add liquidity proportional parameters

### DIFF
--- a/pkg/interfaces/contracts/vault/IRouter.sol
+++ b/pkg/interfaces/contracts/vault/IRouter.sol
@@ -390,14 +390,12 @@ interface IRouter {
     /**
      * @notice Queries an `addLiquidityProportional` operation without actually executing it.
      * @param pool Address of the liquidity pool
-     * @param maxAmountsIn Maximum amounts of tokens to be added, sorted in token registration order
      * @param exactBptAmountOut Exact amount of pool tokens to be received
      * @param userData Additional (optional) data sent with the query request
      * @return amountsIn Expected amounts of tokens to add, sorted in token registration order
      */
     function queryAddLiquidityProportional(
         address pool,
-        uint256[] memory maxAmountsIn,
         uint256 exactBptAmountOut,
         bytes memory userData
     ) external returns (uint256[] memory amountsIn);

--- a/pkg/vault/contracts/Router.sol
+++ b/pkg/vault/contracts/Router.sol
@@ -738,10 +738,15 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
     /// @inheritdoc IRouter
     function queryAddLiquidityProportional(
         address pool,
-        uint256[] memory maxAmountsIn,
         uint256 exactBptAmountOut,
         bytes memory userData
     ) external saveSender returns (uint256[] memory amountsIn) {
+        uint256 numTokens = _vault.getPoolTokens(pool).length;
+        uint256[] memory maxAmountsIn = new uint256[](numTokens);
+        for (uint256 i = 0; i < numTokens; ++i) {
+            maxAmountsIn[i] = _MAX_AMOUNT;
+        }
+
         (amountsIn, , ) = abi.decode(
             _vault.quote(
                 abi.encodeWithSelector(

--- a/pkg/vault/test/.contract-sizes/Router
+++ b/pkg/vault/test/.contract-sizes/Router
@@ -1,2 +1,2 @@
-Bytecode	23.334
-InitCode	24.380
+Bytecode	23.554
+InitCode	24.606

--- a/pkg/vault/test/Queries.test.ts
+++ b/pkg/vault/test/Queries.test.ts
@@ -112,15 +112,13 @@ describe('Queries', function () {
 
   describe('addLiquidityProportional', () => {
     it('queries addLiquidityProportional correctly', async () => {
-      const amountsIn = await router
-        .connect(zero)
-        .queryAddLiquidityProportional.staticCall(pool, [DAI_AMOUNT_IN, USDC_AMOUNT_IN], BPT_AMOUNT, '0x');
+      const amountsIn = await router.connect(zero).queryAddLiquidityProportional.staticCall(pool, BPT_AMOUNT, '0x');
       expect(amountsIn).to.be.deep.eq([DAI_AMOUNT_IN, USDC_AMOUNT_IN]);
     });
 
     it('reverts if not a static call', async () => {
       await expect(
-        router.queryAddLiquidityProportional.staticCall(pool, [DAI_AMOUNT_IN, USDC_AMOUNT_IN], BPT_AMOUNT, '0x')
+        router.queryAddLiquidityProportional.staticCall(pool, BPT_AMOUNT, '0x')
       ).to.be.revertedWithCustomError(vault, 'NotStaticCall');
     });
   });

--- a/pkg/vault/test/foundry/RouterQueriesDiffRates.t.sol
+++ b/pkg/vault/test/foundry/RouterQueriesDiffRates.t.sol
@@ -147,7 +147,6 @@ contract RouterQueriesDiffRatesTest is BaseVaultTest {
         _prankStaticCall();
         uint256[] memory queryAmountsIn = router.queryAddLiquidityProportional(
             pool,
-            expectedAmountsIn,
             exactBptAmountOut,
             bytes("")
         );

--- a/pkg/vault/test/foundry/RouterQueriesDiffRates.t.sol
+++ b/pkg/vault/test/foundry/RouterQueriesDiffRates.t.sol
@@ -145,11 +145,7 @@ contract RouterQueriesDiffRatesTest is BaseVaultTest {
 
         uint256 snapshotId = vm.snapshot();
         _prankStaticCall();
-        uint256[] memory queryAmountsIn = router.queryAddLiquidityProportional(
-            pool,
-            exactBptAmountOut,
-            bytes("")
-        );
+        uint256[] memory queryAmountsIn = router.queryAddLiquidityProportional(pool, exactBptAmountOut, bytes(""));
 
         vm.revertTo(snapshotId);
 

--- a/pkg/vault/test/foundry/mutation/router/Router.t.sol
+++ b/pkg/vault/test/foundry/mutation/router/Router.t.sol
@@ -244,7 +244,7 @@ contract RouterMutationTest is BaseVaultTest {
 
         // tx.origin needs to be 0x0 for the transaction to be considered a query
         vm.prank(address(bob), address(0));
-        router.queryAddLiquidityProportional(pool, amountsIn, poolInitAmount.mulDown(2e18), bytes(""));
+        router.queryAddLiquidityProportional(pool, poolInitAmount.mulDown(2e18), bytes(""));
 
         assertEq(PoolHooksMock(poolHooksContract).getSavedSender(), bob, "saveSender not implemented");
     }


### PR DESCRIPTION
# Description

Max amounts in is not needed for the query.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A