### PR TITLE
Receive ETH test / VaultAdmin default functions

### DIFF
--- a/pkg/vault/contracts/VaultAdmin.sol
+++ b/pkg/vault/contracts/VaultAdmin.sol
@@ -726,4 +726,22 @@ contract VaultAdmin is IVaultAdmin, VaultCommon, Authentication, VaultGuard {
     function _canPerform(bytes32 actionId, address user, address where) internal view returns (bool) {
         return _authorizer.canPerform(actionId, user, where);
     }
+
+    /*******************************************************************************
+                                     Default handlers
+    *******************************************************************************/
+
+    receive() external payable {
+        revert CannotReceiveEth();
+    }
+
+    // solhint-disable no-complex-fallback
+
+    fallback() external payable {
+        if (msg.value > 0) {
+            revert CannotReceiveEth();
+        }
+
+        revert("Not implemented");
+    }
 }

--- a/pkg/vault/test/.contract-sizes/VaultAdmin
+++ b/pkg/vault/test/.contract-sizes/VaultAdmin
@@ -1,2 +1,2 @@
-Bytecode	13.755
-InitCode	14.772
+Bytecode	13.896
+InitCode	14.913

--- a/pkg/vault/test/foundry/VaultDefaultHandlers.t.sol
+++ b/pkg/vault/test/foundry/VaultDefaultHandlers.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+
 import { IRateProvider } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IRateProvider.sol";
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
@@ -12,15 +14,33 @@ import { VaultExtensionMock } from "../../contracts/test/VaultExtensionMock.sol"
 
 import { BaseVaultTest } from "./utils/BaseVaultTest.sol";
 
-contract VaultDefaultHandlers is BaseVaultTest {
+interface IRandom {
+    function nonexistentFunction() external payable;
+}
+
+contract VaultDefaultHandlersTest is BaseVaultTest {
+    using Address for address payable;
+
     function setUp() public virtual override {
         BaseVaultTest.setUp();
     }
 
-    function testReceive() public {
+    function testReceiveVault() public {
         vm.prank(alice);
         vm.expectRevert(IVaultErrors.CannotReceiveEth.selector);
         payable(address(vault)).transfer(1);
+    }
+
+    function testReceiveVaultExtension() public {
+        vm.prank(alice);
+        vm.expectRevert(IVaultErrors.CannotReceiveEth.selector);
+        payable(address(vaultExtension)).transfer(1);
+    }
+
+    function testReceiveVaultAdmin() public {
+        vm.prank(alice);
+        vm.expectRevert(IVaultErrors.CannotReceiveEth.selector);
+        payable(address(vaultAdmin)).transfer(1);
     }
 
     function testDefaultHandlerWithEth() public {
@@ -46,5 +66,23 @@ contract VaultDefaultHandlers is BaseVaultTest {
         IVault vaultExtension = IVault(vault.getVaultExtension());
         vm.expectRevert(IVaultErrors.NotVaultDelegateCall.selector);
         vaultExtension.isPoolRegistered(pool);
+    }
+
+    function testSendEthNowhereExtension() public {
+        // Try sending ETH directly to the VaultExtension
+        vm.expectRevert(IVaultErrors.CannotReceiveEth.selector);
+        IRandom(address(vaultExtension)).nonexistentFunction{ value: 1 }();
+    }
+
+    function testSendEthNowhereAdmin() public {
+        // Try sending ETH directly to the VaultAdmin
+        vm.expectRevert(IVaultErrors.CannotReceiveEth.selector);
+        IRandom(address(vaultAdmin)).nonexistentFunction{ value: 1 }();
+    }
+
+    function testAdminFallback() public {
+        // Try calling an non-existent function on the VaultAdmin
+        vm.expectRevert("Not implemented");
+        IRandom(address(vaultAdmin)).nonexistentFunction();
     }
 }

--- a/pkg/vault/test/foundry/mutation/vault/VaultAdmin.t.sol
+++ b/pkg/vault/test/foundry/mutation/vault/VaultAdmin.t.sol
@@ -371,18 +371,18 @@ contract VaultAdminMutationTest is BaseVaultTest {
 
     function testRemoveLiquidityFromBufferHookWhenNotVaultDelegateCall() public {
         vm.expectRevert(IVaultErrors.NotVaultDelegateCall.selector);
-        VaultAdmin(address(vaultAdmin)).removeLiquidityFromBufferHook(IERC4626(address(0)), 0, address(0));
+        VaultAdmin(payable(address(vaultAdmin))).removeLiquidityFromBufferHook(IERC4626(address(0)), 0, address(0));
     }
 
     function testRemoveLiquidityFromBufferHookWhenVaultIsNotSender() public {
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.SenderIsNotVault.selector, address(this)));
-        VaultAdmin(address(vault)).removeLiquidityFromBufferHook(IERC4626(address(0)), 0, address(0));
+        VaultAdmin(payable(address(vault))).removeLiquidityFromBufferHook(IERC4626(address(0)), 0, address(0));
     }
 
     function testRemoveLiquidityFromBufferHookWhenNotUnlocked() public {
         vm.prank(address(vault));
         vm.expectRevert(IVaultErrors.VaultIsNotUnlocked.selector);
-        VaultAdmin(address(vault)).removeLiquidityFromBufferHook(IERC4626(address(0)), 0, address(0));
+        VaultAdmin(payable(address(vault))).removeLiquidityFromBufferHook(IERC4626(address(0)), 0, address(0));
     }
 
     function testRemoveLiquidityFromBufferHookWhenNotInitialized() public {
@@ -390,7 +390,7 @@ contract VaultAdminMutationTest is BaseVaultTest {
         vault.forceUnlock();
         vm.prank(address(vault));
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.BufferNotInitialized.selector, wrappedToken));
-        VaultAdmin(address(vault)).removeLiquidityFromBufferHook(wrappedToken, 0, address(0));
+        VaultAdmin(payable(address(vault))).removeLiquidityFromBufferHook(wrappedToken, 0, address(0));
     }
 
     function testRemoveLiquidityFromBufferNonReentrant() public {


### PR DESCRIPTION
# Description

Per audit discussion, test sending ETH/triggering fallback on all contracts. We hadn't done anything with VaultAdmin (the end of the line), and maybe we don't need to, but this also explicitly disallows sending ETH or invoking the fallback on the Admin, just in case.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [X] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
