### PR TITLE
Fix fee collection (2: update reserves)

### DIFF
--- a/pkg/vault/contracts/VaultAdmin.sol
+++ b/pkg/vault/contracts/VaultAdmin.sol
@@ -284,10 +284,12 @@ contract VaultAdmin is IVaultAdmin, VaultCommon, Authentication {
             (totalSwapFees[i], totalYieldFees[i]) = _aggregateFeeAmounts[pool][token].fromPackedBalance();
 
             if (totalSwapFees[i] > 0 || totalYieldFees[i] > 0) {
+                uint256 totalFees = totalSwapFees[i] + totalYieldFees[i];
                 // The ProtocolFeeController will pull tokens from the Vault.
-                token.forceApprove(feeController, totalSwapFees[i] + totalYieldFees[i]);
+                token.forceApprove(feeController, totalFees);
 
                 _aggregateFeeAmounts[pool][token] = 0;
+                _reservesOf[token] -= totalFees;
             }
         }
 

--- a/pkg/vault/test/foundry/ProtocolFeeController.t.sol
+++ b/pkg/vault/test/foundry/ProtocolFeeController.t.sol
@@ -690,6 +690,10 @@ contract ProtocolFeeControllerTest is BaseVaultTest {
             "Wrong USDC protocol yield fees"
         );
 
+        // Get reserves
+        uint256 reservesOfDaiBeforeCollect = vault.getReservesOf(dai);
+        uint256 reservesOfUsdcBeforeCollect = vault.getReservesOf(usdc);
+
         // Collecting fees will emit events, and call `receiveAggregateFees`.
         vm.expectEmit();
         emit IProtocolFeeController.ProtocolSwapFeeCollected(pool, dai, PROTOCOL_SWAP_FEE_AMOUNT);
@@ -725,6 +729,18 @@ contract ProtocolFeeControllerTest is BaseVaultTest {
 
         uint256[] memory protocolFeeAmounts = feeController.getProtocolFeeAmounts(pool);
         uint256[] memory poolCreatorFeeAmounts = feeController.getPoolCreatorFeeAmounts(pool);
+
+        // Check reserves
+        assertEq(
+            vault.getReservesOf(dai),
+            reservesOfDaiBeforeCollect - protocolFeeAmounts[daiIdx] - poolCreatorFeeAmounts[daiIdx],
+            "DAI: Incorrect Vault reserves"
+        );
+        assertEq(
+            vault.getReservesOf(usdc),
+            reservesOfUsdcBeforeCollect - protocolFeeAmounts[usdcIdx] - poolCreatorFeeAmounts[usdcIdx],
+            "USDC: Incorrect Vault reserves"
+        );
 
         uint256 aggregateSwapFeePercentage = feeController.computeAggregateFeePercentage(
             MAX_PROTOCOL_SWAP_FEE_PCT,

--- a/pkg/vault/test/foundry/VaultSwap.t.sol
+++ b/pkg/vault/test/foundry/VaultSwap.t.sol
@@ -424,8 +424,20 @@ contract VaultSwapTest is BaseVaultTest {
         );
 
         IProtocolFeeController feeController = vault.getProtocolFeeController();
+        uint256 reservesOfDaiBeforeCollect = vault.getReservesOf(dai);
+        uint256 reservesOfUsdcBeforeCollect = vault.getReservesOf(usdc);
         vault.collectAggregateFees(pool);
         uint256[] memory feeAmounts = feeController.getProtocolFeeAmounts(pool);
+        assertEq(
+            vault.getReservesOf(dai),
+            reservesOfDaiBeforeCollect - feeAmounts[daiIdx],
+            "DAI: Incorrect Vault reserves"
+        );
+        assertEq(
+            vault.getReservesOf(usdc),
+            reservesOfUsdcBeforeCollect - feeAmounts[usdcIdx],
+            "USDC: Incorrect Vault reserves"
+        );
 
         authorizer.grantRole(
             IAuthentication(address(feeController)).getActionId(IProtocolFeeController.withdrawProtocolFees.selector),


### PR DESCRIPTION
# Description

Alternative to #857.
This one keeps the current fee controller privilege to alter the reserves outside the credit / debt mechanism.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #853