### PR TITLE
Document pool creator fee algorithm in the "setters"

### DIFF
--- a/pkg/interfaces/contracts/vault/IProtocolFeeController.sol
+++ b/pkg/interfaces/contracts/vault/IProtocolFeeController.sol
@@ -270,6 +270,10 @@ interface IProtocolFeeController {
 
     /**
      * @notice Assigns a new pool creator swap fee percentage to the specified pool.
+     * @dev Fees are divided between the protocol, pool creator, and LPs. The pool creator percentage is applied to
+     * the "net" amount after protocol fees, and divides the remainder between the pool creator and LPs. If the
+     * pool creator fee is 100%, none of the fee amount remains in the pool for LPs.
+     *
      * @param pool The address of the pool for which the pool creator fee will be changed
      * @param poolCreatorSwapFeePercentage The new pool creator swap fee percentage to apply to the pool
      */
@@ -277,6 +281,10 @@ interface IProtocolFeeController {
 
     /**
      * @notice Assigns a new pool creator yield fee percentage to the specified pool.
+     * @dev Fees are divided between the protocol, pool creator, and LPs. The pool creator percentage is applied to
+     * the "net" amount after protocol fees, and divides the remainder between the pool creator and LPs. If the
+     * pool creator fee is 100%, none of the fee amount remains in the pool for LPs.
+     *
      * @param pool The address of the pool for which the pool creator fee will be changed
      * @param poolCreatorYieldFeePercentage The new pool creator yield fee percentage to apply to the pool
      */


### PR DESCRIPTION
# Description

This is already documented in the main interface comment block, but the `setPoolCreatorSwap/YieldFeePercentage` functions don't say this locally. Add a short description to both functions.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [X] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests have 100% code coverage
- [A] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
