### PR TITLE
Use sender for buffer add liquidity + variable name refactor

### DIFF
--- a/pkg/interfaces/contracts/vault/IRouter.sol
+++ b/pkg/interfaces/contracts/vault/IRouter.sol
@@ -317,16 +317,13 @@ interface IRouter {
      * @param wrappedToken Address of the wrapped token that implements IERC4626
      * @param amountUnderlyingRaw Amount of underlying tokens that will be deposited into the buffer
      * @param amountWrappedRaw Amount of wrapped tokens that will be deposited into the buffer
-     * @param sharesOwner Address that will own the liquidity. Only this contract will be able to remove liquidity
-     * from the buffer
      * @return issuedShares the amount of tokens sharesOwner has in the buffer, denominated in underlying tokens
      * (This is the BPT of the vault's internal ERC4626 buffers)
      */
     function addLiquidityToBuffer(
         IERC4626 wrappedToken,
         uint256 amountUnderlyingRaw,
-        uint256 amountWrappedRaw,
-        address sharesOwner
+        uint256 amountWrappedRaw
     ) external returns (uint256 issuedShares);
 
     /**

--- a/pkg/vault/contracts/Router.sol
+++ b/pkg/vault/contracts/Router.sol
@@ -648,8 +648,7 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
     function addLiquidityToBuffer(
         IERC4626 wrappedToken,
         uint256 amountUnderlyingRaw,
-        uint256 amountWrappedRaw,
-        address sharesOwner
+        uint256 amountWrappedRaw
     ) external returns (uint256 issuedShares) {
         return
             abi.decode(
@@ -659,7 +658,7 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
                         wrappedToken,
                         amountUnderlyingRaw,
                         amountWrappedRaw,
-                        sharesOwner
+                        msg.sender
                     )
                 ),
                 (uint256)

--- a/pkg/vault/test/foundry/BatchRouterERC4626Pool.t.sol
+++ b/pkg/vault/test/foundry/BatchRouterERC4626Pool.t.sol
@@ -402,6 +402,6 @@ contract BatchRouterERC4626PoolTest is BaseERC4626BufferTest {
     function testInvalidUnderlyingToken() public {
         vm.expectRevert(IVaultErrors.InvalidUnderlyingTokenAsset.selector);
         vm.prank(lp);
-        router.addLiquidityToBuffer(waInvalid, bufferInitialAmount, bufferInitialAmount, lp);
+        router.addLiquidityToBuffer(waInvalid, bufferInitialAmount, bufferInitialAmount);
     }
 }

--- a/pkg/vault/test/foundry/BufferVaultPrimitive.t.sol
+++ b/pkg/vault/test/foundry/BufferVaultPrimitive.t.sol
@@ -103,7 +103,7 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
 
         // Add Liquidity with the right asset.
         vm.prank(lp);
-        router.addLiquidityToBuffer(IERC4626(address(waDAI)), _wrapAmount, _wrapAmount, lp);
+        router.addLiquidityToBuffer(IERC4626(address(waDAI)), _wrapAmount, _wrapAmount);
 
         // Change Asset to the wrong asset.
         waDAI.setAsset(usdc);
@@ -314,7 +314,7 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
 
     function testDisableVaultBuffer() public {
         vm.prank(lp);
-        router.addLiquidityToBuffer(IERC4626(address(waDAI)), _wrapAmount, _wrapAmount, lp);
+        router.addLiquidityToBuffer(IERC4626(address(waDAI)), _wrapAmount, _wrapAmount);
 
         vm.prank(admin);
         IVaultAdmin(address(vault)).pauseVaultBuffers();
@@ -334,7 +334,7 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
         batchRouter.swapExactIn(paths, MAX_UINT256, false, bytes(""));
 
         vm.expectRevert(IVaultErrors.VaultBuffersArePaused.selector);
-        router.addLiquidityToBuffer(IERC4626(address(waDAI)), _wrapAmount, _wrapAmount, lp);
+        router.addLiquidityToBuffer(IERC4626(address(waDAI)), _wrapAmount, _wrapAmount);
 
         // Remove liquidity is supposed to pass even with buffers paused, so revert is not expected.
         router.removeLiquidityFromBuffer(IERC4626(address(waDAI)), _wrapAmount);
@@ -360,7 +360,7 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
         uint256 wrappedAmountIn = _wrapAmount.mulDown(2e18);
 
         vm.prank(lp);
-        uint256 lpShares = router.addLiquidityToBuffer(waDAI, underlyingAmountIn, wrappedAmountIn, lp);
+        uint256 lpShares = router.addLiquidityToBuffer(waDAI, underlyingAmountIn, wrappedAmountIn);
 
         BufferAndLPBalances memory afterBalances = _measureBuffer();
 
@@ -409,7 +409,7 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
         uint256 wrappedAmountIn = _wrapAmount.mulDown(2e18);
 
         vm.prank(lp);
-        uint256 lpShares = router.addLiquidityToBuffer(waDAI, underlyingAmountIn, wrappedAmountIn, lp);
+        uint256 lpShares = router.addLiquidityToBuffer(waDAI, underlyingAmountIn, wrappedAmountIn);
 
         BufferAndLPBalances memory beforeBalances = _measureBuffer();
 

--- a/pkg/vault/test/foundry/VaultExplorer.t.sol
+++ b/pkg/vault/test/foundry/VaultExplorer.t.sol
@@ -767,7 +767,7 @@ contract VaultExplorerTest is BaseVaultTest {
 
         uint256 depositAmount = 100e18;
 
-        router.addLiquidityToBuffer(IERC4626(address(waDAI)), depositAmount, depositAmount, lp);
+        router.addLiquidityToBuffer(IERC4626(address(waDAI)), depositAmount, depositAmount);
         vm.stopPrank();
     }
 }

--- a/pkg/vault/test/foundry/YieldBearingPoolBufferAsVaultPrimitive.t.sol
+++ b/pkg/vault/test/foundry/YieldBearingPoolBufferAsVaultPrimitive.t.sol
@@ -38,6 +38,7 @@ contract YieldBearingPoolBufferAsVaultPrimitiveTest is BaseERC4626BufferTest {
     }
 
     function testAddLiquidityEvents() public {
+        vm.startPrank(lp);
         // Can add the same amount again, since twice as much was minted.
         vm.expectEmit();
         emit IVaultEvents.LiquidityAddedToBuffer(
@@ -47,7 +48,7 @@ contract YieldBearingPoolBufferAsVaultPrimitiveTest is BaseERC4626BufferTest {
             bufferInitialAmount,
             bufferInitialAmount * 2
         );
-        router.addLiquidityToBuffer(waDAI, bufferInitialAmount, bufferInitialAmount, lp);
+        router.addLiquidityToBuffer(waDAI, bufferInitialAmount, bufferInitialAmount);
 
         vm.expectEmit();
         emit IVaultEvents.LiquidityAddedToBuffer(
@@ -57,7 +58,8 @@ contract YieldBearingPoolBufferAsVaultPrimitiveTest is BaseERC4626BufferTest {
             bufferInitialAmount,
             bufferInitialAmount * 2
         );
-        router.addLiquidityToBuffer(waUSDC, bufferInitialAmount, bufferInitialAmount, lp);
+        router.addLiquidityToBuffer(waUSDC, bufferInitialAmount, bufferInitialAmount);
+        vm.stopPrank();
     }
 
     function testRemoveLiquidityEvents() public {
@@ -226,9 +228,9 @@ contract YieldBearingPoolBufferAsVaultPrimitiveTest is BaseERC4626BufferTest {
     function testYieldBearingPoolSwapUnbalancedBufferExactIn() public {
         vm.startPrank(lp);
         // Surplus of underlying.
-        router.addLiquidityToBuffer(waDAI, unbalanceDelta, 0, lp);
+        router.addLiquidityToBuffer(waDAI, unbalanceDelta, 0);
         // Surplus of wrapped.
-        router.addLiquidityToBuffer(waUSDC, 0, unbalanceDelta, lp);
+        router.addLiquidityToBuffer(waUSDC, 0, unbalanceDelta);
         vm.stopPrank();
 
         SwapResultLocals memory vars = _createSwapResultLocals(SwapKind.EXACT_IN);
@@ -257,9 +259,9 @@ contract YieldBearingPoolBufferAsVaultPrimitiveTest is BaseERC4626BufferTest {
     function testYieldBearingPoolSwapUnbalancedBufferExactOut() public {
         vm.startPrank(lp);
         // Surplus of underlying.
-        router.addLiquidityToBuffer(waDAI, unbalanceDelta, 0, lp);
+        router.addLiquidityToBuffer(waDAI, unbalanceDelta, 0);
         // Surplus of wrapped.
-        router.addLiquidityToBuffer(waUSDC, 0, unbalanceDelta, lp);
+        router.addLiquidityToBuffer(waUSDC, 0, unbalanceDelta);
         vm.stopPrank();
 
         SwapResultLocals memory vars = _createSwapResultLocals(SwapKind.EXACT_OUT);

--- a/pkg/vault/test/foundry/fork/YieldBearingPoolSwapBase.t.sol
+++ b/pkg/vault/test/foundry/fork/YieldBearingPoolSwapBase.t.sol
@@ -994,14 +994,12 @@ abstract contract YieldBearingPoolSwapBase is BaseVaultTest {
         router.addLiquidityToBuffer(
             ybToken2,
             _token2BufferInitAmount,
-            ybToken2.convertToShares(_token2BufferInitAmount),
-            lp
+            ybToken2.convertToShares(_token2BufferInitAmount)
         );
         router.addLiquidityToBuffer(
             ybToken1,
             _token1BufferInitAmount,
-            ybToken1.convertToShares(_token1BufferInitAmount),
-            lp
+            ybToken1.convertToShares(_token1BufferInitAmount)
         );
         vm.stopPrank();
     }

--- a/pkg/vault/test/foundry/unit/VaultAdminUnit.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultAdminUnit.t.sol
@@ -118,20 +118,20 @@ contract VaultAdminUnitTest is BaseVaultTest {
 
     function testAddLiquidityToBufferBaseTokenChanged() public {
         vm.startPrank(bob);
-        router.addLiquidityToBuffer(waDAI, liquidityAmount, liquidityAmount, bob);
+        router.addLiquidityToBuffer(waDAI, liquidityAmount, liquidityAmount);
 
         // Changes the wrapped token asset. The function `addLiquidityToBuffer` should revert, since the buffer was
         // initialized already with another underlying asset.
         waDAI.setAsset(usdc);
 
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.WrongWrappedTokenAsset.selector, address(waDAI)));
-        router.addLiquidityToBuffer(waDAI, liquidityAmount, liquidityAmount, bob);
+        router.addLiquidityToBuffer(waDAI, liquidityAmount, liquidityAmount);
         vm.stopPrank();
     }
 
     function testRemoveLiquidityFromBufferNotEnoughShares() public {
         vm.startPrank(bob);
-        uint256 shares = router.addLiquidityToBuffer(waDAI, liquidityAmount, liquidityAmount, bob);
+        uint256 shares = router.addLiquidityToBuffer(waDAI, liquidityAmount, liquidityAmount);
 
         authorizer.grantRole(vault.getActionId(IVaultAdmin.removeLiquidityFromBuffer.selector), address(router));
         vm.expectRevert(IVaultErrors.NotEnoughBufferShares.selector);

--- a/pkg/vault/test/foundry/unit/VaultBufferUnit.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultBufferUnit.t.sol
@@ -255,7 +255,7 @@ contract VaultBufferUnitTest is BaseVaultTest {
 
     function _initializeBuffer() private {
         vm.prank(lp);
-        router.addLiquidityToBuffer(IERC4626(address(wDaiInitialized)), _wrapAmount, _wrapAmount, lp);
+        router.addLiquidityToBuffer(IERC4626(address(wDaiInitialized)), _wrapAmount, _wrapAmount);
     }
 
     function _exactInWrapUnwrapPath(

--- a/pkg/vault/test/foundry/utils/BaseERC4626BufferTest.sol
+++ b/pkg/vault/test/foundry/utils/BaseERC4626BufferTest.sol
@@ -66,8 +66,8 @@ abstract contract BaseERC4626BufferTest is BaseVaultTest {
         permit2.approve(address(waUSDC), address(router), type(uint160).max, type(uint48).max);
         permit2.approve(address(waUSDC), address(batchRouter), type(uint160).max, type(uint48).max);
 
-        router.addLiquidityToBuffer(waDAI, bufferInitialAmount, bufferInitialAmount, lp);
-        router.addLiquidityToBuffer(waUSDC, bufferInitialAmount, bufferInitialAmount, lp);
+        router.addLiquidityToBuffer(waDAI, bufferInitialAmount, bufferInitialAmount);
+        router.addLiquidityToBuffer(waUSDC, bufferInitialAmount, bufferInitialAmount);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
# Description

We need to use `msg.sender` when adding liquidity for buffers, otherwise any caller can add liquidity in the name of someone else. The actual LP doesn't lose funds, but the caller can use the approvals granted to lock the tokens into buffers, which is not correct. This is the same pattern we use for regular `addLiquidity`.

Also a minor refactor so that the vault admin code matches the interface.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A