### PR TITLE
Fee controller coverage

### DIFF
--- a/pkg/vault/contracts/test/PoolMock.sol
+++ b/pkg/vault/contracts/test/PoolMock.sol
@@ -9,10 +9,11 @@ import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol"
 import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
 import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
+import { PoolInfo } from "@balancer-labs/v3-pool-utils/contracts/PoolInfo.sol";
 
 import { BalancerPoolToken } from "../BalancerPoolToken.sol";
 
-contract PoolMock is IBasePool, IPoolLiquidity, BalancerPoolToken {
+contract PoolMock is IBasePool, IPoolLiquidity, BalancerPoolToken, PoolInfo {
     using FixedPoint for uint256;
 
     uint256 public constant MIN_INIT_BPT = 1e6;
@@ -23,7 +24,11 @@ contract PoolMock is IBasePool, IPoolLiquidity, BalancerPoolToken {
     // If non-zero, use this return value for `getRate` (otherwise, defer to BalancerPoolToken's base implementation).
     uint256 private _mockRate;
 
-    constructor(IVault vault, string memory name, string memory symbol) BalancerPoolToken(vault, name, symbol) {
+    constructor(
+        IVault vault,
+        string memory name,
+        string memory symbol
+    ) BalancerPoolToken(vault, name, symbol) PoolInfo(vault) {
         // solhint-previous-line no-empty-blocks
     }
 


### PR DESCRIPTION
# Description

This adds a test that was missing (identified on the coverage report), where we collect fees with 0% protocol and 100% pool creator fees.

It also adds PoolInfo as a base contract for PoolMock, so that test pools can access the `IPoolInfo` functions as a convenience (and more like real pools).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [X] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
