### PR TITLE
Simplify BaseHooks

### DIFF
--- a/pkg/pool-hooks/contracts/DirectionalFeeHookExample.sol
+++ b/pkg/pool-hooks/contracts/DirectionalFeeHookExample.sol
@@ -13,7 +13,7 @@ import {
 } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
 import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
-
+import { VaultGuard } from "@balancer-labs/v3-vault/contracts/VaultGuard.sol";
 import { BaseHooks } from "@balancer-labs/v3-vault/contracts/BaseHooks.sol";
 
 /**
@@ -30,7 +30,7 @@ import { BaseHooks } from "@balancer-labs/v3-vault/contracts/BaseHooks.sol";
  * perhaps establishing a range within which swaps charge the standard fee, and ensuring a smooth and symmetrical
  * fee increase on either side.
  */
-contract DirectionalFeeHookExample is BaseHooks {
+contract DirectionalFeeHookExample is BaseHooks, VaultGuard {
     using FixedPoint for uint256;
 
     // Only stable pools from the allowed factory are able to register and use this hook.
@@ -49,7 +49,7 @@ contract DirectionalFeeHookExample is BaseHooks {
         address indexed pool
     );
 
-    constructor(IVault vault, address allowedStablePoolFactory) BaseHooks(vault) {
+    constructor(IVault vault, address allowedStablePoolFactory) VaultGuard(vault) {
         // Although the hook allows any factory to be registered during deployment, it should be a stable pool factory.
         _allowedStablePoolFactory = allowedStablePoolFactory;
     }

--- a/pkg/pool-hooks/contracts/ExitFeeHookExample.sol
+++ b/pkg/pool-hooks/contracts/ExitFeeHookExample.sol
@@ -17,6 +17,7 @@ import {
 } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
 import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
+import { VaultGuard } from "@balancer-labs/v3-vault/contracts/VaultGuard.sol";
 import { BaseHooks } from "@balancer-labs/v3-vault/contracts/BaseHooks.sol";
 
 /**
@@ -35,7 +36,7 @@ import { BaseHooks } from "@balancer-labs/v3-vault/contracts/BaseHooks.sol";
  * Finally, since the only way to deposit fee tokens back into the pool balance (without minting new BPT) is through
  * the special "donation" add liquidity type, this hook also requires that the pool support donation.
  */
-contract ExitFeeHookExample is BaseHooks, Ownable {
+contract ExitFeeHookExample is BaseHooks, VaultGuard, Ownable {
     using FixedPoint for uint256;
 
     // Percentages are represented as 18-decimal FP numbers, which have a maximum value of FixedPoint.ONE (100%),
@@ -83,7 +84,7 @@ contract ExitFeeHookExample is BaseHooks, Ownable {
      */
     error PoolDoesNotSupportDonation();
 
-    constructor(IVault vault) BaseHooks(vault) Ownable(msg.sender) {
+    constructor(IVault vault) VaultGuard(vault) Ownable(msg.sender) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/pool-hooks/contracts/FeeTakingHookExample.sol
+++ b/pkg/pool-hooks/contracts/FeeTakingHookExample.sol
@@ -19,6 +19,7 @@ import {
 } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
 import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
+import { VaultGuard } from "@balancer-labs/v3-vault/contracts/VaultGuard.sol";
 import { BaseHooks } from "@balancer-labs/v3-vault/contracts/BaseHooks.sol";
 
 /**
@@ -33,7 +34,7 @@ import { BaseHooks } from "@balancer-labs/v3-vault/contracts/BaseHooks.sol";
  * must be modified in order to charge the fee - `enableHookAdjustedAmounts` must also be set to true in the
  * pool configuration. Otherwise, the Vault would ignore the adjusted values, and not recognize the fee.
  */
-contract FeeTakingHookExample is BaseHooks, Ownable {
+contract FeeTakingHookExample is BaseHooks, VaultGuard, Ownable {
     using FixedPoint for uint256;
     using SafeERC20 for IERC20;
 
@@ -97,7 +98,7 @@ contract FeeTakingHookExample is BaseHooks, Ownable {
         uint256 feeAmount
     );
 
-    constructor(IVault vault) BaseHooks(vault) Ownable(msg.sender) {
+    constructor(IVault vault) VaultGuard(vault) Ownable(msg.sender) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/pool-hooks/contracts/LotteryHookExample.sol
+++ b/pkg/pool-hooks/contracts/LotteryHookExample.sol
@@ -19,7 +19,7 @@ import {
 
 import { EnumerableMap } from "@balancer-labs/v3-solidity-utils/contracts/openzeppelin/EnumerableMap.sol";
 import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
-
+import { VaultGuard } from "@balancer-labs/v3-vault/contracts/VaultGuard.sol";
 import { BaseHooks } from "@balancer-labs/v3-vault/contracts/BaseHooks.sol";
 
 /**
@@ -28,7 +28,7 @@ import { BaseHooks } from "@balancer-labs/v3-vault/contracts/BaseHooks.sol";
  * If the drawn number is not equal to the LUCKY_NUMBER, the user will pay fees to the hook contract. But, if the
  * drawn number is equal to LUCKY_NUMBER, the user won't pay hook fees and will receive all fees accrued by the hook.
  */
-contract LotteryHookExample is BaseHooks, Ownable {
+contract LotteryHookExample is BaseHooks, VaultGuard, Ownable {
     using FixedPoint for uint256;
     using EnumerableMap for EnumerableMap.IERC20ToUint256Map;
     using SafeERC20 for IERC20;
@@ -90,7 +90,7 @@ contract LotteryHookExample is BaseHooks, Ownable {
         uint256 amountWon
     );
 
-    constructor(IVault vault, address router) BaseHooks(vault) Ownable(msg.sender) {
+    constructor(IVault vault, address router) VaultGuard(vault) Ownable(msg.sender) {
         _trustedRouter = router;
     }
 

--- a/pkg/pool-hooks/contracts/VeBALFeeDiscountHookExample.sol
+++ b/pkg/pool-hooks/contracts/VeBALFeeDiscountHookExample.sol
@@ -15,13 +15,14 @@ import {
     HookFlags
 } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
+import { VaultGuard } from "@balancer-labs/v3-vault/contracts/VaultGuard.sol";
 import { BaseHooks } from "@balancer-labs/v3-vault/contracts/BaseHooks.sol";
 
 /**
  * @notice Hook that gives a swap fee discount to veBAL holders.
  * @dev Uses the dynamic fee mechanism to give a 50% discount on swap fees.
  */
-contract VeBALFeeDiscountHookExample is BaseHooks {
+contract VeBALFeeDiscountHookExample is BaseHooks, VaultGuard {
     // Only pools from a specific factory are able to register and use this hook.
     address private immutable _allowedFactory;
     // Only trusted routers are allowed to call this hook, because the hook relies on the `getSender` implementation
@@ -43,7 +44,12 @@ contract VeBALFeeDiscountHookExample is BaseHooks {
         address indexed pool
     );
 
-    constructor(IVault vault, address allowedFactory, address veBAL, address trustedRouter) BaseHooks(vault) {
+    constructor(
+        IVault vault,
+        address allowedFactory,
+        address veBAL,
+        address trustedRouter
+    ) VaultGuard(vault) {
         _allowedFactory = allowedFactory;
         _trustedRouter = trustedRouter;
         _veBAL = IERC20(veBAL);

--- a/pkg/pool-hooks/contracts/VeBALFeeDiscountHookExample.sol
+++ b/pkg/pool-hooks/contracts/VeBALFeeDiscountHookExample.sol
@@ -44,12 +44,7 @@ contract VeBALFeeDiscountHookExample is BaseHooks, VaultGuard {
         address indexed pool
     );
 
-    constructor(
-        IVault vault,
-        address allowedFactory,
-        address veBAL,
-        address trustedRouter
-    ) VaultGuard(vault) {
+    constructor(IVault vault, address allowedFactory, address veBAL, address trustedRouter) VaultGuard(vault) {
         _allowedFactory = allowedFactory;
         _trustedRouter = trustedRouter;
         _veBAL = IERC20(veBAL);

--- a/pkg/vault/contracts/BaseHooks.sol
+++ b/pkg/vault/contracts/BaseHooks.sol
@@ -2,7 +2,6 @@
 
 pragma solidity ^0.8.24;
 
-import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import { IHooks } from "@balancer-labs/v3-interfaces/contracts/vault/IHooks.sol";
 import {
     AddLiquidityKind,
@@ -14,19 +13,13 @@ import {
     AfterSwapParams
 } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
-import { VaultGuard } from "./VaultGuard.sol";
-
 /**
  * @notice Base for pool hooks contracts.
  * @dev Hook contracts that only implement a subset of callbacks can inherit from here instead of IHooks,
  * and only override what they need. `VaultGuard` allows use of the `onlyVault` modifier, which isn't used
  * in this abstract contract, but should be used in real derived hook contracts.
  */
-abstract contract BaseHooks is IHooks, VaultGuard {
-    constructor(IVault vault) VaultGuard(vault) {
-        // solhint-disable-previous-line no-empty-blocks
-    }
-
+abstract contract BaseHooks is IHooks {
     /// @inheritdoc IHooks
     function onRegister(
         address,

--- a/pkg/vault/contracts/test/BaseHooksMock.sol
+++ b/pkg/vault/contracts/test/BaseHooksMock.sol
@@ -2,16 +2,11 @@
 
 pragma solidity ^0.8.24;
 
-import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
 import "../BaseHooks.sol";
 
 contract BaseHooksMock is BaseHooks {
-    constructor(IVault vault) BaseHooks(vault) {
-        // solhint-disable-previous-line no-empty-blocks
-    }
-
     /// @inheritdoc IHooks
     function onRegister(
         address factory,

--- a/pkg/vault/contracts/test/MinimalHooksPoolMock.sol
+++ b/pkg/vault/contracts/test/MinimalHooksPoolMock.sol
@@ -2,8 +2,6 @@
 
 pragma solidity ^0.8.24;
 
-import { IHooks } from "@balancer-labs/v3-interfaces/contracts/vault/IHooks.sol";
-import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
 import { BaseHooks } from "../BaseHooks.sol";
@@ -11,8 +9,6 @@ import { BaseHooks } from "../BaseHooks.sol";
 /// @dev Simple hook contract that does nothing but return true on every call.
 contract MinimalHooksPoolMock is BaseHooks {
     HookFlags private _hookFlags;
-
-    constructor(IVault vault) BaseHooks(vault) {}
 
     function onRegister(
         address,

--- a/pkg/vault/contracts/test/PoolHooksMock.sol
+++ b/pkg/vault/contracts/test/PoolHooksMock.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.24;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 
-import { IHooks } from "@balancer-labs/v3-interfaces/contracts/vault/IHooks.sol";
 import { IRouterCommon } from "@balancer-labs/v3-interfaces/contracts/vault/IRouterCommon.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import { IVaultMock } from "@balancer-labs/v3-interfaces/contracts/test/IVaultMock.sol";
@@ -15,9 +14,10 @@ import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/Fixe
 import { ScalingHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/ScalingHelpers.sol";
 
 import { RateProviderMock } from "./RateProviderMock.sol";
+import { VaultGuard } from "../VaultGuard.sol";
 import { BaseHooks } from "../BaseHooks.sol";
 
-contract PoolHooksMock is BaseHooks {
+contract PoolHooksMock is BaseHooks, VaultGuard {
     using FixedPoint for uint256;
     using ScalingHelpers for uint256;
 
@@ -70,7 +70,7 @@ contract PoolHooksMock is BaseHooks {
 
     HookFlags private _hookFlags;
 
-    constructor(IVault vault) BaseHooks(vault) {
+    constructor(IVault vault) VaultGuard(vault) {
         shouldSettleDiscount = true;
     }
 

--- a/pkg/vault/test/foundry/BaseHooks.t.sol
+++ b/pkg/vault/test/foundry/BaseHooks.t.sol
@@ -19,7 +19,7 @@ contract BaseHooksTest is BaseVaultTest {
         BaseVaultTest.setUp();
 
         // Not using PoolHooksMock address because onRegister of BaseHooks fails, so the test does not run.
-        testHook = new BaseHooksMock(IVault(address(vault)));
+        testHook = new BaseHooksMock();
     }
 
     function testOnRegister() public {

--- a/pkg/vault/test/gas/PoolMockWithHooks.test.ts
+++ b/pkg/vault/test/gas/PoolMockWithHooks.test.ts
@@ -18,9 +18,7 @@ class PoolMockWithHooksBenchmark extends Benchmark {
       args: [await this.vault.getAddress(), MONTH * 12],
     })) as unknown as PoolFactoryMock;
 
-    const hooks = (await deploy('MinimalHooksPoolMock', {
-      args: [this.vault],
-    })) as unknown as MinimalHooksPoolMock;
+    const hooks = (await deploy('MinimalHooksPoolMock')) as unknown as MinimalHooksPoolMock;
 
     await hooks.setHookFlags({
       enableHookAdjustedAmounts: false,


### PR DESCRIPTION
# Description

An early mentor of mine (and an attorney) often said: "For every convenience, there's a consequence." BaseHooks was descended from VaultGuard as a convenience, so that derived hooks could use the `onlyVault` modifier, and had built-in Vault storage, without having to do anything.

This was causing inheritance issues for some hooks, though. This PR removes this dependency, so that BaseHooks simply implements IHooks. Derived hooks that need the VaultGuard will inherit it directly.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [X] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
