### PR TITLE
Interface package lint issues

### DIFF
--- a/pkg/interfaces/contracts/solidity-utils/helpers/IPoolVersion.sol
+++ b/pkg/interfaces/contracts/solidity-utils/helpers/IPoolVersion.sol
@@ -6,8 +6,8 @@ pragma solidity ^0.8.24;
 interface IPoolVersion {
     /**
      * @notice Returns a JSON representation of the deployed pool version containing name, version number and task ID.
-     * @dev This is typically only useful in complex Pool deployment schemes, where multiple subsystems need to know about
-     * each other. Note that this value will only be updated at factory creation time.
+     * @dev This is typically only useful in complex Pool deployment schemes, where multiple subsystems need to know
+     * about each other. Note that this value will only be updated at factory creation time.
      */
     function getPoolVersion() external view returns (string memory);
 }

--- a/pkg/interfaces/contracts/vault/IBasePool.sol
+++ b/pkg/interfaces/contracts/vault/IBasePool.sol
@@ -10,7 +10,8 @@ import { SwapKind, PoolSwapParams } from "./VaultTypes.sol";
  * @notice Base interface for a Balancer Pool.
  * @dev All pool types should implement this interface. Note that it also requires implementation of:
  * - `ISwapFeePercentageBounds` to specify the minimum and maximum swap fee percentages.
- * - `IUnbalancedLiquidityInvariantRatioBounds` to specify how much the invariant can change during an unbalanced liquidity operation.
+ * - `IUnbalancedLiquidityInvariantRatioBounds` to specify how much the invariant can change during an unbalanced
+ * liquidity operation.
  */
 interface IBasePool is ISwapFeePercentageBounds, IUnbalancedLiquidityInvariantRatioBounds {
     /***************************************************************************

--- a/pkg/interfaces/contracts/vault/IBatchRouter.sol
+++ b/pkg/interfaces/contracts/vault/IBatchRouter.sol
@@ -139,10 +139,12 @@ interface IBatchRouter {
     // user to construct a batch operation containing the buffer swap.
 
     /**
-     * @dev An "ERC4626 pool" is one in which all tokens conform to the IERC4626 yield-bearing token standard (e.g., waDAI).
      * @notice Add arbitrary amounts of underlying tokens to an ERC4626 pool through the buffer.
+     * @dev An "ERC4626 pool" is one in which all tokens conform to the IERC4626 yield-bearing token standard
+     * (e.g., waDAI).
+     *
      * @param pool Address of the liquidity pool
-     * @param exactUnderlyingAmountsIn Exact amounts of underlying tokens to be added, sorted in token registration order
+     * @param exactUnderlyingAmountsIn Exact amounts of underlying tokens in, sorted in token registration order
      * @param minBptAmountOut Minimum amount of pool tokens to be received
      * @param wethIsEth If true, incoming ETH will be wrapped to WETH and outgoing WETH will be unwrapped to ETH
      * @param userData Additional (optional) data required for adding liquidity
@@ -157,10 +159,12 @@ interface IBatchRouter {
     ) external payable returns (uint256 bptAmountOut);
 
     /**
-     * @dev An "ERC4626 pool" is one in which all tokens conform to the IERC4626 yield-bearing token standard (e.g., waDAI).
      * @notice Add proportional amounts of underlying tokens to an ERC4626 pool through the buffer.
+     * @dev An "ERC4626 pool" is one in which all tokens conform to the IERC4626 yield-bearing token standard
+     * (e.g., waDAI).
+     *
      * @param pool Address of the liquidity pool
-     * @param maxUnderlyingAmountsIn Maximum amounts of underlying tokens to be added, sorted in token registration order
+     * @param maxUnderlyingAmountsIn Maximum amounts of underlying tokens in, sorted in token registration order
      * @param exactBptAmountOut Exact amount of pool tokens to be received
      * @param wethIsEth If true, incoming ETH will be wrapped to WETH and outgoing WETH will be unwrapped to ETH
      * @param userData Additional (optional) data required for adding liquidity
@@ -175,11 +179,13 @@ interface IBatchRouter {
     ) external payable returns (uint256[] memory underlyingAmountsIn);
 
     /**
-     * @dev An "ERC4626 pool" is one in which all tokens conform to the IERC4626 yield-bearing token standard (e.g., waDAI).
-     * @notice Remove proportional amounts of underlying tokens from an ERC4626 pool, burning an exact pool token amount.
+     * @notice Remove proportional amounts of underlying from an ERC4626 pool, burning an exact pool token amount.
+     * @dev An "ERC4626 pool" is one in which all tokens conform to the IERC4626 yield-bearing token standard
+     * (e.g., waDAI).
+     *
      * @param pool Address of the liquidity pool
      * @param exactBptAmountIn Exact amount of pool tokens provided
-     * @param minUnderlyingAmountsOut Minimum amounts of underlying tokens to be received, sorted in token registration order
+     * @param minUnderlyingAmountsOut Minimum amounts of underlying tokens out, sorted in token registration order
      * @param wethIsEth If true, incoming ETH will be wrapped to WETH and outgoing WETH will be unwrapped to ETH
      * @param userData Additional (optional) data required for removing liquidity
      * @return underlyingAmountsOut Actual amounts of tokens received, sorted in token registration order
@@ -193,10 +199,12 @@ interface IBatchRouter {
     ) external payable returns (uint256[] memory underlyingAmountsOut);
 
     /**
-     * @dev An "ERC4626 pool" is one in which all tokens conform to the IERC4626 yield-bearing token standard (e.g., waDAI).
      * @notice Queries an `addLiquidityUnbalancedToERC4626Pool` operation without actually executing it.
+     * @dev An "ERC4626 pool" is one in which all tokens conform to the IERC4626 yield-bearing token standard
+     * (e.g., waDAI).
+     *
      * @param pool Address of the liquidity pool
-     * @param exactUnderlyingAmountsIn Exact amounts of underlying tokens to be added, sorted in token registration order
+     * @param exactUnderlyingAmountsIn Exact amounts of underlying tokens in, sorted in token registration order
      * @param userData Additional (optional) data required for the query
      * @return bptAmountOut Expected amount of pool tokens to receive
      */
@@ -207,8 +215,10 @@ interface IBatchRouter {
     ) external returns (uint256 bptAmountOut);
 
     /**
-     * @dev An "ERC4626 pool" is one in which all tokens conform to the IERC4626 yield-bearing token standard (e.g., waDAI).
      * @notice Queries an `addLiquidityProportionalToERC4626Pool` operation without actually executing it.
+     * @dev An "ERC4626 pool" is one in which all tokens conform to the IERC4626 yield-bearing token standard
+     * (e.g., waDAI).
+     *
      * @param pool Address of the liquidity pool
      * @param exactBptAmountOut Exact amount of pool tokens to be received
      * @param userData Additional (optional) data required for the query
@@ -221,8 +231,10 @@ interface IBatchRouter {
     ) external returns (uint256[] memory underlyingAmountsIn);
 
     /**
-     * @dev An "ERC4626 pool" is one in which all tokens conform to the IERC4626 yield-bearing token standard (e.g., waDAI).
      * @notice Queries a `removeLiquidityProportionalFromERC4626Pool` operation without actually executing it.
+     * @dev An "ERC4626 pool" is one in which all tokens conform to the IERC4626 yield-bearing token standard
+     * (e.g., waDAI).
+     *
      * @param pool Address of the liquidity pool
      * @param exactBptAmountIn Exact amount of pool tokens provided for the query
      * @param userData Additional (optional) data required for the query

--- a/pkg/interfaces/contracts/vault/IRouter.sol
+++ b/pkg/interfaces/contracts/vault/IRouter.sol
@@ -14,7 +14,7 @@ interface IRouter {
     ***************************************************************************/
 
     /**
-     * @notice Data for the pool initialization hook
+     * @notice Data for the pool initialization hook.
      * @param sender Account originating the pool initialization operation
      * @param pool Address of the liquidity pool
      * @param tokens Pool tokens, in token registration order
@@ -204,6 +204,7 @@ interface IRouter {
      * @notice Removes liquidity from a pool with a custom request.
      * @dev The given maximum and minimum amounts given may be interpreted as exact depending on the pool type.
      * In any case the caller can expect them to be hard boundaries for the request.
+     *
      * @param pool Address of the liquidity pool
      * @param maxBptAmountIn Maximum amount of pool tokens provided
      * @param minAmountsOut Minimum amounts of tokens to be received, sorted in token registration order


### PR DESCRIPTION
# Description

Apparently lint doesn't always catch things in packages without code? These were line-length issues that only showed up when compiling an unrelated PR (hence this separate one).

Also had some NatSpec in reversed order; not sure how we got the beans above the frank there. 

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [X] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
