### PR TITLE
Non payable quote

### DIFF
--- a/pkg/interfaces/contracts/vault/IVaultExtension.sol
+++ b/pkg/interfaces/contracts/vault/IVaultExtension.sol
@@ -386,7 +386,7 @@ interface IVaultExtension {
      * @param data Contains function signature and args to be passed to the msg.sender
      * @return result Resulting data from the call
      */
-    function quote(bytes calldata data) external payable returns (bytes memory result);
+    function quote(bytes calldata data) external returns (bytes memory result);
 
     /**
      * @notice Performs a callback on msg.sender with arguments provided in `data`.
@@ -403,7 +403,7 @@ interface IVaultExtension {
      *
      * @param data Contains function signature and args to be passed to the msg.sender
      */
-    function quoteAndRevert(bytes calldata data) external payable;
+    function quoteAndRevert(bytes calldata data) external;
 
     /**
      * @notice Checks if the queries enabled on the Vault.

--- a/pkg/vault/contracts/VaultExtension.sol
+++ b/pkg/vault/contracts/VaultExtension.sol
@@ -840,15 +840,15 @@ contract VaultExtension is IVaultExtension, VaultCommon, Proxy {
     }
 
     /// @inheritdoc IVaultExtension
-    function quote(bytes calldata data) external payable query onlyVaultDelegateCall returns (bytes memory result) {
+    function quote(bytes calldata data) external query onlyVaultDelegateCall returns (bytes memory result) {
         // Forward the incoming call to the original sender of this transaction.
-        return (msg.sender).functionCallWithValue(data, msg.value);
+        return (msg.sender).functionCall(data);
     }
 
     /// @inheritdoc IVaultExtension
-    function quoteAndRevert(bytes calldata data) external payable query onlyVaultDelegateCall {
+    function quoteAndRevert(bytes calldata data) external query onlyVaultDelegateCall {
         // Forward the incoming call to the original sender of this transaction.
-        (bool success, bytes memory result) = (msg.sender).call{ value: msg.value }(data);
+        (bool success, bytes memory result) = (msg.sender).call(data);
         if (success) {
             // This will only revert if result is empty and sender account has no code.
             Address.verifyCallResultFromTarget(msg.sender, success, result);

--- a/pkg/vault/test/.contract-sizes/VaultAdmin
+++ b/pkg/vault/test/.contract-sizes/VaultAdmin
@@ -1,2 +1,2 @@
-Bytecode	11.419
-InitCode	12.451
+Bytecode	11.427
+InitCode	12.459

--- a/pkg/vault/test/.contract-sizes/VaultExtension
+++ b/pkg/vault/test/.contract-sizes/VaultExtension
@@ -1,2 +1,2 @@
-Bytecode	20.176
-InitCode	21.346
+Bytecode	20.154
+InitCode	21.324


### PR DESCRIPTION
# Description

The Vault cannot receive ETH. PR #663 enforced this on `unlock`; we can do the same for `quote` and `quoteAndRevert`.

Only the Router and BatchRouter contracts can receive ETH; all native wrapping/unwrapping is done there.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [X] Optimization: [ ] gas / [X] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Resolves #862 
Closes #187 
