### PR TITLE
Make min trade size immutable; disable for testing purposes in general

### DIFF
--- a/pkg/vault/contracts/Vault.sol
+++ b/pkg/vault/contracts/Vault.sol
@@ -55,7 +55,16 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
 
     IVaultExtension private immutable _vaultExtension;
 
-    constructor(IVaultExtension vaultExtension, IAuthorizer authorizer, IProtocolFeeController protocolFeeController) {
+    // Minimum swap amount (applied to scaled18 values), enforced as a security measure to block potential
+    // exploitation of rounding errors
+    uint256 internal immutable _MINIMUM_TRADE_AMOUNT;
+
+    constructor(
+        IVaultExtension vaultExtension,
+        IAuthorizer authorizer,
+        IProtocolFeeController protocolFeeController,
+        uint256 minTradeAmount
+    ) {
         if (address(vaultExtension.vault()) != address(this)) {
             revert WrongVaultExtensionDeployment();
         }
@@ -72,6 +81,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
         _vaultBufferPeriodEndTime = IVaultAdmin(address(vaultExtension)).getBufferPeriodEndTime();
 
         _authorizer = authorizer;
+        _MINIMUM_TRADE_AMOUNT = minTradeAmount;
     }
 
     /*******************************************************************************
@@ -1407,7 +1417,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
 
     // Minimum swap amount (applied to scaled18 values), enforced as a security measure to block potential
     // exploitation of rounding errors.
-    function _ensureValidTradeAmount(uint256 tradeAmount) private pure {
+    function _ensureValidTradeAmount(uint256 tradeAmount) private view {
         if (tradeAmount != 0 && tradeAmount < _MINIMUM_TRADE_AMOUNT) {
             revert TradeAmountTooSmall();
         }

--- a/pkg/vault/contracts/VaultFactory.sol
+++ b/pkg/vault/contracts/VaultFactory.sol
@@ -31,6 +31,7 @@ contract VaultFactory is Authentication {
     IAuthorizer private immutable _authorizer;
     uint32 private immutable _pauseWindowDuration;
     uint32 private immutable _bufferPeriodDuration;
+    uint256 private immutable _minTradeAmount;
     address private immutable _deployer;
 
     bytes private _creationCode;
@@ -40,13 +41,15 @@ contract VaultFactory is Authentication {
     constructor(
         IAuthorizer authorizer,
         uint32 pauseWindowDuration,
-        uint32 bufferPeriodDuration
+        uint32 bufferPeriodDuration,
+        uint256 minTradeAmount
     ) Authentication(bytes32(uint256(uint160(address(this))))) {
         _deployer = msg.sender;
         _creationCode = type(Vault).creationCode;
         _authorizer = authorizer;
         _pauseWindowDuration = pauseWindowDuration;
         _bufferPeriodDuration = bufferPeriodDuration;
+        _minTradeAmount = minTradeAmount;
     }
 
     /**
@@ -73,7 +76,10 @@ contract VaultFactory is Authentication {
         VaultExtension vaultExtension = new VaultExtension(IVault(vaultAddress), vaultAdmin);
         ProtocolFeeController feeController = new ProtocolFeeController(IVault(vaultAddress));
 
-        address deployedAddress = _create(abi.encode(vaultExtension, _authorizer, feeController), salt);
+        address deployedAddress = _create(
+            abi.encode(vaultExtension, _authorizer, feeController, _minTradeAmount),
+            salt
+        );
 
         // This should always be the case, but we enforce the end state to match the expected outcome anyway.
         if (deployedAddress != targetAddress) {

--- a/pkg/vault/contracts/VaultStorage.sol
+++ b/pkg/vault/contracts/VaultStorage.sol
@@ -46,10 +46,6 @@ contract VaultStorage {
     // Minimum given amount to wrap/unwrap (applied to native decimal values), to avoid rounding issues.
     uint256 internal constant _MINIMUM_WRAP_AMOUNT = 1e3;
 
-    // Minimum swap amount (applied to scaled18 values), enforced as a security measure to block potential
-    // exploitation of rounding errors
-    uint256 internal constant _MINIMUM_TRADE_AMOUNT = 1e6;
-
     // Maximum pause and buffer period durations.
     uint256 internal constant _MAX_PAUSE_WINDOW_DURATION = 365 days * 4;
     uint256 internal constant _MAX_BUFFER_PERIOD_DURATION = 90 days;

--- a/pkg/vault/contracts/test/VaultMock.sol
+++ b/pkg/vault/contracts/test/VaultMock.sol
@@ -55,8 +55,9 @@ contract VaultMock is IVaultMainMock, Vault {
     constructor(
         IVaultExtension vaultExtension,
         IAuthorizer authorizer,
-        IProtocolFeeController protocolFeeController
-    ) Vault(vaultExtension, authorizer, protocolFeeController) {
+        IProtocolFeeController protocolFeeController,
+        uint256 minTradeAmount
+    ) Vault(vaultExtension, authorizer, protocolFeeController, minTradeAmount) {
         uint32 pauseWindowEndTime = IVaultAdmin(address(vaultExtension)).getPauseWindowEndTime();
         uint32 bufferPeriodDuration = IVaultAdmin(address(vaultExtension)).getBufferPeriodDuration();
         _poolFactoryMock = new PoolFactoryMock(IVault(address(this)), pauseWindowEndTime - bufferPeriodDuration);

--- a/pkg/vault/test/.contract-sizes/Vault
+++ b/pkg/vault/test/.contract-sizes/Vault
@@ -1,2 +1,2 @@
-Bytecode	23.966
-InitCode	25.233
+Bytecode	23.994
+InitCode	25.281

--- a/pkg/vault/test/foundry/DynamicFeePoolTest.t.sol
+++ b/pkg/vault/test/foundry/DynamicFeePoolTest.t.sol
@@ -31,6 +31,9 @@ contract DynamicFeePoolTest is BaseVaultTest {
 
     function setUp() public virtual override {
         defaultBalance = 1e10 * 1e18;
+        // We will use min trade amount in this test.
+        vaultMockMinTradeAmount = MIN_TRADE_AMOUNT;
+
         BaseVaultTest.setUp();
 
         (daiIdx, usdcIdx) = getSortedIndexes(address(dai), address(usdc));

--- a/pkg/vault/test/foundry/VaultFactory.t.sol
+++ b/pkg/vault/test/foundry/VaultFactory.t.sol
@@ -12,6 +12,8 @@ import { BasicAuthorizerMock } from "@balancer-labs/v3-solidity-utils/contracts/
 import { VaultFactory } from "../../contracts/VaultFactory.sol";
 
 contract VaultFactoryTest is Test {
+    uint256 private constant _MIN_TRADE_AMOUNT = 1e6;
+
     address deployer;
     BasicAuthorizerMock authorizer;
     VaultFactory factory;
@@ -19,7 +21,7 @@ contract VaultFactoryTest is Test {
     function setUp() public virtual {
         deployer = makeAddr("deployer");
         authorizer = new BasicAuthorizerMock();
-        factory = new VaultFactory(authorizer, 90 days, 30 days);
+        factory = new VaultFactory(authorizer, 90 days, 30 days, _MIN_TRADE_AMOUNT);
     }
 
     /// forge-config: default.fuzz.runs = 100

--- a/pkg/vault/test/foundry/VaultLiquidity.t.sol
+++ b/pkg/vault/test/foundry/VaultLiquidity.t.sol
@@ -19,6 +19,8 @@ contract VaultLiquidityTest is BaseVaultTest {
     uint256 internal usdcIdx;
 
     function setUp() public virtual override {
+        // We will use min trade amount in this test.
+        vaultMockMinTradeAmount = MIN_TRADE_AMOUNT;
         BaseVaultTest.setUp();
 
         (daiIdx, usdcIdx) = getSortedIndexes(address(dai), address(usdc));

--- a/pkg/vault/test/foundry/VaultSwap.t.sol
+++ b/pkg/vault/test/foundry/VaultSwap.t.sol
@@ -33,6 +33,9 @@ contract VaultSwapTest is BaseVaultTest {
     uint256 internal usdcIdx;
 
     function setUp() public virtual override {
+        // We will use min trade amount in this test.
+        vaultMockMinTradeAmount = MIN_TRADE_AMOUNT;
+
         BaseVaultTest.setUp();
 
         noInitPool = PoolMock(createPool());

--- a/pkg/vault/test/foundry/utils/BaseVaultTest.sol
+++ b/pkg/vault/test/foundry/utils/BaseVaultTest.sol
@@ -104,15 +104,21 @@ abstract contract BaseVaultTest is VaultStorage, BaseTest, Permit2Helpers {
     // Default protocol swap fee percentage.
     uint64 internal protocolSwapFeePercentage = 50e16; // 50%
 
+    // VaultMock can override min trade amount; tests shall use 0 by default to simplify fuzz tests.
+    // Min trade amount is meant to be an extra protection against unknown rounding errors; the Vault should still work
+    // without it, so it can be zeroed out in general.
+    // Change this value before calling `setUp` to test under real conditions.
+    uint256 vaultMockMinTradeAmount = 0;
+
     // Applies to Weighted Pools.
     uint256 constant MIN_SWAP_FEE = 1e12; // 0.00001%
     uint256 constant MAX_SWAP_FEE = 10e16; // 10%
-    uint256 constant MIN_TRADE_AMOUNT = 1e6;
+    uint256 internal MIN_TRADE_AMOUNT = 1e6;
 
     function setUp() public virtual override {
         BaseTest.setUp();
 
-        vault = IVaultMock(address(VaultMockDeployer.deploy()));
+        vault = IVaultMock(address(VaultMockDeployer.deploy(vaultMockMinTradeAmount)));
         vm.label(address(vault), "vault");
         vaultExtension = IVaultExtension(vault.getVaultExtension());
         vm.label(address(vaultExtension), "vaultExtension");

--- a/pkg/vault/test/foundry/utils/VaultMockDeployer.sol
+++ b/pkg/vault/test/foundry/utils/VaultMockDeployer.sol
@@ -15,6 +15,10 @@ import { ProtocolFeeController } from "../../../contracts/ProtocolFeeController.
 
 library VaultMockDeployer {
     function deploy() internal returns (VaultMock vault) {
+        return deploy(0);
+    }
+
+    function deploy(uint256 minTradeAmount) internal returns (VaultMock vault) {
         IAuthorizer authorizer = new BasicAuthorizerMock();
         bytes32 salt = bytes32(0);
         vault = VaultMock(payable(CREATE3.getDeployed(salt)));
@@ -22,7 +26,7 @@ library VaultMockDeployer {
         VaultExtensionMock vaultExtension = new VaultExtensionMock(IVault(address(vault)), vaultAdmin);
         ProtocolFeeController protocolFeeController = new ProtocolFeeControllerMock(IVault(address(vault)));
 
-        _create(abi.encode(vaultExtension, authorizer, protocolFeeController), salt);
+        _create(abi.encode(vaultExtension, authorizer, protocolFeeController, minTradeAmount), salt);
         return vault;
     }
 

--- a/pvt/helpers/src/models/vault/VaultDeployer.ts
+++ b/pvt/helpers/src/models/vault/VaultDeployer.ts
@@ -17,6 +17,8 @@ import { VaultMock } from '@balancer-labs/v3-vault/typechain-types';
 import { BasicAuthorizerMock } from '@balancer-labs/v3-solidity-utils/typechain-types';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 
+const _MINIMUM_TRADE_AMOUNT = 1e6;
+
 export async function deploy(params: VaultDeploymentInputParams = {}): Promise<Vault> {
   const deployment = await TypesConverter.toVaultDeployment(params);
 
@@ -52,7 +54,7 @@ async function deployReal(deployment: VaultDeploymentParams, authorizer: BaseCon
   });
 
   return await contract.deploy('v3-vault/Vault', {
-    args: [vaultExtension, authorizer, protocolFeeController],
+    args: [vaultExtension, authorizer, protocolFeeController, _MINIMUM_TRADE_AMOUNT],
     from: admin,
   });
 }
@@ -78,7 +80,7 @@ async function deployMocked(deployment: VaultDeploymentParams, authorizer: BaseC
   });
 
   return await contract.deploy('v3-vault/VaultMock', {
-    args: [vaultExtension, authorizer, protocolFeeController],
+    args: [vaultExtension, authorizer, protocolFeeController, 0],
     from: admin,
   });
 }


### PR DESCRIPTION
# Description

E2e fuzz tests become cumbersome when they start hitting the min swap amount.
This is meant to be an extra layer of protection against unforeseen rounding issues, but the vault should still work without it. Therefore it's useful to have it disabled for most tests (only those that explicitly want to hit the limit should have it enabled).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A