### PR TITLE
Consistent buffer terminology

### DIFF
--- a/pkg/interfaces/contracts/vault/IBatchRouter.sol
+++ b/pkg/interfaces/contracts/vault/IBatchRouter.sol
@@ -15,16 +15,15 @@ interface IBatchRouter {
     struct SwapPathStep {
         address pool;
         IERC20 tokenOut;
-        // if true, pool is a yield-bearing token buffer. Used to wrap/unwrap tokens if pool doesn't have
-        // enough liquidity
+        // If true, the "pool" is an ERC4626 Buffer. Used to wrap/unwrap tokens if pool doesn't have enough liquidity.
         bool isBuffer;
     }
 
     struct SwapPathExactAmountIn {
         IERC20 tokenIn;
-        // for each step:
-        // if tokenIn == pool, use removeLiquidity SINGLE_TOKEN_EXACT_IN
-        // if tokenOut == pool, use addLiquidity UNBALANCED
+        // For each step:
+        // If tokenIn == pool, use removeLiquidity SINGLE_TOKEN_EXACT_IN.
+        // If tokenOut == pool, use addLiquidity UNBALANCED.
         SwapPathStep[] steps;
         uint256 exactAmountIn;
         uint256 minAmountOut;
@@ -33,8 +32,8 @@ interface IBatchRouter {
     struct SwapPathExactAmountOut {
         IERC20 tokenIn;
         // for each step:
-        // if tokenIn == pool, use removeLiquidity SINGLE_TOKEN_EXACT_OUT
-        // if tokenOut == pool, use addLiquidity SINGLE_TOKEN_EXACT_OUT
+        // If tokenIn == pool, use removeLiquidity SINGLE_TOKEN_EXACT_OUT.
+        // If tokenOut == pool, use addLiquidity SINGLE_TOKEN_EXACT_OUT.
         SwapPathStep[] steps;
         uint256 maxAmountIn;
         uint256 exactAmountOut;

--- a/pkg/interfaces/contracts/vault/IRouter.sol
+++ b/pkg/interfaces/contracts/vault/IRouter.sol
@@ -309,11 +309,11 @@ interface IRouter {
     ) external payable returns (uint256 amountIn);
 
     /*******************************************************************************
-                            Yield-bearing token buffers
+                                  ERC4626 Buffers
     *******************************************************************************/
 
     /**
-     * @notice Adds liquidity for the first time to a yield-bearing token buffer (internal ERC4626 buffer in the Vault).
+     * @notice Adds liquidity for the first time to an internal ERC4626 buffer in the Vault.
      * @dev Calling this method binds the wrapped token to its underlying asset internally; the asset in the wrapper
      * cannot change afterwards, or every other operation on that wrapper (add / remove / wrap / unwrap) will fail.
      *
@@ -330,7 +330,7 @@ interface IRouter {
     ) external returns (uint256 issuedShares);
 
     /**
-     * @notice Adds liquidity to a yield-bearing token buffer (internal ERC4626 buffer in the Vault).
+     * @notice Adds liquidity to an internal ERC4626 buffer in the Vault.
      * @dev Requires the buffer to be initialized beforehand.
      * @param wrappedToken Address of the wrapped token that implements IERC4626
      * @param amountUnderlyingRaw Amount of underlying tokens that will be deposited into the buffer
@@ -345,7 +345,7 @@ interface IRouter {
     ) external returns (uint256 issuedShares);
 
     /**
-     * @notice Removes liquidity from a yield-bearing token buffer (internal ERC4626 buffer in the Vault).
+     * @notice Removes liquidity from an(internal ERC4626 buffer in the Vault.
      * @dev Only proportional withdrawals are supported, and removing liquidity is permissioned.
      * Requires the buffer to be initialized beforehand.
      *

--- a/pkg/interfaces/contracts/vault/IVaultAdmin.sol
+++ b/pkg/interfaces/contracts/vault/IVaultAdmin.sol
@@ -180,7 +180,7 @@ interface IVaultAdmin {
     function disableQuery() external;
 
     /*******************************************************************************
-                              Yield-bearing token buffers
+                                  ERC4626 Buffers
     *******************************************************************************/
 
     /**

--- a/pkg/interfaces/contracts/vault/IVaultExplorer.sol
+++ b/pkg/interfaces/contracts/vault/IVaultExplorer.sol
@@ -383,7 +383,7 @@ interface IVaultExplorer {
     function collectAggregateFees(address pool) external;
 
     /*******************************************************************************
-                              Yield-bearing Token Buffers
+                                  ERC4626 Buffers
     *******************************************************************************/
 
     /**

--- a/pkg/interfaces/contracts/vault/IVaultMain.sol
+++ b/pkg/interfaces/contracts/vault/IVaultMain.sol
@@ -123,7 +123,7 @@ interface IVaultMain {
     function getPoolTokenCountAndIndexOfToken(address pool, IERC20 token) external view returns (uint256, uint256);
 
     /*******************************************************************************
-                            Yield-bearing token buffers
+                                  ERC4626 Buffers
     *******************************************************************************/
 
     /**

--- a/pkg/vault/contracts/Router.sol
+++ b/pkg/vault/contracts/Router.sol
@@ -641,7 +641,7 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
     }
 
     /*******************************************************************************
-                            Yield-bearing token buffers
+                                  ERC4626 Buffers
     *******************************************************************************/
 
     /// @inheritdoc IRouter

--- a/pkg/vault/contracts/Vault.sol
+++ b/pkg/vault/contracts/Vault.sol
@@ -1043,7 +1043,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
     }
 
     /*******************************************************************************
-                             Yield-bearing token buffers
+                                  ERC4626 Buffers
     *******************************************************************************/
 
     /// @inheritdoc IVaultMain

--- a/pkg/vault/contracts/VaultAdmin.sol
+++ b/pkg/vault/contracts/VaultAdmin.sol
@@ -401,7 +401,7 @@ contract VaultAdmin is IVaultAdmin, VaultCommon, Authentication {
     }
 
     /*******************************************************************************
-                                Yield-bearing token buffers
+                                  ERC4626 Buffers
     *******************************************************************************/
 
     /// @inheritdoc IVaultAdmin

--- a/pkg/vault/contracts/VaultExplorer.sol
+++ b/pkg/vault/contracts/VaultExplorer.sol
@@ -296,7 +296,7 @@ contract VaultExplorer is IVaultExplorer {
     }
 
     /*******************************************************************************
-                              Yield-bearing Token Buffers
+                                  ERC4626 Buffers
     *******************************************************************************/
 
     /// @inheritdoc IVaultExplorer


### PR DESCRIPTION
# Description

We started renaming "yield-bearing token buffer" to "ERC4626 buffer," but didn't complete it. I don't think we necessarily need to go all the way and change variable names in tests, etc., but headers and primary comments should be consistent.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [X] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
