### PR TITLE
Add state influencing behavior/accuracy to dynamic data

### DIFF
--- a/pkg/interfaces/contracts/pool-stable/IStablePool.sol
+++ b/pkg/interfaces/contracts/pool-stable/IStablePool.sol
@@ -22,6 +22,10 @@ struct StablePoolImmutableData {
 
 /**
  * @notice Snapshot of current Stable Pool data that can change.
+ * @dev Note that live balances will not necessarily be accurate if the pool is in Recovery Mode. Withdrawals
+ * in Recovery Mode do not make external calls (including those necessary for updating live balances), so if
+ * there are withdrawals, raw and live balances will be out of sync until Recovery Mode is disabled.
+ *
  * @param balancesLiveScaled18 Token balances after paying yield fees, applying decimal scaling and rates
  * @param tokenRates 18-decimal FP values for rate tokens (e.g., yield-bearing), or FP(1) for standard tokens
  * @param staticSwapFeePercentage 18-decimal FP value of the static swap fee percentage
@@ -31,6 +35,9 @@ struct StablePoolImmutableData {
  * and assumes prices are near parity. lower values = closer to the constant product curve (e.g., more like a
  * weighted pool). This has higher slippage, and accommodates greater price volatility.
  * @param isAmpUpdating True if an amplification parameter update is in progress
+ * @param isPoolInitialized If false, the pool has not been seeded with initial liquidity, so operations will revert
+ * @param isPoolPaused If true, the pool is paused, and all non-recovery-mode state-changing operations will revert
+ * @param isPoolInRecoveryMode If true, Recovery Mode withdrawals are enabled, and live balances may be inaccurate
  */
 struct StablePoolDynamicData {
     uint256[] balancesLiveScaled18;
@@ -40,6 +47,9 @@ struct StablePoolDynamicData {
     uint256 bptRate;
     uint256 amplificationParameter;
     bool isAmpUpdating;
+    bool isPoolInitialized;
+    bool isPoolPaused;
+    bool isPoolInRecoveryMode;
 }
 
 /// @notice Full Stable Pool interface.

--- a/pkg/interfaces/contracts/pool-stable/IStablePool.sol
+++ b/pkg/interfaces/contracts/pool-stable/IStablePool.sol
@@ -75,13 +75,13 @@ interface IStablePool is IBasePool {
     function getAmplificationParameter() external view returns (uint256 value, bool isUpdating, uint256 precision);
 
     /**
-     * @notice Get relevant dynamic pool data required for swap/add/remove calculations.
+     * @notice Get dynamic pool data relevant to swap/add/remove calculations.
      * @return data A struct containing all dynamic stable pool parameters
      */
     function getStablePoolDynamicData() external view returns (StablePoolDynamicData memory data);
 
     /**
-     * @notice Get relevant immutable pool data required for swap/add/remove calculations.
+     * @notice Get immutable pool data relevant to swap/add/remove calculations.
      * @return data A struct containing all immutable stable pool parameters
      */
     function getStablePoolImmutableData() external view returns (StablePoolImmutableData memory data);

--- a/pkg/interfaces/contracts/pool-utils/IPoolInfo.sol
+++ b/pkg/interfaces/contracts/pool-utils/IPoolInfo.sol
@@ -36,6 +36,10 @@ interface IPoolInfo {
 
     /**
      * @notice Gets the current live balances of the pool as fixed point, 18-decimal numbers.
+     * @dev Note that live balances will not necessarily be accurate if the pool is in Recovery Mode.
+     * Withdrawals in Recovery Mode do not make external calls (including those necessary for updating live balances),
+     * so if there are withdrawals, raw and live balances will be out of sync until Recovery Mode is disabled.
+     *
      * @return balancesLiveScaled18 Token balances after paying yield fees, applying decimal scaling and rates
      */
     function getCurrentLiveBalances() external view returns (uint256[] memory balancesLiveScaled18);

--- a/pkg/pool-stable/contracts/StablePool.sol
+++ b/pkg/pool-stable/contracts/StablePool.sol
@@ -14,7 +14,7 @@ import {
     IUnbalancedLiquidityInvariantRatioBounds
 } from "@balancer-labs/v3-interfaces/contracts/vault/IUnbalancedLiquidityInvariantRatioBounds.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
-import { SwapKind, PoolSwapParams } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+import { SwapKind, PoolSwapParams, PoolConfig } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 import { IBasePool } from "@balancer-labs/v3-interfaces/contracts/vault/IBasePool.sol";
 
 import { BalancerPoolToken } from "@balancer-labs/v3-vault/contracts/BalancerPoolToken.sol";
@@ -333,6 +333,11 @@ contract StablePool is IStablePool, BalancerPoolToken, BasePoolAuthentication, P
         data.totalSupply = totalSupply();
         data.bptRate = getRate();
         (data.amplificationParameter, data.isAmpUpdating) = _getAmplificationParameter();
+
+        PoolConfig memory poolConfig = _vault.getPoolConfig(address(this));
+        data.isPoolInitialized = poolConfig.isPoolInitialized;
+        data.isPoolPaused = poolConfig.isPoolPaused;
+        data.isPoolInRecoveryMode = poolConfig.isPoolInRecoveryMode;
     }
 
     /// @inheritdoc IStablePool

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -13,7 +13,7 @@ import {
 } from "@balancer-labs/v3-interfaces/contracts/vault/IUnbalancedLiquidityInvariantRatioBounds.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
-import { SwapKind, PoolSwapParams } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+import { SwapKind, PoolSwapParams, PoolConfig } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 import { IBasePool } from "@balancer-labs/v3-interfaces/contracts/vault/IBasePool.sol";
 
 import { BalancerPoolToken } from "@balancer-labs/v3-vault/contracts/BalancerPoolToken.sol";
@@ -218,6 +218,11 @@ contract WeightedPool is IWeightedPool, BalancerPoolToken, PoolInfo, Version {
         data.staticSwapFeePercentage = _vault.getStaticSwapFeePercentage((address(this)));
         data.totalSupply = totalSupply();
         data.bptRate = getRate();
+
+        PoolConfig memory poolConfig = _vault.getPoolConfig(address(this));
+        data.isPoolInitialized = poolConfig.isPoolInitialized;
+        data.isPoolPaused = poolConfig.isPoolPaused;
+        data.isPoolInRecoveryMode = poolConfig.isPoolInRecoveryMode;
     }
 
     /// @inheritdoc IWeightedPool


### PR DESCRIPTION
# Description

After discussions today, realized that the dynamic pool data can at times be misleading. For instance, if the pool is paused or non initialized, operations will fail. And if the pool is in Recovery Mode, live balances may be inaccurate. This adds documentation to that effect, and also adds the relevant pool config flags to the dynamic data output, so that users can check whether they can rely on the data.

I was going to update the tests, and realized we don't have any for this, I guess because it's an off-chain-only feature.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
