### PR TITLE
Replace encodeWithSelector with encodeCall on tests

### DIFF
--- a/pkg/pool-utils/test/foundry/PoolInfo.t.sol
+++ b/pkg/pool-utils/test/foundry/PoolInfo.t.sol
@@ -36,12 +36,12 @@ contract PoolInfoTest is BaseTest {
 
         vm.mockCall(
             address(poolInfo),
-            abi.encodeWithSelector(ISwapFeePercentageBounds.getMinimumSwapFeePercentage.selector),
+            abi.encodeCall(ISwapFeePercentageBounds.getMinimumSwapFeePercentage),
             abi.encode(0)
         );
         vm.mockCall(
             address(poolInfo),
-            abi.encodeWithSelector(ISwapFeePercentageBounds.getMaximumSwapFeePercentage.selector),
+            abi.encodeCall(ISwapFeePercentageBounds.getMaximumSwapFeePercentage),
             abi.encode(FixedPoint.ONE) // 100%
         );
         vault.manualRegisterPool(address(poolInfo), poolTokens);

--- a/pkg/pool-utils/test/foundry/PoolInfo.t.sol
+++ b/pkg/pool-utils/test/foundry/PoolInfo.t.sol
@@ -36,12 +36,12 @@ contract PoolInfoTest is BaseTest {
 
         vm.mockCall(
             address(poolInfo),
-            abi.encodeCall(ISwapFeePercentageBounds.getMinimumSwapFeePercentage),
+            abi.encodeWithSelector(ISwapFeePercentageBounds.getMinimumSwapFeePercentage.selector),
             abi.encode(0)
         );
         vm.mockCall(
             address(poolInfo),
-            abi.encodeCall(ISwapFeePercentageBounds.getMaximumSwapFeePercentage),
+            abi.encodeWithSelector(ISwapFeePercentageBounds.getMaximumSwapFeePercentage.selector),
             abi.encode(FixedPoint.ONE) // 100%
         );
         vault.manualRegisterPool(address(poolInfo), poolTokens);

--- a/pkg/vault/test/foundry/BufferVaultPrimitive.t.sol
+++ b/pkg/vault/test/foundry/BufferVaultPrimitive.t.sol
@@ -190,8 +190,8 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
         uint256 vaultBalance = dai.balanceOf(address(vault));
 
         vault.unlock(
-            abi.encodeWithSelector(
-                BufferVaultPrimitiveTest.erc4626MaliciousHook.selector,
+            abi.encodeCall(
+                BufferVaultPrimitiveTest.erc4626MaliciousHook,
                 BufferWrapOrUnwrapParams({
                     kind: SwapKind.EXACT_IN,
                     direction: WrappingDirection.WRAP,
@@ -249,8 +249,8 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
         waDAI.setMaliciousWrapper(true);
 
         vault.unlock(
-            abi.encodeWithSelector(
-                BufferVaultPrimitiveTest.erc4626MaliciousHook.selector,
+            abi.encodeCall(
+                BufferVaultPrimitiveTest.erc4626MaliciousHook,
                 BufferWrapOrUnwrapParams({
                     kind: SwapKind.EXACT_OUT,
                     direction: WrappingDirection.WRAP,

--- a/pkg/vault/test/foundry/DynamicFeePoolTest.t.sol
+++ b/pkg/vault/test/foundry/DynamicFeePoolTest.t.sol
@@ -92,13 +92,13 @@ contract DynamicFeePoolTest is BaseVaultTest {
 
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(PoolHooksMock.onComputeDynamicSwapFeePercentage.selector, poolSwapParams, pool, 0),
+            abi.encodeCall(PoolHooksMock.onComputeDynamicSwapFeePercentage, (poolSwapParams, pool, 0)),
             1 // callCount
         );
 
         vm.expectCall(
             pool,
-            abi.encodeWithSelector(PoolMock.onSwap.selector, poolSwapParams),
+            abi.encodeCall(PoolMock.onSwap, poolSwapParams),
             1 // callCount
         );
 
@@ -130,13 +130,13 @@ contract DynamicFeePoolTest is BaseVaultTest {
 
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(PoolHooksMock.onComputeDynamicSwapFeePercentage.selector, poolSwapParams, pool, 0),
+            abi.encodeCall(PoolHooksMock.onComputeDynamicSwapFeePercentage, (poolSwapParams, pool, 0)),
             1 // callCount
         );
 
         vm.expectCall(
             pool,
-            abi.encodeWithSelector(PoolMock.onSwap.selector, poolSwapParams),
+            abi.encodeCall(PoolMock.onSwap, poolSwapParams),
             1 // callCount
         );
 
@@ -173,19 +173,21 @@ contract DynamicFeePoolTest is BaseVaultTest {
 
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onComputeDynamicSwapFeePercentage.selector,
-                PoolSwapParams({
-                    kind: SwapKind.EXACT_IN,
-                    amountGivenScaled18: 0,
-                    balancesScaled18: balances,
-                    indexIn: 0,
-                    indexOut: 0,
-                    router: address(0),
-                    userData: bytes("")
-                }),
-                pool,
-                10e16
+            abi.encodeCall(
+                IHooks.onComputeDynamicSwapFeePercentage,
+                (
+                    PoolSwapParams({
+                        kind: SwapKind.EXACT_IN,
+                        amountGivenScaled18: 0,
+                        balancesScaled18: balances,
+                        indexIn: 0,
+                        indexOut: 0,
+                        router: address(0),
+                        userData: bytes("")
+                    }),
+                    pool,
+                    10e16
+                )
             ),
             1 // callCount
         );

--- a/pkg/vault/test/foundry/HookAdjustedLiquidity.t.sol
+++ b/pkg/vault/test/foundry/HookAdjustedLiquidity.t.sol
@@ -112,16 +112,18 @@ contract HookAdjustedLiquidityTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onAfterAddLiquidity.selector,
-                address(router),
-                pool,
-                AddLiquidityKind.PROPORTIONAL,
-                actualAmountsIn,
-                actualAmountsIn,
-                expectedBptOut,
-                expectedBalances,
-                bytes("")
+            abi.encodeCall(
+                IHooks.onAfterAddLiquidity,
+                (
+                    address(router),
+                    pool,
+                    AddLiquidityKind.PROPORTIONAL,
+                    actualAmountsIn,
+                    actualAmountsIn,
+                    expectedBptOut,
+                    expectedBalances,
+                    bytes("")
+                )
             )
         );
 
@@ -159,16 +161,18 @@ contract HookAdjustedLiquidityTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onAfterAddLiquidity.selector,
-                address(router),
-                pool,
-                AddLiquidityKind.PROPORTIONAL,
-                actualAmountsIn,
-                actualAmountsIn,
-                expectedBptOut,
-                expectedBalances,
-                bytes("")
+            abi.encodeCall(
+                IHooks.onAfterAddLiquidity,
+                (
+                    address(router),
+                    pool,
+                    AddLiquidityKind.PROPORTIONAL,
+                    actualAmountsIn,
+                    actualAmountsIn,
+                    expectedBptOut,
+                    expectedBalances,
+                    bytes("")
+                )
             )
         );
 
@@ -260,16 +264,18 @@ contract HookAdjustedLiquidityTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onAfterRemoveLiquidity.selector,
-                address(router),
-                pool,
-                RemoveLiquidityKind.PROPORTIONAL,
-                expectedBptIn,
-                actualAmountsOut,
-                actualAmountsOut,
-                expectedBalances,
-                bytes("")
+            abi.encodeCall(
+                IHooks.onAfterRemoveLiquidity,
+                (
+                    address(router),
+                    pool,
+                    RemoveLiquidityKind.PROPORTIONAL,
+                    expectedBptIn,
+                    actualAmountsOut,
+                    actualAmountsOut,
+                    expectedBalances,
+                    bytes("")
+                )
             )
         );
 
@@ -318,16 +324,18 @@ contract HookAdjustedLiquidityTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onAfterRemoveLiquidity.selector,
-                address(router),
-                pool,
-                RemoveLiquidityKind.PROPORTIONAL,
-                expectedBptIn,
-                actualAmountsOut,
-                actualAmountsOut,
-                expectedBalances,
-                bytes("")
+            abi.encodeCall(
+                IHooks.onAfterRemoveLiquidity,
+                (
+                    address(router),
+                    pool,
+                    RemoveLiquidityKind.PROPORTIONAL,
+                    expectedBptIn,
+                    actualAmountsOut,
+                    actualAmountsOut,
+                    expectedBalances,
+                    bytes("")
+                )
             )
         );
 

--- a/pkg/vault/test/foundry/HookAdjustedSwap.t.sol
+++ b/pkg/vault/test/foundry/HookAdjustedSwap.t.sol
@@ -79,8 +79,8 @@ contract HookAdjustedSwapTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onAfterSwap.selector,
+            abi.encodeCall(
+                IHooks.onAfterSwap,
                 AfterSwapParams({
                     kind: SwapKind.EXACT_IN,
                     tokenIn: dai,
@@ -141,8 +141,8 @@ contract HookAdjustedSwapTest is BaseVaultTest {
         // Check that balances were not changed before onBeforeHook.
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onAfterSwap.selector,
+            abi.encodeCall(
+                IHooks.onAfterSwap,
                 AfterSwapParams({
                     kind: SwapKind.EXACT_IN,
                     tokenIn: dai,
@@ -200,8 +200,8 @@ contract HookAdjustedSwapTest is BaseVaultTest {
         // Check that balances were not changed before onBeforeHook.
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onAfterSwap.selector,
+            abi.encodeCall(
+                IHooks.onAfterSwap,
                 AfterSwapParams({
                     kind: SwapKind.EXACT_OUT,
                     tokenIn: dai,
@@ -271,8 +271,8 @@ contract HookAdjustedSwapTest is BaseVaultTest {
         // Check that balances were not changed before onBeforeHook.
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onAfterSwap.selector,
+            abi.encodeCall(
+                IHooks.onAfterSwap,
                 AfterSwapParams({
                     kind: SwapKind.EXACT_OUT,
                     tokenIn: dai,
@@ -333,8 +333,8 @@ contract HookAdjustedSwapTest is BaseVaultTest {
         // Check that  onAfterHook was called with the correct params.
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onAfterSwap.selector,
+            abi.encodeCall(
+                IHooks.onAfterSwap,
                 AfterSwapParams({
                     kind: SwapKind.EXACT_IN,
                     tokenIn: dai,
@@ -378,8 +378,8 @@ contract HookAdjustedSwapTest is BaseVaultTest {
         // Check that onAfterSwap was called with the correct parameters.
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onAfterSwap.selector,
+            abi.encodeCall(
+                IHooks.onAfterSwap,
                 AfterSwapParams({
                     kind: SwapKind.EXACT_OUT,
                     tokenIn: dai,
@@ -424,8 +424,8 @@ contract HookAdjustedSwapTest is BaseVaultTest {
         // Check that onAfterHook was called with the correct params.
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onAfterSwap.selector,
+            abi.encodeCall(
+                IHooks.onAfterSwap,
                 AfterSwapParams({
                     kind: SwapKind.EXACT_IN,
                     tokenIn: dai,

--- a/pkg/vault/test/foundry/Hooks.t.sol
+++ b/pkg/vault/test/foundry/Hooks.t.sol
@@ -96,12 +96,9 @@ contract HooksTest is BaseVaultTest {
 
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onRegister.selector,
-                address(anotherFactory),
-                address(anotherPool),
-                tokenConfig,
-                liquidityManagement
+            abi.encodeCall(
+                IHooks.onRegister,
+                (address(anotherFactory), address(anotherPool), tokenConfig, liquidityManagement)
             )
         );
 
@@ -160,19 +157,21 @@ contract HooksTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onComputeDynamicSwapFeePercentage.selector,
-                PoolSwapParams({
-                    kind: SwapKind.EXACT_IN,
-                    amountGivenScaled18: defaultAmount,
-                    balancesScaled18: [defaultAmount, defaultAmount].toMemoryArray(),
-                    indexIn: usdcIdx,
-                    indexOut: daiIdx,
-                    router: address(router),
-                    userData: bytes("")
-                }),
-                pool,
-                0
+            abi.encodeCall(
+                IHooks.onComputeDynamicSwapFeePercentage,
+                (
+                    PoolSwapParams({
+                        kind: SwapKind.EXACT_IN,
+                        amountGivenScaled18: defaultAmount,
+                        balancesScaled18: [defaultAmount, defaultAmount].toMemoryArray(),
+                        indexIn: usdcIdx,
+                        indexOut: daiIdx,
+                        router: address(router),
+                        userData: bytes("")
+                    }),
+                    pool,
+                    0
+                )
             )
         );
         router.swapSingleTokenExactIn(pool, usdc, dai, defaultAmount, 0, MAX_UINT256, false, bytes(""));
@@ -192,19 +191,21 @@ contract HooksTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onComputeDynamicSwapFeePercentage.selector,
-                PoolSwapParams({
-                    kind: SwapKind.EXACT_IN,
-                    amountGivenScaled18: defaultAmount,
-                    balancesScaled18: [defaultAmount, defaultAmount].toMemoryArray(),
-                    indexIn: usdcIdx,
-                    indexOut: daiIdx,
-                    router: address(router),
-                    userData: bytes("")
-                }),
-                pool,
-                staticSwapFeePercentage
+            abi.encodeCall(
+                IHooks.onComputeDynamicSwapFeePercentage,
+                (
+                    PoolSwapParams({
+                        kind: SwapKind.EXACT_IN,
+                        amountGivenScaled18: defaultAmount,
+                        balancesScaled18: [defaultAmount, defaultAmount].toMemoryArray(),
+                        indexIn: usdcIdx,
+                        indexOut: daiIdx,
+                        router: address(router),
+                        userData: bytes("")
+                    }),
+                    pool,
+                    staticSwapFeePercentage
+                )
             )
         );
         router.swapSingleTokenExactIn(pool, usdc, dai, defaultAmount, 0, MAX_UINT256, false, bytes(""));
@@ -232,18 +233,20 @@ contract HooksTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onBeforeSwap.selector,
-                PoolSwapParams({
-                    kind: SwapKind.EXACT_IN,
-                    amountGivenScaled18: defaultAmount,
-                    balancesScaled18: [defaultAmount, defaultAmount].toMemoryArray(),
-                    indexIn: usdcIdx,
-                    indexOut: daiIdx,
-                    router: address(router),
-                    userData: bytes("")
-                }),
-                pool
+            abi.encodeCall(
+                IHooks.onBeforeSwap,
+                (
+                    PoolSwapParams({
+                        kind: SwapKind.EXACT_IN,
+                        amountGivenScaled18: defaultAmount,
+                        balancesScaled18: [defaultAmount, defaultAmount].toMemoryArray(),
+                        indexIn: usdcIdx,
+                        indexOut: daiIdx,
+                        router: address(router),
+                        userData: bytes("")
+                    }),
+                    pool
+                )
             )
         );
         router.swapSingleTokenExactIn(pool, usdc, dai, defaultAmount, 0, MAX_UINT256, false, bytes(""));
@@ -279,8 +282,8 @@ contract HooksTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onAfterSwap.selector,
+            abi.encodeCall(
+                IHooks.onAfterSwap,
                 AfterSwapParams({
                     kind: SwapKind.EXACT_IN,
                     tokenIn: usdc,
@@ -337,15 +340,17 @@ contract HooksTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onBeforeAddLiquidity.selector,
-                router,
-                pool,
-                AddLiquidityKind.UNBALANCED,
-                [defaultAmount, defaultAmount].toMemoryArray(),
-                bptAmountRoundDown,
-                [defaultAmount, defaultAmount].toMemoryArray(),
-                bytes("")
+            abi.encodeCall(
+                IHooks.onBeforeAddLiquidity,
+                (
+                    address(router),
+                    pool,
+                    AddLiquidityKind.UNBALANCED,
+                    [defaultAmount, defaultAmount].toMemoryArray(),
+                    bptAmountRoundDown,
+                    [defaultAmount, defaultAmount].toMemoryArray(),
+                    bytes("")
+                )
             )
         );
         router.addLiquidityUnbalanced(
@@ -416,15 +421,17 @@ contract HooksTest is BaseVaultTest {
 
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onBeforeRemoveLiquidity.selector,
-                router,
-                pool,
-                RemoveLiquidityKind.PROPORTIONAL,
-                bptAmount,
-                [defaultAmountRoundDown, defaultAmountRoundDown].toMemoryArray(),
-                [2 * defaultAmount, 2 * defaultAmount].toMemoryArray(),
-                bytes("")
+            abi.encodeCall(
+                IHooks.onBeforeRemoveLiquidity,
+                (
+                    address(router),
+                    pool,
+                    RemoveLiquidityKind.PROPORTIONAL,
+                    bptAmount,
+                    [defaultAmountRoundDown, defaultAmountRoundDown].toMemoryArray(),
+                    [2 * defaultAmount, 2 * defaultAmount].toMemoryArray(),
+                    bytes("")
+                )
             )
         );
         vm.prank(alice);
@@ -490,16 +497,18 @@ contract HooksTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onAfterAddLiquidity.selector,
-                router,
-                pool,
-                AddLiquidityKind.UNBALANCED,
-                [defaultAmount, defaultAmount].toMemoryArray(),
-                [defaultAmount, defaultAmount].toMemoryArray(),
-                bptAmount,
-                [2 * defaultAmount, 2 * defaultAmount].toMemoryArray(),
-                bytes("")
+            abi.encodeCall(
+                IHooks.onAfterAddLiquidity,
+                (
+                    address(router),
+                    pool,
+                    AddLiquidityKind.UNBALANCED,
+                    [defaultAmount, defaultAmount].toMemoryArray(),
+                    [defaultAmount, defaultAmount].toMemoryArray(),
+                    bptAmount,
+                    [2 * defaultAmount, 2 * defaultAmount].toMemoryArray(),
+                    bytes("")
+                )
             )
         );
         router.addLiquidityUnbalanced(
@@ -589,16 +598,18 @@ contract HooksTest is BaseVaultTest {
 
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onAfterRemoveLiquidity.selector,
-                router,
-                pool,
-                RemoveLiquidityKind.PROPORTIONAL,
-                bptAmount,
-                [defaultAmount, defaultAmount].toMemoryArray(),
-                [defaultAmount, defaultAmount].toMemoryArray(),
-                [defaultAmount, defaultAmount].toMemoryArray(),
-                bytes("")
+            abi.encodeCall(
+                IHooks.onAfterRemoveLiquidity,
+                (
+                    address(router),
+                    pool,
+                    RemoveLiquidityKind.PROPORTIONAL,
+                    bptAmount,
+                    [defaultAmount, defaultAmount].toMemoryArray(),
+                    [defaultAmount, defaultAmount].toMemoryArray(),
+                    [defaultAmount, defaultAmount].toMemoryArray(),
+                    bytes("")
+                )
             )
         );
 

--- a/pkg/vault/test/foundry/HooksAlteringBalances.t.sol
+++ b/pkg/vault/test/foundry/HooksAlteringBalances.t.sol
@@ -68,25 +68,27 @@ contract HooksAlteringBalancesTest is BaseVaultTest {
         // Check that balances were not changed before onBeforeHook.
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onBeforeSwap.selector,
-                PoolSwapParams({
-                    kind: SwapKind.EXACT_IN,
-                    amountGivenScaled18: _swapAmount,
-                    balancesScaled18: originalBalances,
-                    indexIn: daiIdx,
-                    indexOut: usdcIdx,
-                    router: address(router),
-                    userData: bytes("")
-                }),
-                pool
+            abi.encodeCall(
+                IHooks.onBeforeSwap,
+                (
+                    PoolSwapParams({
+                        kind: SwapKind.EXACT_IN,
+                        amountGivenScaled18: _swapAmount,
+                        balancesScaled18: originalBalances,
+                        indexIn: daiIdx,
+                        indexOut: usdcIdx,
+                        router: address(router),
+                        userData: bytes("")
+                    }),
+                    pool
+                )
             )
         );
 
         vm.expectCall(
             pool,
-            abi.encodeWithSelector(
-                IBasePool.onSwap.selector,
+            abi.encodeCall(
+                IBasePool.onSwap,
                 PoolSwapParams({
                     kind: SwapKind.EXACT_IN,
                     amountGivenScaled18: _swapAmount,
@@ -119,27 +121,25 @@ contract HooksAlteringBalancesTest is BaseVaultTest {
         // Check that balances were not changed before onBeforeHook.
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onBeforeAddLiquidity.selector,
-                router,
-                pool,
-                AddLiquidityKind.CUSTOM,
-                amountsIn,
-                bptAmountRoundDown,
-                originalBalances,
-                bytes("")
+            abi.encodeCall(
+                IHooks.onBeforeAddLiquidity,
+                (
+                    address(router),
+                    pool,
+                    AddLiquidityKind.CUSTOM,
+                    amountsIn,
+                    bptAmountRoundDown,
+                    originalBalances,
+                    bytes("")
+                )
             )
         );
 
         vm.expectCall(
             pool,
-            abi.encodeWithSelector(
-                IPoolLiquidity.onAddLiquidityCustom.selector,
-                router,
-                amountsIn,
-                bptAmountRoundDown,
-                newBalances,
-                bytes("")
+            abi.encodeCall(
+                IPoolLiquidity.onAddLiquidityCustom,
+                (address(router), amountsIn, bptAmountRoundDown, newBalances, bytes(""))
             )
         );
 
@@ -170,28 +170,18 @@ contract HooksAlteringBalancesTest is BaseVaultTest {
         // Check if balances were not changed before onBeforeHook.
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onBeforeRemoveLiquidity.selector,
-                router,
-                pool,
-                RemoveLiquidityKind.CUSTOM,
-                bptAmount,
-                amountsOut,
-                originalBalances,
-                bytes("")
+            abi.encodeCall(
+                IHooks.onBeforeRemoveLiquidity,
+                (address(router), pool, RemoveLiquidityKind.CUSTOM, bptAmount, amountsOut, originalBalances, bytes(""))
             )
         );
 
         // removeLiquidityCustom passes the minAmountsOut to the callback, so we can check that they are updated.
         vm.expectCall(
             pool,
-            abi.encodeWithSelector(
-                IPoolLiquidity.onRemoveLiquidityCustom.selector,
-                router,
-                bptAmount,
-                amountsOut,
-                newBalances,
-                bytes("")
+            abi.encodeCall(
+                IPoolLiquidity.onRemoveLiquidityCustom,
+                (address(router), bptAmount, amountsOut, newBalances, bytes(""))
             )
         );
         vm.prank(alice);

--- a/pkg/vault/test/foundry/HooksAlteringRates.t.sol
+++ b/pkg/vault/test/foundry/HooksAlteringRates.t.sol
@@ -70,8 +70,8 @@ contract HooksAlteringRatesTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectCall(
             pool,
-            abi.encodeWithSelector(
-                IBasePool.onSwap.selector,
+            abi.encodeCall(
+                IBasePool.onSwap,
                 PoolSwapParams({
                     kind: SwapKind.EXACT_IN,
                     amountGivenScaled18: rateAdjustedAmount,
@@ -121,7 +121,7 @@ contract HooksAlteringRatesTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(IHooks.onAfterInitialize.selector, expectedAmounts, bptAmount, "")
+            abi.encodeCall(IHooks.onAfterInitialize, (expectedAmounts, bptAmount, ""))
         );
 
         router.initialize(
@@ -160,16 +160,18 @@ contract HooksAlteringRatesTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onAfterAddLiquidity.selector,
-                router,
-                pool,
-                AddLiquidityKind.UNBALANCED,
-                expectedAmountsIn,
-                [defaultAmount, defaultAmount].toMemoryArray(),
-                defaultAmount * 2,
-                expectedBalances,
-                bytes("")
+            abi.encodeCall(
+                IHooks.onAfterAddLiquidity,
+                (
+                    address(router),
+                    pool,
+                    AddLiquidityKind.UNBALANCED,
+                    expectedAmountsIn,
+                    [defaultAmount, defaultAmount].toMemoryArray(),
+                    defaultAmount * 2,
+                    expectedBalances,
+                    bytes("")
+                )
             )
         );
 
@@ -213,13 +215,9 @@ contract HooksAlteringRatesTest is BaseVaultTest {
         // removeLiquidityCustom passes the minAmountsOut to the callback, so we can check that they are updated.
         vm.expectCall(
             pool,
-            abi.encodeWithSelector(
-                IPoolLiquidity.onRemoveLiquidityCustom.selector,
-                router,
-                bptAmount,
-                expectedAmountsOut,
-                expectedBalances,
-                bytes("")
+            abi.encodeCall(
+                IPoolLiquidity.onRemoveLiquidityCustom,
+                (address(router), bptAmount, expectedAmountsOut, expectedBalances, bytes(""))
             )
         );
         vm.prank(alice);

--- a/pkg/vault/test/foundry/Initializer.t.sol
+++ b/pkg/vault/test/foundry/Initializer.t.sol
@@ -61,11 +61,7 @@ contract InitializerTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onBeforeInitialize.selector,
-                [defaultAmount, defaultAmount].toMemoryArray(),
-                bytes("0xff")
-            )
+            abi.encodeCall(IHooks.onBeforeInitialize, ([defaultAmount, defaultAmount].toMemoryArray(), bytes("0xff")))
         );
         router.initialize(
             pool,
@@ -95,11 +91,9 @@ contract InitializerTest is BaseVaultTest {
         vm.prank(bob);
         vm.expectCall(
             address(poolHooksContract),
-            abi.encodeWithSelector(
-                IHooks.onAfterInitialize.selector,
-                [defaultAmount, defaultAmount].toMemoryArray(),
-                2 * defaultAmount - MIN_BPT,
-                bytes("0xff")
+            abi.encodeCall(
+                IHooks.onAfterInitialize,
+                ([defaultAmount, defaultAmount].toMemoryArray(), 2 * defaultAmount - MIN_BPT, bytes("0xff"))
             )
         );
         router.initialize(

--- a/pkg/vault/test/foundry/Permit2.t.sol
+++ b/pkg/vault/test/foundry/Permit2.t.sol
@@ -93,23 +93,15 @@ contract Permit2Test is BaseVaultTest {
         );
 
         bytes[] memory multicallData = new bytes[](2);
-        multicallData[0] = abi.encodeWithSelector(
-            IRouter.addLiquidityUnbalanced.selector,
-            pool,
-            amountsIn,
-            bptAmountOut,
-            false,
-            bytes("")
+        multicallData[0] = abi.encodeCall(
+            IRouter.addLiquidityUnbalanced,
+            (pool, amountsIn, bptAmountOut, false, bytes(""))
         );
 
         uint256[] memory minAmountsOut = [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray();
-        multicallData[1] = abi.encodeWithSelector(
-            IRouter.removeLiquidityProportional.selector,
-            pool,
-            bptAmountOut,
-            minAmountsOut,
-            false,
-            bytes("")
+        multicallData[1] = abi.encodeCall(
+            IRouter.removeLiquidityProportional,
+            (pool, bptAmountOut, minAmountsOut, false, bytes(""))
         );
 
         vm.prank(alice);
@@ -136,13 +128,9 @@ contract Permit2Test is BaseVaultTest {
         uint256[] memory amountsIn = [uint256(defaultAmount), uint256(defaultAmount)].toMemoryArray();
         bptAmountOut = defaultAmount * 2;
 
-        multicallData[0] = abi.encodeWithSelector(
-            IRouter.addLiquidityUnbalanced.selector,
-            pool,
-            amountsIn,
-            bptAmountOut,
-            false,
-            bytes("")
+        multicallData[0] = abi.encodeCall(
+            IRouter.addLiquidityUnbalanced,
+            (pool, amountsIn, bptAmountOut, false, bytes(""))
         );
 
         vm.expectCall(address(router), multicallData[0]);

--- a/pkg/vault/test/foundry/ProtocolFeeController.t.sol
+++ b/pkg/vault/test/foundry/ProtocolFeeController.t.sol
@@ -736,10 +736,7 @@ contract ProtocolFeeControllerTest is BaseVaultTest {
         swapAmounts[daiIdx] = PROTOCOL_SWAP_FEE_AMOUNT;
         yieldAmounts[usdcIdx] = PROTOCOL_YIELD_FEE_AMOUNT;
 
-        vm.expectCall(
-            address(feeController),
-            abi.encodeWithSelector(ProtocolFeeController.collectAggregateFeesHook.selector, pool)
-        );
+        vm.expectCall(address(feeController), abi.encodeCall(ProtocolFeeController.collectAggregateFeesHook, pool));
         // Move them to the fee controller.
         feeController.collectAggregateFees(pool);
 

--- a/pkg/vault/test/foundry/VaultLiquidityRate.t.sol
+++ b/pkg/vault/test/foundry/VaultLiquidityRate.t.sol
@@ -73,11 +73,13 @@ contract VaultLiquidityWithRatesTest is BaseVaultTest {
         vm.startPrank(alice);
         vm.expectCall(
             pool,
-            abi.encodeWithSelector(
-                IBasePool.computeBalance.selector,
-                expectedBalances, // liveBalancesScaled18
-                wstethIdx,
-                150e16 // 150% growth
+            abi.encodeCall(
+                IBasePool.computeBalance,
+                (
+                    expectedBalances, // liveBalancesScaled18
+                    wstethIdx,
+                    150e16 // 150% growth
+                )
             )
         );
 
@@ -99,13 +101,15 @@ contract VaultLiquidityWithRatesTest is BaseVaultTest {
         vm.startPrank(alice);
         vm.expectCall(
             pool,
-            abi.encodeWithSelector(
-                IPoolLiquidity.onAddLiquidityCustom.selector,
-                router,
-                expectedAmountsInRaw, // maxAmountsIn
-                defaultAmount, // minBptOut
-                expectedBalancesRaw,
-                bytes("")
+            abi.encodeCall(
+                IPoolLiquidity.onAddLiquidityCustom,
+                (
+                    address(router),
+                    expectedAmountsInRaw, // maxAmountsIn
+                    defaultAmount, // minBptOut
+                    expectedBalancesRaw,
+                    bytes("")
+                )
             )
         );
 
@@ -157,11 +161,13 @@ contract VaultLiquidityWithRatesTest is BaseVaultTest {
 
         vm.expectCall(
             pool,
-            abi.encodeWithSelector(
-                IBasePool.computeBalance.selector,
-                [balances.balancesLiveScaled18[daiIdx], balances.balancesLiveScaled18[wstethIdx]].toMemoryArray(),
-                wstethIdx, // tokenOutIndex
-                50e16 // invariantRatio
+            abi.encodeCall(
+                IBasePool.computeBalance,
+                (
+                    [balances.balancesLiveScaled18[daiIdx], balances.balancesLiveScaled18[wstethIdx]].toMemoryArray(),
+                    wstethIdx, // tokenOutIndex
+                    50e16 // invariantRatio
+                )
             )
         );
 
@@ -187,13 +193,15 @@ contract VaultLiquidityWithRatesTest is BaseVaultTest {
 
         vm.expectCall(
             pool,
-            abi.encodeWithSelector(
-                IPoolLiquidity.onRemoveLiquidityCustom.selector,
-                router,
-                defaultAmount, // maxBptAmountIn
-                expectedAmountsOutRaw, // minAmountsOut
-                [balances.balancesLiveScaled18[daiIdx], balances.balancesLiveScaled18[wstethIdx]].toMemoryArray(),
-                bytes("")
+            abi.encodeCall(
+                IPoolLiquidity.onRemoveLiquidityCustom,
+                (
+                    address(router),
+                    defaultAmount, // maxBptAmountIn
+                    expectedAmountsOutRaw, // minAmountsOut
+                    [balances.balancesLiveScaled18[daiIdx], balances.balancesLiveScaled18[wstethIdx]].toMemoryArray(),
+                    bytes("")
+                )
             )
         );
 

--- a/pkg/vault/test/foundry/VaultSwapRate.t.sol
+++ b/pkg/vault/test/foundry/VaultSwapRate.t.sol
@@ -78,8 +78,8 @@ contract VaultSwapWithRatesTest is BaseVaultTest {
 
         vm.expectCall(
             pool,
-            abi.encodeWithSelector(
-                IBasePool.onSwap.selector,
+            abi.encodeCall(
+                IBasePool.onSwap,
                 PoolSwapParams({
                     kind: SwapKind.EXACT_IN,
                     amountGivenScaled18: defaultAmount,
@@ -115,8 +115,8 @@ contract VaultSwapWithRatesTest is BaseVaultTest {
 
         vm.expectCall(
             pool,
-            abi.encodeWithSelector(
-                IBasePool.onSwap.selector,
+            abi.encodeCall(
+                IBasePool.onSwap,
                 PoolSwapParams({
                     kind: SwapKind.EXACT_OUT,
                     amountGivenScaled18: defaultAmount,

--- a/pkg/vault/test/foundry/unit/ERC20MultiTokenTest.t.sol
+++ b/pkg/vault/test/foundry/unit/ERC20MultiTokenTest.t.sol
@@ -77,7 +77,7 @@ contract ERC20MultiTokenTest is Test, IERC20Errors, ERC20MultiToken {
         emit ERC20MultiToken.Approval(POOL, OWNER, SPENDER, remainingAllowance);
         vm.mockCall(
             POOL,
-            abi.encodeWithSelector(BalancerPoolToken.emitApproval.selector, OWNER, SPENDER, remainingAllowance),
+            abi.encodeCall(BalancerPoolToken.emitApproval, (OWNER, SPENDER, remainingAllowance)),
             new bytes(0)
         );
         token.manualSpendAllowance(POOL, OWNER, SPENDER, spendAmount);
@@ -175,12 +175,7 @@ contract ERC20MultiTokenTest is Test, IERC20Errors, ERC20MultiToken {
         emit ERC20MultiToken.Transfer(POOL, ZERO_ADDRESS, ZERO_ADDRESS, MINIMUM_TOTAL_SUPPLY);
         vm.mockCall(
             POOL,
-            abi.encodeWithSelector(
-                BalancerPoolToken.emitTransfer.selector,
-                ZERO_ADDRESS,
-                ZERO_ADDRESS,
-                MINIMUM_TOTAL_SUPPLY
-            ),
+            abi.encodeCall(BalancerPoolToken.emitTransfer, (ZERO_ADDRESS, ZERO_ADDRESS, MINIMUM_TOTAL_SUPPLY)),
             new bytes(0)
         );
         token.manualMintMinimumSupplyReserve(POOL);
@@ -261,7 +256,7 @@ contract ERC20MultiTokenTest is Test, IERC20Errors, ERC20MultiToken {
 
         vm.mockCall(
             POOL,
-            abi.encodeWithSelector(BalancerPoolToken.emitTransfer.selector, OWNER, OWNER2, MINIMUM_TOTAL_SUPPLY),
+            abi.encodeCall(BalancerPoolToken.emitTransfer, (OWNER, OWNER2, MINIMUM_TOTAL_SUPPLY)),
             new bytes(0)
         );
         vm.expectEmit();
@@ -297,29 +292,17 @@ contract ERC20MultiTokenTest is Test, IERC20Errors, ERC20MultiToken {
 
     // #region Private functions
     function _approveWithBPTEmitApprovalMock(address pool, address owner, address spender, uint256 amount) internal {
-        vm.mockCall(
-            pool,
-            abi.encodeWithSelector(BalancerPoolToken.emitApproval.selector, owner, spender, amount),
-            new bytes(0)
-        );
+        vm.mockCall(pool, abi.encodeCall(BalancerPoolToken.emitApproval, (owner, spender, amount)), new bytes(0));
         token.manualApprove(pool, owner, spender, amount);
     }
 
     function _mintWithBPTEmitTransferMock(address pool, address owner, uint256 amount) internal {
-        vm.mockCall(
-            pool,
-            abi.encodeWithSelector(BalancerPoolToken.emitTransfer.selector, ZERO_ADDRESS, owner, amount),
-            new bytes(0)
-        );
+        vm.mockCall(pool, abi.encodeCall(BalancerPoolToken.emitTransfer, (ZERO_ADDRESS, owner, amount)), new bytes(0));
         token.manualMint(pool, owner, amount);
     }
 
     function _burnWithBPTEmitTransferMock(address pool, address from, uint256 amount) internal {
-        vm.mockCall(
-            pool,
-            abi.encodeWithSelector(BalancerPoolToken.emitTransfer.selector, from, ZERO_ADDRESS, amount),
-            new bytes(0)
-        );
+        vm.mockCall(pool, abi.encodeCall(BalancerPoolToken.emitTransfer, (from, ZERO_ADDRESS, amount)), new bytes(0));
         token.manualBurn(pool, from, amount);
     }
     // #endregion

--- a/pkg/vault/test/foundry/unit/VaultUnitLiquidity.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultUnitLiquidity.t.sol
@@ -127,7 +127,7 @@ contract VaultUnitLiquidityTest is BaseTest {
         (uint256 currentInvariant, uint256 newInvariantAndInvariantWithFeesApplied) = (1e16, 1e18);
         vm.mockCall(
             params.pool,
-            abi.encodeWithSelector(IBasePool.computeInvariant.selector, poolData.balancesLiveScaled18),
+            abi.encodeCall(IBasePool.computeInvariant, poolData.balancesLiveScaled18),
             abi.encode(currentInvariant)
         );
 
@@ -138,7 +138,7 @@ contract VaultUnitLiquidityTest is BaseTest {
 
         vm.mockCall(
             params.pool,
-            abi.encodeWithSelector(IBasePool.computeInvariant.selector, newBalances),
+            abi.encodeCall(IBasePool.computeInvariant, newBalances),
             abi.encode(newInvariantAndInvariantWithFeesApplied)
         );
 
@@ -183,11 +183,9 @@ contract VaultUnitLiquidityTest is BaseTest {
         uint256 newSupply = totalSupply + params.minBptAmountOut;
         vm.mockCall(
             params.pool,
-            abi.encodeWithSelector(
-                IBasePool.computeBalance.selector,
-                poolData.balancesLiveScaled18,
-                tokenInIndex,
-                newSupply.divUp(totalSupply)
+            abi.encodeCall(
+                IBasePool.computeBalance,
+                (poolData.balancesLiveScaled18, tokenInIndex, newSupply.divUp(totalSupply))
             ),
             abi.encode(newSupply)
         );
@@ -235,13 +233,15 @@ contract VaultUnitLiquidityTest is BaseTest {
 
         vm.mockCall(
             address(params.pool),
-            abi.encodeWithSelector(
-                IPoolLiquidity.onAddLiquidityCustom.selector,
-                address(this), // Router
-                maxAmountsInScaled18,
-                params.minBptAmountOut,
-                poolData.balancesLiveScaled18,
-                params.userData
+            abi.encodeCall(
+                IPoolLiquidity.onAddLiquidityCustom,
+                (
+                    address(this), // Router
+                    maxAmountsInScaled18,
+                    params.minBptAmountOut,
+                    poolData.balancesLiveScaled18,
+                    params.userData
+                )
             ),
             abi.encode(expectedAmountsInScaled18, bptAmountOut, expectSwapFeeAmountsScaled18, params.userData)
         );
@@ -271,13 +271,15 @@ contract VaultUnitLiquidityTest is BaseTest {
         uint256 bptAmountOut = 0;
         vm.mockCall(
             address(params.pool),
-            abi.encodeWithSelector(
-                IPoolLiquidity.onAddLiquidityCustom.selector,
-                address(this), // Router
-                maxAmountsInScaled18,
-                params.minBptAmountOut,
-                poolData.balancesLiveScaled18,
-                params.userData
+            abi.encodeCall(
+                IPoolLiquidity.onAddLiquidityCustom,
+                (
+                    address(this), // Router
+                    maxAmountsInScaled18,
+                    params.minBptAmountOut,
+                    poolData.balancesLiveScaled18,
+                    params.userData
+                )
             ),
             abi.encode(new uint256[](tokens.length), bptAmountOut, new uint256[](tokens.length), params.userData)
         );
@@ -305,13 +307,15 @@ contract VaultUnitLiquidityTest is BaseTest {
 
         vm.mockCall(
             address(params.pool),
-            abi.encodeWithSelector(
-                IPoolLiquidity.onAddLiquidityCustom.selector,
-                address(this), // Router
-                maxAmountsInScaled18,
-                params.minBptAmountOut,
-                poolData.balancesLiveScaled18,
-                params.userData
+            abi.encodeCall(
+                IPoolLiquidity.onAddLiquidityCustom,
+                (
+                    address(this), // Router
+                    maxAmountsInScaled18,
+                    params.minBptAmountOut,
+                    poolData.balancesLiveScaled18,
+                    params.userData
+                )
             ),
             abi.encode(expectedAmountsInScaled18, params.minBptAmountOut, new uint256[](tokens.length), params.userData)
         );
@@ -419,11 +423,9 @@ contract VaultUnitLiquidityTest is BaseTest {
         uint256 newSupply = totalSupply - expectBPTAmountIn;
         vm.mockCall(
             params.pool,
-            abi.encodeWithSelector(
-                IBasePool.computeBalance.selector,
-                poolData.balancesLiveScaled18,
-                tokenIndex,
-                newSupply.divUp(totalSupply)
+            abi.encodeCall(
+                IBasePool.computeBalance,
+                (poolData.balancesLiveScaled18, tokenIndex, newSupply.divUp(totalSupply))
             ),
             abi.encode(newSupply)
         );
@@ -471,7 +473,7 @@ contract VaultUnitLiquidityTest is BaseTest {
             (uint256 currentInvariant, uint256 invariantAndInvariantWithFeesApplied) = (3e8, 3e9);
             vm.mockCall(
                 params.pool,
-                abi.encodeWithSelector(IBasePool.computeInvariant.selector, poolData.balancesLiveScaled18),
+                abi.encodeCall(IBasePool.computeInvariant, poolData.balancesLiveScaled18),
                 abi.encode(currentInvariant)
             );
 
@@ -483,7 +485,7 @@ contract VaultUnitLiquidityTest is BaseTest {
 
             vm.mockCall(
                 params.pool,
-                abi.encodeWithSelector(IBasePool.computeInvariant.selector, newBalances),
+                abi.encodeCall(IBasePool.computeInvariant, newBalances),
                 abi.encode(invariantAndInvariantWithFeesApplied)
             );
 
@@ -497,7 +499,7 @@ contract VaultUnitLiquidityTest is BaseTest {
             uint256 newInvariantAndInvariantWithFeesApplied = 1e5;
             vm.mockCall(
                 params.pool,
-                abi.encodeWithSelector(IBasePool.computeInvariant.selector, newBalances),
+                abi.encodeCall(IBasePool.computeInvariant, newBalances),
                 abi.encode(newInvariantAndInvariantWithFeesApplied)
             );
         }
@@ -546,13 +548,15 @@ contract VaultUnitLiquidityTest is BaseTest {
 
         vm.mockCall(
             address(params.pool),
-            abi.encodeWithSelector(
-                IPoolLiquidity.onRemoveLiquidityCustom.selector,
-                address(this), // router
-                params.maxBptAmountIn,
-                minAmountsOutScaled18,
-                poolData.balancesLiveScaled18,
-                params.userData
+            abi.encodeCall(
+                IPoolLiquidity.onRemoveLiquidityCustom,
+                (
+                    address(this), // router
+                    params.maxBptAmountIn,
+                    minAmountsOutScaled18,
+                    poolData.balancesLiveScaled18,
+                    params.userData
+                )
             ),
             abi.encode(expectBPTAmountIn, expectedAmountsOutScaled18, expectSwapFeeAmountsScaled18, params.userData)
         );
@@ -583,13 +587,15 @@ contract VaultUnitLiquidityTest is BaseTest {
 
         vm.mockCall(
             address(params.pool),
-            abi.encodeWithSelector(
-                IPoolLiquidity.onRemoveLiquidityCustom.selector,
-                address(this), // Router
-                params.maxBptAmountIn,
-                minAmountsOutScaled18,
-                poolData.balancesLiveScaled18,
-                params.userData
+            abi.encodeCall(
+                IPoolLiquidity.onRemoveLiquidityCustom,
+                (
+                    address(this), // Router
+                    params.maxBptAmountIn,
+                    minAmountsOutScaled18,
+                    poolData.balancesLiveScaled18,
+                    params.userData
+                )
             ),
             abi.encode(bptAmountIn, new uint256[](tokens.length), new uint256[](tokens.length), params.userData)
         );
@@ -619,13 +625,15 @@ contract VaultUnitLiquidityTest is BaseTest {
 
         vm.mockCall(
             address(params.pool),
-            abi.encodeWithSelector(
-                IPoolLiquidity.onRemoveLiquidityCustom.selector,
-                address(this), // Router
-                params.maxBptAmountIn,
-                minAmountsOutScaled18,
-                poolData.balancesLiveScaled18,
-                params.userData
+            abi.encodeCall(
+                IPoolLiquidity.onRemoveLiquidityCustom,
+                (
+                    address(this), // Router
+                    params.maxBptAmountIn,
+                    minAmountsOutScaled18,
+                    poolData.balancesLiveScaled18,
+                    params.userData
+                )
             ),
             abi.encode(bptAmountIn, amountsOutScaled18, new uint256[](tokens.length), params.userData)
         );
@@ -758,11 +766,7 @@ contract VaultUnitLiquidityTest is BaseTest {
     }
 
     function _mockMintCallback(address to, uint256 amount) internal {
-        vm.mockCall(
-            pool,
-            abi.encodeWithSelector(BalancerPoolToken.emitTransfer.selector, ZERO_ADDRESS, to, amount),
-            new bytes(0)
-        );
+        vm.mockCall(pool, abi.encodeCall(BalancerPoolToken.emitTransfer, (ZERO_ADDRESS, to, amount)), new bytes(0));
     }
 
     function _testAddLiquidity(PoolData memory poolData, TestAddLiquidityParams memory params) internal {

--- a/pkg/vault/test/foundry/unit/VaultUnitSwap.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultUnitSwap.t.sol
@@ -553,8 +553,8 @@ contract VaultUnitSwapTest is BaseTest {
     ) internal {
         vm.mockCall(
             pool,
-            abi.encodeWithSelector(
-                IBasePool.onSwap.selector,
+            abi.encodeCall(
+                IBasePool.onSwap,
                 PoolSwapParams({
                     kind: params.kind,
                     amountGivenScaled18: state.amountGivenScaled18,


### PR DESCRIPTION
# Description

Like #907, but applied to tests. Might as well be consistent (also caught some type conversions, which is the point of using encodeCall vs. the selector version).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
