### PR TITLE
Consistent use of "burned"

### DIFF
--- a/pkg/interfaces/contracts/vault/IVaultEvents.sol
+++ b/pkg/interfaces/contracts/vault/IVaultEvents.sol
@@ -159,16 +159,16 @@ interface IVaultEvents {
     event BufferSharesMinted(IERC4626 indexed wrappedToken, address indexed to, uint256 issuedShares);
 
     /**
-     * @notice Buffer shares were burnt for an ERC4626 buffer corresponding to a given wrapped token.
+     * @notice Buffer shares were burned for an ERC4626 buffer corresponding to a given wrapped token.
      * @dev The shares are not tokenized like pool BPT, but accounted for in the Vault. `getBufferOwnerShares`
      * retrieves the current total shares for a given buffer and address, and `getBufferTotalShares` returns the
      * "totalSupply" of a buffer.
      *
      * @param wrappedToken The wrapped token that identifies the buffer
-     * @param from The owner of the burnt shares
-     * @param burntShares The amount of "internal BPT" shares burnt
+     * @param from The owner of the burned shares
+     * @param burnedShares The amount of "internal BPT" shares burned
      */
-    event BufferSharesBurnt(IERC4626 indexed wrappedToken, address indexed from, uint256 burntShares);
+    event BufferSharesBurned(IERC4626 indexed wrappedToken, address indexed from, uint256 burnedShares);
 
     /**
      * @notice Liquidity was removed from an ERC4626 buffer.

--- a/pkg/interfaces/contracts/vault/IVaultMain.sol
+++ b/pkg/interfaces/contracts/vault/IVaultMain.sol
@@ -100,7 +100,7 @@ interface IVaultMain {
      * _queryModeBalanceIncrease (and only in a query context).
      *
      * @param params Parameters for the remove liquidity (see above for struct definition)
-     * @return bptAmountIn Actual amount of BPT burnt
+     * @return bptAmountIn Actual amount of BPT burned
      * @return amountsOut Actual amounts of output tokens
      * @return returnData Arbitrary (optional) data with an encoded response from the pool
      */

--- a/pkg/solidity-utils/contracts/math/BasePoolMath.sol
+++ b/pkg/solidity-utils/contracts/math/BasePoolMath.sol
@@ -358,7 +358,7 @@ library BasePoolMath {
         // Compute the amount to be withdrawn from the pool.
         uint256 amountOut = currentBalances[tokenOutIndex] - newBalance;
 
-        // Calculate the new balance proportionate to the BPT burnt.
+        // Calculate the new balance proportionate to the amount of BPT burned.
         // We round up: higher `newBalanceBeforeTax` makes `taxableAmount` go up, which rounds in the Vault's favor.
         uint256 newBalanceBeforeTax = newSupply.mulDivUp(currentBalances[tokenOutIndex], totalSupply);
 

--- a/pkg/vault/contracts/BatchRouter.sol
+++ b/pkg/vault/contracts/BatchRouter.sol
@@ -235,7 +235,7 @@ contract BatchRouter is IBatchRouter, BatchRouterStorage, RouterCommon, Reentran
                         _vault.sendTo(IERC20(step.pool), address(this), stepExactAmountIn);
                     }
 
-                    // BPT is burnt instantly, so we don't need to send it back later.
+                    // BPT is burned instantly, so we don't need to send it back later.
                     if (_currentSwapTokenInAmounts().tGet(address(stepTokenIn)) > 0) {
                         _currentSwapTokenInAmounts().tSub(address(stepTokenIn), stepExactAmountIn);
                     }
@@ -509,7 +509,7 @@ contract BatchRouter is IBatchRouter, BatchRouterStorage, RouterCommon, Reentran
                     );
 
                     if (stepLocals.isLastStep) {
-                        // BPT is burnt instantly, so we don't need to send it to the Vault during settlement.
+                        // BPT is burned instantly, so we don't need to send it to the Vault during settlement.
                         pathAmountsIn[i] = bptAmountIn;
                         _settledTokenAmounts().tAdd(address(stepTokenIn), bptAmountIn);
 

--- a/pkg/vault/contracts/BatchRouterStorage.sol
+++ b/pkg/vault/contracts/BatchRouterStorage.sol
@@ -60,7 +60,7 @@ contract BatchRouterStorage {
     }
 
     // token -> amount that is part of the current input / output amounts, but is settled preemptively.
-    // This situation happens whenever there is BPT involved in the operation, which is minted and burnt instantly.
+    // This situation happens whenever there is BPT involved in the operation, which is minted and burned instantly.
     // Since those amounts are not tracked in the inputs / outputs to settle, we need to track them elsewhere
     // to return the correct total amounts in and out for each token involved in the operation.
     function _settledTokenAmounts() internal view returns (AddressMappingSlot slot) {

--- a/pkg/vault/contracts/VaultAdmin.sol
+++ b/pkg/vault/contracts/VaultAdmin.sol
@@ -583,7 +583,7 @@ contract VaultAdmin is IVaultAdmin, VaultCommon, Authentication {
         _bufferTotalShares[wrappedToken] = newTotalSupply;
         _bufferLpShares[wrappedToken][from] -= amount;
 
-        emit BufferSharesBurnt(wrappedToken, from, amount);
+        emit BufferSharesBurned(wrappedToken, from, amount);
     }
 
     /// @inheritdoc IVaultAdmin

--- a/pkg/vault/test/foundry/BufferVaultPrimitive.t.sol
+++ b/pkg/vault/test/foundry/BufferVaultPrimitive.t.sol
@@ -9,6 +9,7 @@ import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IERC20Errors } from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 
 import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
+import { IVaultEvents } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultEvents.sol";
 import { IVaultMain } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import { IVaultAdmin } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultAdmin.sol";
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
@@ -462,6 +463,9 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
         uint256 lpShares = router.initializeBuffer(waDAI, underlyingAmountIn, wrappedAmountIn);
 
         BufferAndLPBalances memory beforeBalances = _measureBuffer();
+
+        vm.expectEmit();
+        emit IVaultEvents.BufferSharesBurned(IERC4626(waDAI), lp, lpShares);
 
         vm.prank(lp);
         (uint256 underlyingRemoved, uint256 wrappedRemoved) = router.removeLiquidityFromBuffer(waDAI, lpShares);

--- a/pkg/vault/test/foundry/VaultLiquidity.t.sol
+++ b/pkg/vault/test/foundry/VaultLiquidity.t.sol
@@ -466,7 +466,7 @@ contract VaultLiquidityTest is BaseVaultTest {
             "Remove - Pool balance: token 1"
         );
 
-        // User has burnt the correct amount of BPT.
+        // User has burned the correct amount of BPT.
         assertEq(balancesBefore.userBpt, bptAmountIn, "Remove - User BPT balance before");
         assertEq(balancesAfter.userBpt, 0, "Remove - User BPT balance after");
 

--- a/pkg/vault/test/foundry/VaultLiquidityFees.t.sol
+++ b/pkg/vault/test/foundry/VaultLiquidityFees.t.sol
@@ -263,7 +263,7 @@ contract VaultLiquidityWithFeesTest is BaseVaultTest {
             "Remove - Pool balance: token 1"
         );
 
-        // User has burnt the correct amount of BPT.
+        // User has burned the correct amount of BPT.
         assertEq(balancesBefore.userBpt - balancesAfter.userBpt, bptAmountIn, "Wrong amount of BPT burned");
     }
 }

--- a/pkg/vault/test/foundry/unit/VaultAdminUnit.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultAdminUnit.t.sol
@@ -200,7 +200,7 @@ contract VaultAdminUnitTest is BaseVaultTest {
         );
 
         assertEq(vault.getBufferOwnerShares(waDAI, bob), issuedShares, "Wrong bob shares");
-        assertEq(vault.getBufferOwnerShares(waDAI, address(0)), _MINIMUM_TOTAL_SUPPLY, "Wrong burnt shares");
+        assertEq(vault.getBufferOwnerShares(waDAI, address(0)), _MINIMUM_TOTAL_SUPPLY, "Wrong burned shares");
         assertEq(vault.getBufferTotalShares(waDAI), issuedShares + _MINIMUM_TOTAL_SUPPLY, "Wrong total shares");
     }
 


### PR DESCRIPTION
# Description

A nit-picky one perhaps, but noticed in recent PRs that we aren't using burned consistently. Sometimes we were using "burnt," which is British.

(Also noticed there was no test checking for the burn event.)

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
