### PR TITLE
Add missing comment on _settleWrap and _settleUnwrap

### DIFF
--- a/pkg/vault/contracts/Vault.sol
+++ b/pkg/vault/contracts/Vault.sol
@@ -1489,9 +1489,9 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
         if (underlyingBalancesAfter < expectedUnderlyingReservesAfter) {
             // If Vault's underlying balance is smaller than expected, the Vault was drained and the operation should
             // revert. It may happen in different ways, depending on the wrap/unwrap operation:
-            // * deposit: the wrapper didn't respect the exact amount in of underlying.
-            // * mint: the underlying amount subtracted from the vault is bigger than wrapper's calculated amount in.
-            // * withdraw: the wrapper didn't respect the exact amount out of underlying.
+            // * deposit: the wrapper didn't respect the exact amount in of underlying;
+            // * mint: the underlying amount subtracted from the vault is bigger than wrapper's calculated amount in;
+            // * withdraw: the wrapper didn't respect the exact amount out of underlying;
             // * redeem: the underlying amount added to the vault is smaller than wrapper's calculated amount out.
             revert NotEnoughUnderlying(
                 IERC4626(address(wrappedToken)),
@@ -1508,9 +1508,9 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
         if (wrappedBalancesAfter < expectedWrappedReservesAfter) {
             // If the Vault's wrapped balance is smaller than expected, the Vault was drained and the operation should
             // revert. It may happen in different ways, depending on the wrap/unwrap operation:
-            // * deposit: the wrapped amount added to the vault is smaller than wrapper's calculated amount out.
-            // * mint: the wrapper didn't respect the exact amount out of wrapped.
-            // * withdraw: the wrapped amount subtracted from the vault is bigger than wrapper's calculated amount in.
+            // * deposit: the wrapped amount added to the vault is smaller than wrapper's calculated amount out;
+            // * mint: the wrapper didn't respect the exact amount out of wrapped;
+            // * withdraw: the wrapped amount subtracted from the vault is bigger than wrapper's calculated amount in;
             // * redeem: the wrapper didn't respect the exact amount in of wrapped.
             revert NotEnoughWrapped(
                 IERC4626(address(wrappedToken)),

--- a/pkg/vault/contracts/Vault.sol
+++ b/pkg/vault/contracts/Vault.sol
@@ -1224,6 +1224,8 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
             // drain the vault.
             underlyingToken.forceApprove(address(wrappedToken), 0);
 
+            // Check if the Vault's underlying balance decreased by `vaultUnderlyingDeltaHint` and the Vault's
+            // wrapped balance increased by `vaultWrappedDeltaHint`. If not, reverts.
             _settleWrap(underlyingToken, IERC20(wrappedToken), vaultUnderlyingDeltaHint, vaultWrappedDeltaHint);
 
             // Only updates buffer balances if buffer has a surplus of underlying tokens.
@@ -1358,6 +1360,8 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
                 vaultWrappedDeltaHint = wrappedToken.withdraw(vaultUnderlyingDeltaHint, address(this), address(this));
             }
 
+            // Check if the Vault's underlying balance increased by `vaultUnderlyingDeltaHint` and the Vault's
+            // wrapped balance decreased by `vaultWrappedDeltaHint`. If not, reverts.
             _settleUnwrap(underlyingToken, IERC20(wrappedToken), vaultUnderlyingDeltaHint, vaultWrappedDeltaHint);
 
             // Only updates buffer balances if buffer has a surplus of wrapped tokens.

--- a/pkg/vault/contracts/Vault.sol
+++ b/pkg/vault/contracts/Vault.sol
@@ -1225,7 +1225,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
             underlyingToken.forceApprove(address(wrappedToken), 0);
 
             // Check if the Vault's underlying balance decreased by `vaultUnderlyingDeltaHint` and the Vault's
-            // wrapped balance increased by `vaultWrappedDeltaHint`. If not, reverts.
+            // wrapped balance increased by `vaultWrappedDeltaHint`. If not, it reverts.
             _settleWrap(underlyingToken, IERC20(wrappedToken), vaultUnderlyingDeltaHint, vaultWrappedDeltaHint);
 
             // Only updates buffer balances if buffer has a surplus of underlying tokens.

--- a/pkg/vault/contracts/Vault.sol
+++ b/pkg/vault/contracts/Vault.sol
@@ -1361,7 +1361,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
             }
 
             // Check if the Vault's underlying balance increased by `vaultUnderlyingDeltaHint` and the Vault's
-            // wrapped balance decreased by `vaultWrappedDeltaHint`. If not, reverts.
+            // wrapped balance decreased by `vaultWrappedDeltaHint`. If not, it reverts.
             _settleUnwrap(underlyingToken, IERC20(wrappedToken), vaultUnderlyingDeltaHint, vaultWrappedDeltaHint);
 
             // Only updates buffer balances if buffer has a surplus of wrapped tokens.


### PR DESCRIPTION
# Description

Auditors skipped an important row when reading `_wrapWithBuffer` and `_unwrapWithBuffer`. This PR makes sure these rows are explained and not easy to miss.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [x] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

