### PR TITLE
Fix fee collection (1: using credit)

### DIFF
--- a/pkg/interfaces/contracts/vault/IProtocolFeeController.sol
+++ b/pkg/interfaces/contracts/vault/IProtocolFeeController.sol
@@ -207,22 +207,6 @@ interface IProtocolFeeController {
     ) external returns (uint256 aggregateSwapFeePercentage, uint256 aggregateYieldFeePercentage);
 
     /**
-     * @notice Called by the Vault when aggregate swap or yield fees are collected.
-     * @dev This must be called from the Vault, during permissionless collection. Note that since charging protocol
-     * fees (i.e., distributing tokens between pool and fee balances) occurs in the Vault, but fee collection
-     * happens in the ProtocolFeeController, the swap fees reported here may encompass multiple operations.
-     *
-     * @param pool The address of the pool on which the swap fees were charged
-     * @param swapFeeAmounts An array parallel to the pool tokens, with the swap fees collected in each token
-     * @param yieldFeeAmounts An array parallel to the pool tokens, with the yield fees collected in each token
-     */
-    function receiveAggregateFees(
-        address pool,
-        uint256[] memory swapFeeAmounts,
-        uint256[] memory yieldFeeAmounts
-    ) external;
-
-    /**
      * @notice Set the global protocol swap fee percentage, used by standard pools.
      * @param newProtocolSwapFeePercentage The new protocol swap fee percentage
      */

--- a/pkg/interfaces/contracts/vault/IProtocolFeeController.sol
+++ b/pkg/interfaces/contracts/vault/IProtocolFeeController.sol
@@ -94,6 +94,9 @@ interface IProtocolFeeController {
     /// @dev Returns the main Vault address.
     function vault() external view returns (IVault);
 
+    /// @dev Collects aggregate fees from the Vault for a given pool.
+    function collectAggregateFees(address pool) external;
+
     /**
      * @notice Getter for the current global protocol swap fee.
      * @return protocolSwapFeePercentage The global protocol swap fee percentage

--- a/pkg/interfaces/contracts/vault/IVaultAdmin.sol
+++ b/pkg/interfaces/contracts/vault/IVaultAdmin.sol
@@ -119,7 +119,9 @@ interface IVaultAdmin {
      * @dev Fees are sent to the ProtocolFeeController address.
      * @param pool The pool on which all aggregate fees should be collected
      */
-    function collectAggregateFees(address pool) external;
+    function collectAggregateFees(
+        address pool
+    ) external returns (uint256[] memory totalSwapFees, uint256[] memory totalYieldFees);
 
     /**
      * @notice Update an aggregate swap fee percentage.

--- a/pkg/interfaces/contracts/vault/IVaultAdmin.sol
+++ b/pkg/interfaces/contracts/vault/IVaultAdmin.sol
@@ -118,10 +118,12 @@ interface IVaultAdmin {
      * @notice Collects accumulated aggregate swap and yield fees for the specified pool.
      * @dev Fees are sent to the ProtocolFeeController address.
      * @param pool The pool on which all aggregate fees should be collected
+     * @return swapFeeAmounts An array with the total swap fees collected, sorted in token registration order
+     * @return yieldFeeAmounts An array with the total yield fees collected, sorted in token registration order
      */
     function collectAggregateFees(
         address pool
-    ) external returns (uint256[] memory totalSwapFees, uint256[] memory totalYieldFees);
+    ) external returns (uint256[] memory swapFeeAmounts, uint256[] memory yieldFeeAmounts);
 
     /**
      * @notice Update an aggregate swap fee percentage.

--- a/pkg/vault/contracts/ProtocolFeeController.sol
+++ b/pkg/vault/contracts/ProtocolFeeController.sol
@@ -161,6 +161,11 @@ contract ProtocolFeeController is
         getVault().unlock(abi.encodeWithSelector(ProtocolFeeController.collectAggregateFeesHook.selector, pool));
     }
 
+    /**
+     * @dev Copy and zero out the `aggregateFeeAmounts` collected in the Vault accounting, supplying credit
+     * for each token. Then have the Vault transfer tokens to this contract, debiting each token for the amount
+     * transferred so that the transaction settles when the hook returns.
+     */
     function collectAggregateFeesHook(address pool) external onlyVault {
         (uint256[] memory totalSwapFees, uint256[] memory totalYieldFees) = getVault().collectAggregateFees(pool);
         _receiveAggregateFees(pool, totalSwapFees, totalYieldFees);
@@ -328,8 +333,8 @@ contract ProtocolFeeController is
      * happens in the ProtocolFeeController, the swap fees reported here may encompass multiple operations.
      *
      * @param pool The address of the pool on which the swap fees were charged
-     * @param swapFeeAmounts An array parallel to the pool tokens, with the swap fees collected in each token
-     * @param yieldFeeAmounts An array parallel to the pool tokens, with the yield fees collected in each token
+     * @param swapFeeAmounts An array with the total swap fees collected, sorted in token registration order
+     * @param yieldFeeAmounts An array with the total yield fees collected, sorted in token registration order
      */
     function _receiveAggregateFees(
         address pool,

--- a/pkg/vault/contracts/VaultAdmin.sol
+++ b/pkg/vault/contracts/VaultAdmin.sol
@@ -276,6 +276,7 @@ contract VaultAdmin is IVaultAdmin, VaultCommon, Authentication {
         public
         onlyVaultDelegateCall
         onlyWhenUnlocked
+        onlyProtocolFeeController
         withRegisteredPool(pool)
         returns (uint256[] memory totalSwapFees, uint256[] memory totalYieldFees)
     {

--- a/pkg/vault/contracts/VaultAdmin.sol
+++ b/pkg/vault/contracts/VaultAdmin.sol
@@ -270,12 +270,20 @@ contract VaultAdmin is IVaultAdmin, VaultCommon, Authentication {
     }
 
     /// @inheritdoc IVaultAdmin
-    function collectAggregateFees(address pool) public onlyVaultDelegateCall onlyWhenUnlocked withRegisteredPool(pool) {
+    function collectAggregateFees(
+        address pool
+    )
+        public
+        onlyVaultDelegateCall
+        onlyWhenUnlocked
+        withRegisteredPool(pool)
+        returns (uint256[] memory totalSwapFees, uint256[] memory totalYieldFees)
+    {
         IERC20[] memory poolTokens = _vault.getPoolTokens(pool);
         uint256 numTokens = poolTokens.length;
 
-        uint256[] memory totalSwapFees = new uint256[](numTokens);
-        uint256[] memory totalYieldFees = new uint256[](numTokens);
+        totalSwapFees = new uint256[](numTokens);
+        totalYieldFees = new uint256[](numTokens);
 
         for (uint256 i = 0; i < poolTokens.length; ++i) {
             IERC20 token = poolTokens[i];
@@ -288,8 +296,6 @@ contract VaultAdmin is IVaultAdmin, VaultCommon, Authentication {
                 _supplyCredit(token, totalSwapFees[i] + totalYieldFees[i]);
             }
         }
-
-        _protocolFeeController.receiveAggregateFees(pool, totalSwapFees, totalYieldFees);
     }
 
     /// @inheritdoc IVaultAdmin

--- a/pkg/vault/contracts/VaultAdmin.sol
+++ b/pkg/vault/contracts/VaultAdmin.sol
@@ -270,9 +270,8 @@ contract VaultAdmin is IVaultAdmin, VaultCommon, Authentication {
     }
 
     /// @inheritdoc IVaultAdmin
-    function collectAggregateFees(address pool) public onlyVaultDelegateCall nonReentrant withRegisteredPool(pool) {
+    function collectAggregateFees(address pool) public onlyVaultDelegateCall onlyWhenUnlocked withRegisteredPool(pool) {
         IERC20[] memory poolTokens = _vault.getPoolTokens(pool);
-        address feeController = address(_protocolFeeController);
         uint256 numTokens = poolTokens.length;
 
         uint256[] memory totalSwapFees = new uint256[](numTokens);
@@ -284,10 +283,9 @@ contract VaultAdmin is IVaultAdmin, VaultCommon, Authentication {
             (totalSwapFees[i], totalYieldFees[i]) = _aggregateFeeAmounts[pool][token].fromPackedBalance();
 
             if (totalSwapFees[i] > 0 || totalYieldFees[i] > 0) {
-                // The ProtocolFeeController will pull tokens from the Vault.
-                token.forceApprove(feeController, totalSwapFees[i] + totalYieldFees[i]);
-
+                // Supply credit for the total amount of fees.
                 _aggregateFeeAmounts[pool][token] = 0;
+                _supplyCredit(token, totalSwapFees[i] + totalYieldFees[i]);
             }
         }
 

--- a/pkg/vault/contracts/VaultExplorer.sol
+++ b/pkg/vault/contracts/VaultExplorer.sol
@@ -292,7 +292,7 @@ contract VaultExplorer is IVaultExplorer {
 
     /// @inheritdoc IVaultExplorer
     function collectAggregateFees(address pool) external {
-        return _vault.collectAggregateFees(pool);
+        return _vault.getProtocolFeeController().collectAggregateFees(pool);
     }
 
     /*******************************************************************************

--- a/pkg/vault/test/.contract-sizes/VaultAdmin
+++ b/pkg/vault/test/.contract-sizes/VaultAdmin
@@ -1,2 +1,2 @@
-Bytecode	12.354
-InitCode	13.386
+Bytecode	11.668
+InitCode	12.700

--- a/pkg/vault/test/.contract-sizes/VaultAdmin
+++ b/pkg/vault/test/.contract-sizes/VaultAdmin
@@ -1,2 +1,2 @@
-Bytecode	11.668
-InitCode	12.700
+Bytecode	11.419
+InitCode	12.451

--- a/pkg/vault/test/foundry/ProtocolFeeController.t.sol
+++ b/pkg/vault/test/foundry/ProtocolFeeController.t.sol
@@ -625,7 +625,7 @@ contract ProtocolFeeControllerTest is BaseVaultTest {
         uint256 creatorBalanceDAIBefore = dai.balanceOf(lp);
         uint256 creatorBalanceUSDCBefore = usdc.balanceOf(lp);
 
-        vault.collectAggregateFees(pool);
+        feeController.collectAggregateFees(pool);
         feeController.withdrawPoolCreatorFees(pool);
 
         assertEq(
@@ -712,7 +712,7 @@ contract ProtocolFeeControllerTest is BaseVaultTest {
             )
         );
         // Move them to the fee controller.
-        vault.collectAggregateFees(pool);
+        feeController.collectAggregateFees(pool);
 
         // Now the fee controller should have them - and the Vault should be zero.
         assertEq(vault.getAggregateSwapFeeAmount(pool, dai), 0, "Non-zero post-collection DAI protocol swap fees");

--- a/pkg/vault/test/foundry/ProtocolFeeController.t.sol
+++ b/pkg/vault/test/foundry/ProtocolFeeController.t.sol
@@ -13,6 +13,7 @@ import { PoolConfig, FEE_SCALING_FACTOR } from "@balancer-labs/v3-interfaces/con
 
 import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
 
+import { ProtocolFeeController } from "../../contracts/ProtocolFeeController.sol";
 import { ProtocolFeeControllerMock } from "../../contracts/test/ProtocolFeeControllerMock.sol";
 import { PoolMock } from "../../contracts/test/PoolMock.sol";
 
@@ -704,12 +705,7 @@ contract ProtocolFeeControllerTest is BaseVaultTest {
 
         vm.expectCall(
             address(feeController),
-            abi.encodeWithSelector(
-                IProtocolFeeController.receiveAggregateFees.selector,
-                pool,
-                swapAmounts,
-                yieldAmounts
-            )
+            abi.encodeWithSelector(ProtocolFeeController.collectAggregateFeesHook.selector, pool)
         );
         // Move them to the fee controller.
         feeController.collectAggregateFees(pool);

--- a/pkg/vault/test/foundry/ProtocolFeeController.t.sol
+++ b/pkg/vault/test/foundry/ProtocolFeeController.t.sol
@@ -691,6 +691,9 @@ contract ProtocolFeeControllerTest is BaseVaultTest {
             "Wrong USDC protocol yield fees"
         );
 
+        uint256 reservesOfDaiBeforeCollect = vault.getReservesOf(dai);
+        uint256 reservesOfUsdcBeforeCollect = vault.getReservesOf(usdc);
+
         // Collecting fees will emit events, and call `receiveAggregateFees`.
         vm.expectEmit();
         emit IProtocolFeeController.ProtocolSwapFeeCollected(pool, dai, PROTOCOL_SWAP_FEE_AMOUNT);
@@ -721,6 +724,18 @@ contract ProtocolFeeControllerTest is BaseVaultTest {
 
         uint256[] memory protocolFeeAmounts = feeController.getProtocolFeeAmounts(pool);
         uint256[] memory poolCreatorFeeAmounts = feeController.getPoolCreatorFeeAmounts(pool);
+
+        // Check reserves
+        assertEq(
+            vault.getReservesOf(dai),
+            reservesOfDaiBeforeCollect - protocolFeeAmounts[daiIdx] - poolCreatorFeeAmounts[daiIdx],
+            "DAI: Incorrect Vault reserves"
+        );
+        assertEq(
+            vault.getReservesOf(usdc),
+            reservesOfUsdcBeforeCollect - protocolFeeAmounts[usdcIdx] - poolCreatorFeeAmounts[usdcIdx],
+            "USDC: Incorrect Vault reserves"
+        );
 
         uint256 aggregateSwapFeePercentage = feeController.computeAggregateFeePercentage(
             MAX_PROTOCOL_SWAP_FEE_PCT,

--- a/pkg/vault/test/foundry/VaultSwap.t.sol
+++ b/pkg/vault/test/foundry/VaultSwap.t.sol
@@ -424,7 +424,7 @@ contract VaultSwapTest is BaseVaultTest {
         );
 
         IProtocolFeeController feeController = vault.getProtocolFeeController();
-        vault.collectAggregateFees(pool);
+        feeController.collectAggregateFees(pool);
         uint256[] memory feeAmounts = feeController.getProtocolFeeAmounts(pool);
 
         authorizer.grantRole(

--- a/pkg/vault/test/foundry/VaultSwap.t.sol
+++ b/pkg/vault/test/foundry/VaultSwap.t.sol
@@ -423,9 +423,22 @@ contract VaultSwapTest is BaseVaultTest {
             bytes("")
         );
 
-        IProtocolFeeController feeController = vault.getProtocolFeeController();
+        uint256 reservesOfDaiBeforeCollect = vault.getReservesOf(dai);
+        uint256 reservesOfUsdcBeforeCollect = vault.getReservesOf(usdc);
+
         feeController.collectAggregateFees(pool);
         uint256[] memory feeAmounts = feeController.getProtocolFeeAmounts(pool);
+
+        assertEq(
+            vault.getReservesOf(dai),
+            reservesOfDaiBeforeCollect - feeAmounts[daiIdx],
+            "DAI: Incorrect Vault reserves"
+        );
+        assertEq(
+            vault.getReservesOf(usdc),
+            reservesOfUsdcBeforeCollect - feeAmounts[usdcIdx],
+            "USDC: Incorrect Vault reserves"
+        );
 
         authorizer.grantRole(
             IAuthentication(address(feeController)).getActionId(IProtocolFeeController.withdrawProtocolFees.selector),

--- a/pkg/vault/test/foundry/mutation/vault/VaultAdmin.t.sol
+++ b/pkg/vault/test/foundry/mutation/vault/VaultAdmin.t.sol
@@ -140,7 +140,13 @@ contract VaultAdminMutationTest is BaseVaultTest {
         vaultAdmin.collectAggregateFees(pool);
     }
 
+    function testCollectAggregateFeesWhenNotUnlocked() public {
+        vm.expectRevert(IVaultErrors.VaultIsNotUnlocked.selector);
+        vault.collectAggregateFees(address(0));
+    }
+
     function testCollectAggregateFeesWithoutRegisteredPool() public {
+        vault.manualSetIsUnlocked(true);
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolNotRegistered.selector, address(0)));
         vault.collectAggregateFees(address(0));
     }

--- a/pkg/vault/test/foundry/mutation/vault/VaultAdmin.t.sol
+++ b/pkg/vault/test/foundry/mutation/vault/VaultAdmin.t.sol
@@ -145,8 +145,15 @@ contract VaultAdminMutationTest is BaseVaultTest {
         vault.collectAggregateFees(address(0));
     }
 
+    function testCollectAggregateFeesWhenNotProtocolFeeController() public {
+        vault.manualSetIsUnlocked(true);
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        vault.collectAggregateFees(address(0));
+    }
+
     function testCollectAggregateFeesWithoutRegisteredPool() public {
         vault.manualSetIsUnlocked(true);
+        vm.prank(address(vault.getProtocolFeeController()));
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolNotRegistered.selector, address(0)));
         vault.collectAggregateFees(address(0));
     }


### PR DESCRIPTION
# Description

In the current `main` we're giving the `ProtocolFeeController` a special privilege to pull tokens out of the vault, since we're approving it to pull tokens out in `collectAggregateFees`. The problem here is that the reserves need to be updated as well when doing this.

The mechanism to send tokens out of the vault properly is being used elsewhere extensively, and it involves supplying credit and then settling. This PR applies the same pattern to `collectAggregateFees`.

The result is a code that is a bit more complex on the fee controller side. But it eliminates alternate ways of pulling tokens out of the vault, and associated errors that may arise from them.

Tests WIP.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #853 