### PR TITLE
Replace encodeWithSelector with encodeCall

### DIFF
--- a/pkg/vault/contracts/BatchRouter.sol
+++ b/pkg/vault/contracts/BatchRouter.sol
@@ -64,8 +64,8 @@ contract BatchRouter is IBatchRouter, BatchRouterStorage, RouterCommon, Reentran
         return
             abi.decode(
                 _vault.unlock(
-                    abi.encodeWithSelector(
-                        BatchRouter.swapExactInHook.selector,
+                    abi.encodeCall(
+                        BatchRouter.swapExactInHook,
                         SwapExactInHookParams({
                             sender: msg.sender,
                             paths: paths,
@@ -94,8 +94,8 @@ contract BatchRouter is IBatchRouter, BatchRouterStorage, RouterCommon, Reentran
         return
             abi.decode(
                 _vault.unlock(
-                    abi.encodeWithSelector(
-                        BatchRouter.swapExactOutHook.selector,
+                    abi.encodeCall(
+                        BatchRouter.swapExactOutHook,
                         SwapExactOutHookParams({
                             sender: msg.sender,
                             paths: paths,
@@ -609,8 +609,8 @@ contract BatchRouter is IBatchRouter, BatchRouterStorage, RouterCommon, Reentran
         return
             abi.decode(
                 _vault.quote(
-                    abi.encodeWithSelector(
-                        BatchRouter.querySwapExactInHook.selector,
+                    abi.encodeCall(
+                        BatchRouter.querySwapExactInHook,
                         SwapExactInHookParams({
                             sender: address(this),
                             paths: paths,
@@ -640,8 +640,8 @@ contract BatchRouter is IBatchRouter, BatchRouterStorage, RouterCommon, Reentran
         return
             abi.decode(
                 _vault.quote(
-                    abi.encodeWithSelector(
-                        BatchRouter.querySwapExactOutHook.selector,
+                    abi.encodeCall(
+                        BatchRouter.querySwapExactOutHook,
                         SwapExactOutHookParams({
                             sender: address(this),
                             paths: paths,
@@ -691,8 +691,8 @@ contract BatchRouter is IBatchRouter, BatchRouterStorage, RouterCommon, Reentran
     ) external payable saveSender returns (uint256 bptAmountOut) {
         bptAmountOut = abi.decode(
             _vault.unlock(
-                abi.encodeWithSelector(
-                    BatchRouter.addLiquidityERC4626PoolUnbalancedHook.selector,
+                abi.encodeCall(
+                    BatchRouter.addLiquidityERC4626PoolUnbalancedHook,
                     AddLiquidityHookParams({
                         sender: msg.sender,
                         pool: pool,
@@ -718,8 +718,8 @@ contract BatchRouter is IBatchRouter, BatchRouterStorage, RouterCommon, Reentran
     ) external payable saveSender returns (uint256[] memory underlyingAmountsIn) {
         underlyingAmountsIn = abi.decode(
             _vault.unlock(
-                abi.encodeWithSelector(
-                    BatchRouter.addLiquidityERC4626PoolProportionalHook.selector,
+                abi.encodeCall(
+                    BatchRouter.addLiquidityERC4626PoolProportionalHook,
                     AddLiquidityHookParams({
                         sender: msg.sender,
                         pool: pool,
@@ -745,8 +745,8 @@ contract BatchRouter is IBatchRouter, BatchRouterStorage, RouterCommon, Reentran
     ) external payable saveSender returns (uint256[] memory underlyingAmountsOut) {
         underlyingAmountsOut = abi.decode(
             _vault.unlock(
-                abi.encodeWithSelector(
-                    BatchRouter.removeLiquidityERC4626PoolProportionalHook.selector,
+                abi.encodeCall(
+                    BatchRouter.removeLiquidityERC4626PoolProportionalHook,
                     RemoveLiquidityHookParams({
                         sender: msg.sender,
                         pool: pool,
@@ -770,8 +770,8 @@ contract BatchRouter is IBatchRouter, BatchRouterStorage, RouterCommon, Reentran
     ) external saveSender returns (uint256 bptAmountOut) {
         bptAmountOut = abi.decode(
             _vault.quote(
-                abi.encodeWithSelector(
-                    BatchRouter.addLiquidityERC4626PoolUnbalancedHook.selector,
+                abi.encodeCall(
+                    BatchRouter.addLiquidityERC4626PoolUnbalancedHook,
                     AddLiquidityHookParams({
                         sender: msg.sender,
                         pool: pool,
@@ -795,8 +795,8 @@ contract BatchRouter is IBatchRouter, BatchRouterStorage, RouterCommon, Reentran
     ) external saveSender returns (uint256[] memory underlyingAmountsIn) {
         underlyingAmountsIn = abi.decode(
             _vault.quote(
-                abi.encodeWithSelector(
-                    BatchRouter.addLiquidityERC4626PoolProportionalHook.selector,
+                abi.encodeCall(
+                    BatchRouter.addLiquidityERC4626PoolProportionalHook,
                     AddLiquidityHookParams({
                         sender: msg.sender,
                         pool: pool,
@@ -820,8 +820,8 @@ contract BatchRouter is IBatchRouter, BatchRouterStorage, RouterCommon, Reentran
     ) external saveSender returns (uint256[] memory underlyingAmountsOut) {
         underlyingAmountsOut = abi.decode(
             _vault.quote(
-                abi.encodeWithSelector(
-                    BatchRouter.removeLiquidityERC4626PoolProportionalHook.selector,
+                abi.encodeCall(
+                    BatchRouter.removeLiquidityERC4626PoolProportionalHook,
                     RemoveLiquidityHookParams({
                         sender: msg.sender,
                         pool: pool,

--- a/pkg/vault/contracts/ProtocolFeeController.sol
+++ b/pkg/vault/contracts/ProtocolFeeController.sol
@@ -163,7 +163,7 @@ contract ProtocolFeeController is
 
     /// @inheritdoc IProtocolFeeController
     function collectAggregateFees(address pool) public {
-        _vault.unlock(abi.encodeWithSelector(ProtocolFeeController.collectAggregateFeesHook.selector, pool));
+        _vault.unlock(abi.encodeCall(ProtocolFeeController.collectAggregateFeesHook, pool));
     }
 
     /**

--- a/pkg/vault/contracts/Router.sol
+++ b/pkg/vault/contracts/Router.sol
@@ -46,8 +46,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
         return
             abi.decode(
                 _vault.unlock(
-                    abi.encodeWithSelector(
-                        Router.initializeHook.selector,
+                    abi.encodeCall(
+                        Router.initializeHook,
                         InitializeHookParams({
                             sender: msg.sender,
                             pool: pool,
@@ -122,8 +122,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
     ) external payable saveSender returns (uint256[] memory amountsIn) {
         (amountsIn, , ) = abi.decode(
             _vault.unlock(
-                abi.encodeWithSelector(
-                    Router.addLiquidityHook.selector,
+                abi.encodeCall(
+                    Router.addLiquidityHook,
                     AddLiquidityHookParams({
                         sender: msg.sender,
                         pool: pool,
@@ -149,8 +149,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
     ) external payable saveSender returns (uint256 bptAmountOut) {
         (, bptAmountOut, ) = abi.decode(
             _vault.unlock(
-                abi.encodeWithSelector(
-                    Router.addLiquidityHook.selector,
+                abi.encodeCall(
+                    Router.addLiquidityHook,
                     AddLiquidityHookParams({
                         sender: msg.sender,
                         pool: pool,
@@ -183,8 +183,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
 
         (uint256[] memory amountsIn, , ) = abi.decode(
             _vault.unlock(
-                abi.encodeWithSelector(
-                    Router.addLiquidityHook.selector,
+                abi.encodeCall(
+                    Router.addLiquidityHook,
                     AddLiquidityHookParams({
                         sender: msg.sender,
                         pool: pool,
@@ -210,8 +210,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
         bytes memory userData
     ) external payable saveSender {
         _vault.unlock(
-            abi.encodeWithSelector(
-                Router.addLiquidityHook.selector,
+            abi.encodeCall(
+                Router.addLiquidityHook,
                 AddLiquidityHookParams({
                     sender: msg.sender,
                     pool: pool,
@@ -236,8 +236,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
         return
             abi.decode(
                 _vault.unlock(
-                    abi.encodeWithSelector(
-                        Router.addLiquidityHook.selector,
+                    abi.encodeCall(
+                        Router.addLiquidityHook,
                         AddLiquidityHookParams({
                             sender: msg.sender,
                             pool: pool,
@@ -322,8 +322,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
     ) external payable saveSender returns (uint256[] memory amountsOut) {
         (, amountsOut, ) = abi.decode(
             _vault.unlock(
-                abi.encodeWithSelector(
-                    Router.removeLiquidityHook.selector,
+                abi.encodeCall(
+                    Router.removeLiquidityHook,
                     RemoveLiquidityHookParams({
                         sender: msg.sender,
                         pool: pool,
@@ -356,8 +356,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
 
         (, uint256[] memory amountsOut, ) = abi.decode(
             _vault.unlock(
-                abi.encodeWithSelector(
-                    Router.removeLiquidityHook.selector,
+                abi.encodeCall(
+                    Router.removeLiquidityHook,
                     RemoveLiquidityHookParams({
                         sender: msg.sender,
                         pool: pool,
@@ -388,8 +388,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
 
         (bptAmountIn, , ) = abi.decode(
             _vault.unlock(
-                abi.encodeWithSelector(
-                    Router.removeLiquidityHook.selector,
+                abi.encodeCall(
+                    Router.removeLiquidityHook,
                     RemoveLiquidityHookParams({
                         sender: msg.sender,
                         pool: pool,
@@ -418,8 +418,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
         return
             abi.decode(
                 _vault.unlock(
-                    abi.encodeWithSelector(
-                        Router.removeLiquidityHook.selector,
+                    abi.encodeCall(
+                        Router.removeLiquidityHook,
                         RemoveLiquidityHookParams({
                             sender: msg.sender,
                             pool: pool,
@@ -441,9 +441,7 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
         uint256 exactBptAmountIn
     ) external returns (uint256[] memory amountsOut) {
         amountsOut = abi.decode(
-            _vault.unlock(
-                abi.encodeWithSelector(Router.removeLiquidityRecoveryHook.selector, pool, msg.sender, exactBptAmountIn)
-            ),
+            _vault.unlock(abi.encodeCall(Router.removeLiquidityRecoveryHook, (pool, msg.sender, exactBptAmountIn))),
             (uint256[])
         );
     }
@@ -540,8 +538,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
         return
             abi.decode(
                 _vault.unlock(
-                    abi.encodeWithSelector(
-                        Router.swapSingleTokenHook.selector,
+                    abi.encodeCall(
+                        Router.swapSingleTokenHook,
                         SwapSingleTokenHookParams({
                             sender: msg.sender,
                             kind: SwapKind.EXACT_IN,
@@ -574,8 +572,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
         return
             abi.decode(
                 _vault.unlock(
-                    abi.encodeWithSelector(
-                        Router.swapSingleTokenHook.selector,
+                    abi.encodeCall(
+                        Router.swapSingleTokenHook,
                         SwapSingleTokenHookParams({
                             sender: msg.sender,
                             kind: SwapKind.EXACT_OUT,
@@ -653,13 +651,15 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
         return
             abi.decode(
                 _vault.unlock(
-                    abi.encodeWithSelector(
-                        Router.addLiquidityToBufferHook.selector,
-                        wrappedToken,
-                        amountUnderlyingRaw,
-                        amountWrappedRaw,
-                        msg.sender, // sharesOwner
-                        false // isBufferInitialized
+                    abi.encodeCall(
+                        Router.addLiquidityToBufferHook,
+                        (
+                            wrappedToken,
+                            amountUnderlyingRaw,
+                            amountWrappedRaw,
+                            msg.sender, // sharesOwner
+                            false // isBufferInitialized
+                        )
                     )
                 ),
                 (uint256)
@@ -675,13 +675,15 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
         return
             abi.decode(
                 _vault.unlock(
-                    abi.encodeWithSelector(
-                        Router.addLiquidityToBufferHook.selector,
-                        wrappedToken,
-                        amountUnderlyingRaw,
-                        amountWrappedRaw,
-                        msg.sender, // sharesOwner
-                        true // isBufferInitialized
+                    abi.encodeCall(
+                        Router.addLiquidityToBufferHook,
+                        (
+                            wrappedToken,
+                            amountUnderlyingRaw,
+                            amountWrappedRaw,
+                            msg.sender, // sharesOwner
+                            true // isBufferInitialized
+                        )
                     )
                 ),
                 (uint256)
@@ -726,8 +728,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
     ) external saveSender returns (uint256[] memory amountsIn) {
         (amountsIn, , ) = abi.decode(
             _vault.quote(
-                abi.encodeWithSelector(
-                    Router.queryAddLiquidityHook.selector,
+                abi.encodeCall(
+                    Router.queryAddLiquidityHook,
                     AddLiquidityHookParams({
                         // We use the Router as a sender to simplify basic query functions,
                         // but it is possible to add liquidity to any recipient.
@@ -753,8 +755,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
     ) external saveSender returns (uint256 bptAmountOut) {
         (, bptAmountOut, ) = abi.decode(
             _vault.quote(
-                abi.encodeWithSelector(
-                    Router.queryAddLiquidityHook.selector,
+                abi.encodeCall(
+                    Router.queryAddLiquidityHook,
                     AddLiquidityHookParams({
                         // We use the Router as a sender to simplify basic query functions,
                         // but it is possible to add liquidity to any recipient.
@@ -787,8 +789,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
 
         (uint256[] memory amountsIn, , ) = abi.decode(
             _vault.quote(
-                abi.encodeWithSelector(
-                    Router.queryAddLiquidityHook.selector,
+                abi.encodeCall(
+                    Router.queryAddLiquidityHook,
                     AddLiquidityHookParams({
                         // We use the Router as a sender to simplify basic query functions,
                         // but it is possible to add liquidity to any recipient.
@@ -818,8 +820,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
         return
             abi.decode(
                 _vault.quote(
-                    abi.encodeWithSelector(
-                        Router.queryAddLiquidityHook.selector,
+                    abi.encodeCall(
+                        Router.queryAddLiquidityHook,
                         AddLiquidityHookParams({
                             // We use the Router as a sender to simplify basic query functions,
                             // but it is possible to add liquidity to any recipient.
@@ -869,8 +871,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
         uint256[] memory minAmountsOut = new uint256[](_vault.getPoolTokens(pool).length);
         (, amountsOut, ) = abi.decode(
             _vault.quote(
-                abi.encodeWithSelector(
-                    Router.queryRemoveLiquidityHook.selector,
+                abi.encodeCall(
+                    Router.queryRemoveLiquidityHook,
                     RemoveLiquidityHookParams({
                         // We use the Router as a sender to simplify basic query functions,
                         // but it is possible to remove liquidity from any sender.
@@ -900,8 +902,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
 
         (, uint256[] memory amountsOut, ) = abi.decode(
             _vault.quote(
-                abi.encodeWithSelector(
-                    Router.queryRemoveLiquidityHook.selector,
+                abi.encodeCall(
+                    Router.queryRemoveLiquidityHook,
                     RemoveLiquidityHookParams({
                         // We use the Router as a sender to simplify basic query functions,
                         // but it is possible to remove liquidity from any sender.
@@ -932,8 +934,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
 
         (bptAmountIn, , ) = abi.decode(
             _vault.quote(
-                abi.encodeWithSelector(
-                    Router.queryRemoveLiquidityHook.selector,
+                abi.encodeCall(
+                    Router.queryRemoveLiquidityHook,
                     RemoveLiquidityHookParams({
                         // We use the Router as a sender to simplify basic query functions,
                         // but it is possible to remove liquidity from any sender.
@@ -963,8 +965,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
         return
             abi.decode(
                 _vault.quote(
-                    abi.encodeWithSelector(
-                        Router.queryRemoveLiquidityHook.selector,
+                    abi.encodeCall(
+                        Router.queryRemoveLiquidityHook,
                         RemoveLiquidityHookParams({
                             // We use the Router as a sender to simplify basic query functions,
                             // but it is possible to remove liquidity from any sender.
@@ -990,12 +992,7 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
         return
             abi.decode(
                 _vault.quote(
-                    abi.encodeWithSelector(
-                        Router.queryRemoveLiquidityRecoveryHook.selector,
-                        pool,
-                        address(this),
-                        exactBptAmountIn
-                    )
+                    abi.encodeCall(Router.queryRemoveLiquidityRecoveryHook, (pool, address(this), exactBptAmountIn))
                 ),
                 (uint256[])
             );
@@ -1054,8 +1051,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
         return
             abi.decode(
                 _vault.quote(
-                    abi.encodeWithSelector(
-                        Router.querySwapHook.selector,
+                    abi.encodeCall(
+                        Router.querySwapHook,
                         SwapSingleTokenHookParams({
                             sender: msg.sender,
                             kind: SwapKind.EXACT_IN,
@@ -1085,8 +1082,8 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
         return
             abi.decode(
                 _vault.quote(
-                    abi.encodeWithSelector(
-                        Router.querySwapHook.selector,
+                    abi.encodeCall(
+                        Router.querySwapHook,
                         SwapSingleTokenHookParams({
                             sender: msg.sender,
                             kind: SwapKind.EXACT_OUT,

--- a/pkg/vault/contracts/VaultAdmin.sol
+++ b/pkg/vault/contracts/VaultAdmin.sol
@@ -506,12 +506,7 @@ contract VaultAdmin is IVaultAdmin, VaultCommon, Authentication, VaultGuard {
         return
             abi.decode(
                 _vault.unlock(
-                    abi.encodeWithSelector(
-                        VaultAdmin.removeLiquidityFromBufferHook.selector,
-                        wrappedToken,
-                        sharesToRemove,
-                        msg.sender
-                    )
+                    abi.encodeCall(VaultAdmin.removeLiquidityFromBufferHook, (wrappedToken, sharesToRemove, msg.sender))
                 ),
                 (uint256, uint256)
             );


### PR DESCRIPTION
# Description

Replace `encodeWithSelector` with the more type-safe/less error-prone `encodeCall`, per auditor suggestion.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Resolves #904 
