### PR TITLE
Remove redundant lock functions

### DIFF
--- a/pkg/interfaces/contracts/test/IVaultMainMock.sol
+++ b/pkg/interfaces/contracts/test/IVaultMainMock.sol
@@ -30,8 +30,6 @@ interface IVaultMainMock {
 
     function manualSetPoolRegistered(address pool, bool status) external;
 
-    function manualSetIsUnlocked(bool status) external;
-
     function manualSetInitializedPool(address pool, bool isPoolInitialized) external;
 
     function manualSetPoolPaused(address, bool) external;

--- a/pkg/vault/contracts/test/VaultMock.sol
+++ b/pkg/vault/contracts/test/VaultMock.sol
@@ -144,10 +144,6 @@ contract VaultMock is IVaultMainMock, Vault {
         _poolConfigBits[pool] = _poolConfigBits[pool].setPoolRegistered(status);
     }
 
-    function manualSetIsUnlocked(bool status) public {
-        _isUnlocked().tstore(status);
-    }
-
     function manualSetInitializedPool(address pool, bool isPoolInitialized) public {
         _poolConfigBits[pool] = _poolConfigBits[pool].setPoolInitialized(isPoolInitialized);
     }

--- a/pkg/vault/test/foundry/RouterCommon.t.sol
+++ b/pkg/vault/test/foundry/RouterCommon.t.sol
@@ -73,7 +73,8 @@ contract RouterCommonTest is BaseVaultTest {
     }
 
     function testTakeTokenInWethIsNotEth() public {
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
+
         uint256 amountToDeposit = weth.balanceOf(bob) / 100;
 
         EthStateTest memory vars = _createEthStateTest();
@@ -96,7 +97,8 @@ contract RouterCommonTest is BaseVaultTest {
     }
 
     function testSendTokenOutWethIsEth() public {
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
+
         vm.startPrank(lp);
         uint256 wethDeposit = lp.balance / 10;
         weth.deposit{ value: wethDeposit }();
@@ -122,7 +124,7 @@ contract RouterCommonTest is BaseVaultTest {
     }
 
     function testSendTokenOutWethIsNotEth() public {
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
 
         EthStateTest memory vars = _createEthStateTest();
 

--- a/pkg/vault/test/foundry/VaultExplorer.t.sol
+++ b/pkg/vault/test/foundry/VaultExplorer.t.sol
@@ -128,7 +128,7 @@ contract VaultExplorerTest is BaseVaultTest {
     function testUnlocked() public {
         assertFalse(explorer.isUnlocked(), "Should be locked");
 
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         assertTrue(explorer.isUnlocked(), "Should be unlocked");
     }
 
@@ -145,7 +145,7 @@ contract VaultExplorerTest is BaseVaultTest {
 
         dai.mint(address(vault), defaultAmount);
 
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         uint256 settlementAmount = vault.settle(dai, defaultAmount);
         int256 vaultDelta = vault.getTokenDelta(dai);
 
@@ -157,7 +157,7 @@ contract VaultExplorerTest is BaseVaultTest {
     function testGetReservesOf() public {
         dai.mint(address(vault), defaultAmount);
 
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         uint256 settlementAmount = vault.settle(dai, defaultAmount);
 
         assertEq(settlementAmount, defaultAmount, "Wrong settlement amount");

--- a/pkg/vault/test/foundry/mutation/vault/Vault.t.sol
+++ b/pkg/vault/test/foundry/mutation/vault/Vault.t.sol
@@ -66,7 +66,7 @@ contract VaultMutationTest is BaseVaultTest {
     }
 
     function testSettleReentrancy() public {
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         vm.expectRevert(ReentrancyGuardTransient.ReentrancyGuardReentrantCall.selector);
         vault.manualSettleReentrancy(dai);
     }
@@ -77,7 +77,7 @@ contract VaultMutationTest is BaseVaultTest {
     }
 
     function testSendToReentrancy() public {
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         vm.expectRevert(ReentrancyGuardTransient.ReentrancyGuardReentrantCall.selector);
         vault.manualSendToReentrancy(dai, address(0), 0);
     }
@@ -153,7 +153,7 @@ contract VaultMutationTest is BaseVaultTest {
 
     function testErc4626BufferWrapOrUnwrapWhenNotInitialized() public {
         IERC4626 wrappedToken = IERC4626(address(123));
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
 
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.BufferNotInitialized.selector, wrappedToken));
         BufferWrapOrUnwrapParams memory params;
@@ -162,7 +162,7 @@ contract VaultMutationTest is BaseVaultTest {
     }
 
     function testErc4626BufferWrapOrUnwrapWhenBuffersArePaused() public {
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         authorizer.grantRole(vault.getActionId(IVaultAdmin.pauseVaultBuffers.selector), admin);
         vm.prank(admin);
         vault.pauseVaultBuffers();
@@ -175,7 +175,7 @@ contract VaultMutationTest is BaseVaultTest {
     function testErc4626BufferWrapOrUnwrapReentrancy() public {
         IERC4626 wrappedToken = IERC4626(address(123));
         address underlyingToken = address(345); // Anything non-zero
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         vault.manualSetBufferAsset(wrappedToken, underlyingToken);
 
         vm.expectRevert(ReentrancyGuardTransient.ReentrancyGuardReentrantCall.selector);

--- a/pkg/vault/test/foundry/mutation/vault/VaultAdmin.t.sol
+++ b/pkg/vault/test/foundry/mutation/vault/VaultAdmin.t.sol
@@ -147,13 +147,13 @@ contract VaultAdminMutationTest is BaseVaultTest {
     }
 
     function testCollectAggregateFeesWhenNotProtocolFeeController() public {
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         vault.collectAggregateFees(address(0));
     }
 
     function testCollectAggregateFeesWithoutRegisteredPool() public {
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         vm.prank(address(vault.getProtocolFeeController()));
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolNotRegistered.selector, address(0)));
         vault.collectAggregateFees(address(0));
@@ -269,7 +269,7 @@ contract VaultAdminMutationTest is BaseVaultTest {
     }
 
     function testInitializeBufferWhenPaused() public {
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         authorizer.grantRole(vault.getActionId(IVaultAdmin.pauseVaultBuffers.selector), admin);
         vm.prank(admin);
         vault.pauseVaultBuffers();
@@ -281,7 +281,7 @@ contract VaultAdminMutationTest is BaseVaultTest {
     function testInitializeBufferNonReentrant() public {
         IERC4626 wrappedToken = IERC4626(address(123));
         address underlyingToken = address(345); // Anything non-zero
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         vault.manualSetBufferAsset(wrappedToken, underlyingToken);
         vm.expectRevert(ReentrancyGuardTransient.ReentrancyGuardReentrantCall.selector);
         vault.manualReentrancyAddLiquidityToBuffer(wrappedToken, 0, 0, address(0));
@@ -298,7 +298,7 @@ contract VaultAdminMutationTest is BaseVaultTest {
     }
 
     function testAddLiquidityToBufferWhenPaused() public {
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         authorizer.grantRole(vault.getActionId(IVaultAdmin.pauseVaultBuffers.selector), admin);
         vm.prank(admin);
         vault.pauseVaultBuffers();
@@ -309,7 +309,7 @@ contract VaultAdminMutationTest is BaseVaultTest {
 
     function testAddLiquidityFromBufferWhenNotInitialized() public {
         IERC4626 wrappedToken = IERC4626(address(123));
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.BufferNotInitialized.selector, wrappedToken));
         vault.addLiquidityToBuffer(wrappedToken, 0, 0, address(0));
     }
@@ -317,7 +317,7 @@ contract VaultAdminMutationTest is BaseVaultTest {
     function testAddLiquidityToBufferNonReentrant() public {
         IERC4626 wrappedToken = IERC4626(address(123));
         address underlyingToken = address(345); // Anything non-zero
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         vault.manualSetBufferAsset(wrappedToken, underlyingToken);
         vm.expectRevert(ReentrancyGuardTransient.ReentrancyGuardReentrantCall.selector);
         vault.manualReentrancyAddLiquidityToBuffer(wrappedToken, 0, 0, address(0));
@@ -341,7 +341,7 @@ contract VaultAdminMutationTest is BaseVaultTest {
 
     function testRemoveLiquidityFromBufferHookWhenNotInitialized() public {
         IERC4626 wrappedToken = IERC4626(address(123));
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         vm.prank(address(vault));
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.BufferNotInitialized.selector, wrappedToken));
         VaultAdmin(address(vault)).removeLiquidityFromBufferHook(wrappedToken, 0, address(0));
@@ -350,7 +350,7 @@ contract VaultAdminMutationTest is BaseVaultTest {
     function testRemoveLiquidityFromBufferNonReentrant() public {
         IERC4626 wrappedToken = IERC4626(address(123));
         address underlyingToken = address(345); // Anything non-zero
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         vault.manualSetBufferAsset(wrappedToken, underlyingToken);
 
         // Manually set owner and total shares so that the call doesn't revert before hitting the reentrancy guard.

--- a/pkg/vault/test/foundry/mutation/vault/VaultExtension.t.sol
+++ b/pkg/vault/test/foundry/mutation/vault/VaultExtension.t.sol
@@ -76,7 +76,7 @@ contract VaultExtensionMutationTest is BaseVaultTest {
         IERC20[] memory tokens;
         uint256[] memory exactAmountsIn;
 
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
 
         vm.expectRevert(ReentrancyGuardTransient.ReentrancyGuardReentrantCall.selector);
         vault.manualInitializePoolReentrancy(pool, address(0), tokens, exactAmountsIn, 0, "");

--- a/pkg/vault/test/foundry/unit/VaultAdminUnit.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultAdminUnit.t.sol
@@ -137,7 +137,7 @@ contract VaultAdminUnitTest is BaseVaultTest {
     ********************************************************************************/
 
     function testInitializeBufferTwice() public {
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         vault.initializeBuffer(waDAI, liquidityAmount, liquidityAmount, bob);
 
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.BufferAlreadyInitialized.selector, waDAI));
@@ -145,7 +145,7 @@ contract VaultAdminUnitTest is BaseVaultTest {
     }
 
     function testInitializeBufferAddressZero() public {
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         waDAI.setAsset(IERC20(address(0)));
 
         vm.expectRevert(IVaultErrors.InvalidUnderlyingToken.selector);
@@ -153,7 +153,7 @@ contract VaultAdminUnitTest is BaseVaultTest {
     }
 
     function testInitializeBufferBelowMinimumShares() public {
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         vm.expectRevert(
             abi.encodeWithSelector(IERC20MultiTokenErrors.TotalSupplyTooLow.selector, 3, _MINIMUM_TOTAL_SUPPLY)
         );
@@ -163,7 +163,7 @@ contract VaultAdminUnitTest is BaseVaultTest {
     function testInitializeBuffer() public {
         dai.mint(address(waDAI), underlyingTokensToDeposit); // This will make the rate = 2
 
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         uint256 underlyingAmount = liquidityAmount * 2;
         uint256 wrappedAmount = liquidityAmount;
 

--- a/pkg/vault/test/foundry/unit/VaultCommonModifiers.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultCommonModifiers.t.sol
@@ -18,14 +18,14 @@ contract VaultCommonModifiersTest is BaseVaultTest {
     *******************************************************************************/
 
     function testLock() public {
-        vault.manualSetIsUnlocked(false);
+        vault.forceLock();
 
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.VaultIsNotUnlocked.selector));
         vault.mockIsUnlocked();
     }
 
     function testUnlock() public {
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
 
         // If function does not revert, test passes
         vault.mockIsUnlocked();

--- a/pkg/vault/test/foundry/unit/VaultUnit.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultUnit.t.sol
@@ -177,7 +177,7 @@ contract VaultUnitTest is BaseTest {
         addedReserves = bound(addedReserves, 0, 1e12 * 1e18);
         settleHint = bound(settleHint, 0, addedReserves * 2);
 
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         vault.manualSetReservesOf(dai, initialReserves);
 
         dai.mint(address(vault), initialReserves);
@@ -196,7 +196,7 @@ contract VaultUnitTest is BaseTest {
     }
 
     function testSettleNegative() public {
-        vault.manualSetIsUnlocked(true);
+        vault.forceUnlock();
         vault.manualSetReservesOf(dai, 100);
         // Simulate balance decrease.
         vm.mockCall(address(dai), abi.encodeWithSelector(IERC20.balanceOf.selector), abi.encode(99));


### PR DESCRIPTION
# Description

Noticed during review that we have multiple mock functions that do the same thing. Adopting the "no argument" one - forceLock/Unlock, vs. the more cumbersome manualSetIsUnlocked(bool). Not sure when this duplication was introduced.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
