### PR TITLE
Adjust MIN_WRAP_AMOUNT

### DIFF
--- a/pkg/vault/test/foundry/utils/BaseVaultTest.sol
+++ b/pkg/vault/test/foundry/utils/BaseVaultTest.sol
@@ -62,7 +62,7 @@ abstract contract BaseVaultTest is VaultStorage, BaseTest, Permit2Helpers {
 
     // ERC4626 buffer limits.
     uint256 internal constant BUFFER_MINIMUM_TOTAL_SUPPLY = 1e4;
-    uint256 internal constant PRODUCTION_MIN_WRAP_AMOUNT = 1e4;
+    uint256 internal constant PRODUCTION_MIN_WRAP_AMOUNT = 1e3;
 
     bytes32 internal constant ZERO_BYTES32 = 0x0000000000000000000000000000000000000000000000000000000000000000;
     bytes32 internal constant ONE_BYTES32 = 0x0000000000000000000000000000000000000000000000000000000000000001;


### PR DESCRIPTION
# Description

Too much shuffling / similarly named things here I think; the minimum wrap amount should be 1e3. The buffer minimum total supply is 1e4 (based on tokens like WBTC), as it's applied to unscaled values. The pool minimum total supply, applied to scaled values, remains 1e6. The minimum trade amount for pools (applied to scaled values) is also 1e6.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
