### PR TITLE
remove VaultGuard from BaseHooks

### DIFF
--- a/pkg/vault/contracts/BaseHooks.sol
+++ b/pkg/vault/contracts/BaseHooks.sol
@@ -14,16 +14,15 @@ import {
     AfterSwapParams
 } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
-import { VaultGuard } from "./VaultGuard.sol";
-
 /**
  * @notice Base for pool hooks contracts.
  * @dev Hook contracts that only implement a subset of callbacks can inherit from here instead of IHooks,
- * and only override what they need. `VaultGuard` allows use of the `onlyVault` modifier, which isn't used
- * in this abstract contract, but should be used in real derived hook contracts.
+ * and only override what they need.
+ * @dev `VaultGuard` allows use of the `onlyVault` modifier, which isn't part of this abstract contract,
+ * but should/must be used in real derived hook contracts.
  */
-abstract contract BaseHooks is IHooks, VaultGuard {
-    constructor(IVault vault) VaultGuard(vault) {
+abstract contract BaseHooks is IHooks {
+    constructor() {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/vault/contracts/test/BaseHooksMock.sol
+++ b/pkg/vault/contracts/test/BaseHooksMock.sol
@@ -2,13 +2,12 @@
 
 pragma solidity ^0.8.24;
 
-import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
 import "../BaseHooks.sol";
 
 contract BaseHooksMock is BaseHooks {
-    constructor(IVault vault) BaseHooks(vault) {
+    constructor() BaseHooks() {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/vault/contracts/test/MinimalHooksPoolMock.sol
+++ b/pkg/vault/contracts/test/MinimalHooksPoolMock.sol
@@ -3,7 +3,6 @@
 pragma solidity ^0.8.24;
 
 import { IHooks } from "@balancer-labs/v3-interfaces/contracts/vault/IHooks.sol";
-import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
 import { BaseHooks } from "../BaseHooks.sol";
@@ -12,7 +11,7 @@ import { BaseHooks } from "../BaseHooks.sol";
 contract MinimalHooksPoolMock is BaseHooks {
     HookFlags private _hookFlags;
 
-    constructor(IVault vault) BaseHooks(vault) {}
+    constructor() BaseHooks() {}
 
     function onRegister(
         address,

--- a/pkg/vault/contracts/test/PoolHooksMock.sol
+++ b/pkg/vault/contracts/test/PoolHooksMock.sol
@@ -69,8 +69,10 @@ contract PoolHooksMock is BaseHooks {
     mapping(address pool => bool isFromFactory) private _allowedFactories;
 
     HookFlags private _hookFlags;
+    IVault _vault;
 
-    constructor(IVault vault) BaseHooks(vault) {
+    constructor(IVault vault) BaseHooks() {
+        _vault = vault;
         shouldSettleDiscount = true;
     }
 

--- a/pkg/vault/test/foundry/BaseHooks.t.sol
+++ b/pkg/vault/test/foundry/BaseHooks.t.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.24;
 import "forge-std/Test.sol";
 
 import { IHooks } from "@balancer-labs/v3-interfaces/contracts/vault/IHooks.sol";
-import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
 import { BaseHooksMock } from "../../contracts/test/BaseHooksMock.sol";
@@ -19,7 +18,7 @@ contract BaseHooksTest is BaseVaultTest {
         BaseVaultTest.setUp();
 
         // Not using PoolHooksMock address because onRegister of BaseHooks fails, so the test does not run.
-        testHook = new BaseHooksMock(IVault(address(vault)));
+        testHook = new BaseHooksMock();
     }
 
     function testOnRegister() public {

--- a/pkg/vault/test/gas/PoolMockWithHooks.test.ts
+++ b/pkg/vault/test/gas/PoolMockWithHooks.test.ts
@@ -19,7 +19,7 @@ class PoolMockWithHooksBenchmark extends Benchmark {
     })) as unknown as PoolFactoryMock;
 
     const hooks = (await deploy('MinimalHooksPoolMock', {
-      args: [this.vault],
+      args: [],
     })) as unknown as MinimalHooksPoolMock;
 
     await hooks.setHookFlags({


### PR DESCRIPTION
# Description
Remove VaultGaurd from BaseHooks and its child classes/tests

<!-- Include any context necessary for understanding the PR's purpose. -->
Needlessly including VaultGuard in BaseHooks creates an annoying diamond inheritance pattern when building hook contracts that already have dependencies on the Vault. Removing it and having downstream developers add the `onlyVault` modifier from VaultGuard on their own is a far superior pattern. They are already forced to add the modifier in the derived contracts, so doing an import to do so is a minor lift that alleviates an otherwise frustrating problem.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution
n/a