### PR TITLE
Make initialize non-reentrant

### DIFF
--- a/pkg/interfaces/contracts/test/IVaultExtensionMock.sol
+++ b/pkg/interfaces/contracts/test/IVaultExtensionMock.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.24;
 
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 import { TokenConfig, PoolRoleAccounts, LiquidityManagement } from "../../contracts/vault/VaultTypes.sol";
 
 interface IVaultExtensionMock {
@@ -17,5 +19,14 @@ interface IVaultExtensionMock {
         PoolRoleAccounts calldata roleAccounts,
         address poolHooksContract,
         LiquidityManagement calldata liquidityManagement
+    ) external;
+
+    function manualInitializePoolReentrancy(
+        address pool,
+        address to,
+        IERC20[] memory tokens,
+        uint256[] memory exactAmountsIn,
+        uint256 minBptAmountOut,
+        bytes memory userData
     ) external;
 }

--- a/pkg/vault/contracts/VaultExtension.sol
+++ b/pkg/vault/contracts/VaultExtension.sol
@@ -340,7 +340,7 @@ contract VaultExtension is IVaultExtension, VaultCommon, Proxy {
         uint256[] memory exactAmountsIn,
         uint256 minBptAmountOut,
         bytes memory userData
-    ) external onlyVaultDelegateCall onlyWhenUnlocked withRegisteredPool(pool) returns (uint256 bptAmountOut) {
+    ) external onlyVaultDelegateCall onlyWhenUnlocked withRegisteredPool(pool) nonReentrant returns (uint256 bptAmountOut) {
         _ensureUnpaused(pool);
 
         // Balances are zero until after initialize is called, so there is no need to charge pending yield fee here.
@@ -392,7 +392,7 @@ contract VaultExtension is IVaultExtension, VaultCommon, Proxy {
         uint256[] memory exactAmountsIn,
         uint256[] memory exactAmountsInScaled18,
         uint256 minBptAmountOut
-    ) internal nonReentrant returns (uint256 bptAmountOut) {
+    ) internal returns (uint256 bptAmountOut) {
         mapping(uint256 => bytes32) storage poolBalances = _poolTokenBalances[pool];
 
         for (uint256 i = 0; i < poolData.tokens.length; ++i) {

--- a/pkg/vault/contracts/VaultExtension.sol
+++ b/pkg/vault/contracts/VaultExtension.sol
@@ -340,7 +340,14 @@ contract VaultExtension is IVaultExtension, VaultCommon, Proxy {
         uint256[] memory exactAmountsIn,
         uint256 minBptAmountOut,
         bytes memory userData
-    ) external onlyVaultDelegateCall onlyWhenUnlocked withRegisteredPool(pool) nonReentrant returns (uint256 bptAmountOut) {
+    )
+        external
+        onlyVaultDelegateCall
+        onlyWhenUnlocked
+        withRegisteredPool(pool)
+        nonReentrant
+        returns (uint256 bptAmountOut)
+    {
         _ensureUnpaused(pool);
 
         // Balances are zero until after initialize is called, so there is no need to charge pending yield fee here.

--- a/pkg/vault/contracts/test/VaultExtensionMock.sol
+++ b/pkg/vault/contracts/test/VaultExtensionMock.sol
@@ -41,4 +41,15 @@ contract VaultExtensionMock is IVaultExtensionMock, VaultExtension {
             liquidityManagement
         );
     }
+
+    function manualInitializePoolReentrancy(
+        address pool,
+        address to,
+        IERC20[] memory tokens,
+        uint256[] memory exactAmountsIn,
+        uint256 minBptAmountOut,
+        bytes memory userData
+    ) external nonReentrant {
+        IVault(address(this)).initialize(pool, to, tokens, exactAmountsIn, minBptAmountOut, userData);
+    }
 }

--- a/pkg/vault/test/.contract-sizes/VaultExtension
+++ b/pkg/vault/test/.contract-sizes/VaultExtension
@@ -1,2 +1,2 @@
-Bytecode	19.447
-InitCode	20.610
+Bytecode	19.446
+InitCode	20.609

--- a/pkg/vault/test/foundry/mutation/vault/VaultExtension.t.sol
+++ b/pkg/vault/test/foundry/mutation/vault/VaultExtension.t.sol
@@ -72,6 +72,16 @@ contract VaultExtensionMutationTest is BaseVaultTest {
         vaultExtension.initialize(pool, address(0), tokens, exactAmountsIn, 0, "");
     }
 
+    function testInitializeReentrancy() public {
+        IERC20[] memory tokens;
+        uint256[] memory exactAmountsIn;
+
+        vault.manualSetIsUnlocked(true);
+
+        vm.expectRevert(ReentrancyGuardTransient.ReentrancyGuardReentrantCall.selector);
+        vault.manualInitializePoolReentrancy(pool, address(0), tokens, exactAmountsIn, 0, "");
+    }
+
     function testIsPoolInitializedWhenNotVault() public {
         vm.expectRevert(IVaultErrors.NotVaultDelegateCall.selector);
         vaultExtension.isPoolInitialized(pool);


### PR DESCRIPTION
# Description

There is possible reentrancy if we allow the pre-initialize hook to re-enter the Vault (before setting the initialized bit). Since we don't think the pre-initialize hook needs to be reentrant in the first place, just make the whole initialize function nonReentrant and avoid the issue.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Resolves #898 
