### PR TITLE
Consistent naming for custom liquidity flags

### DIFF
--- a/pkg/vault/contracts/Vault.sol
+++ b/pkg/vault/contracts/Vault.sol
@@ -656,7 +656,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
                     IBasePool(params.pool)
                 );
         } else if (params.kind == AddLiquidityKind.CUSTOM) {
-            poolData.poolConfigBits.requireAddCustomLiquidityEnabled();
+            poolData.poolConfigBits.requireAddLiquidityCustomEnabled();
 
             // Uses msg.sender as the Router (the contract that called the Vault).
             (amountsInScaled18, bptAmountOut, swapFeeAmounts, returnData) = IPoolLiquidity(params.pool)
@@ -902,7 +902,7 @@ contract Vault is IVaultMain, VaultCommon, Proxy {
                 IBasePool(params.pool)
             );
         } else if (params.kind == RemoveLiquidityKind.CUSTOM) {
-            poolData.poolConfigBits.requireRemoveCustomLiquidityEnabled();
+            poolData.poolConfigBits.requireRemoveLiquidityCustomEnabled();
             // Uses msg.sender as the Router (the contract that called the Vault).
             (bptAmountIn, amountsOutScaled18, swapFeeAmounts, returnData) = IPoolLiquidity(params.pool)
                 .onRemoveLiquidityCustom(

--- a/pkg/vault/contracts/lib/PoolConfigLib.sol
+++ b/pkg/vault/contracts/lib/PoolConfigLib.sol
@@ -99,7 +99,7 @@ library PoolConfigLib {
         return PoolConfigBits.unwrap(config).decodeBool(PoolConfigConst.ADD_LIQUIDITY_CUSTOM_OFFSET);
     }
 
-    function requireAddCustomLiquidityEnabled(PoolConfigBits config) internal pure {
+    function requireAddLiquidityCustomEnabled(PoolConfigBits config) internal pure {
         if (config.supportsAddLiquidityCustom() == false) {
             revert IVaultErrors.DoesNotSupportAddLiquidityCustom();
         }
@@ -122,7 +122,7 @@ library PoolConfigLib {
         return PoolConfigBits.unwrap(config).decodeBool(PoolConfigConst.REMOVE_LIQUIDITY_CUSTOM_OFFSET);
     }
 
-    function requireRemoveCustomLiquidityEnabled(PoolConfigBits config) internal pure {
+    function requireRemoveLiquidityCustomEnabled(PoolConfigBits config) internal pure {
         if (config.supportsRemoveLiquidityCustom() == false) {
             revert IVaultErrors.DoesNotSupportRemoveLiquidityCustom();
         }

--- a/pkg/vault/test/foundry/unit/PoolConfigLib.t.sol
+++ b/pkg/vault/test/foundry/unit/PoolConfigLib.t.sol
@@ -145,18 +145,18 @@ contract PoolConfigLibTest is Test {
         assertTrue(config.supportsAddLiquidityCustom(), "supportsAddLiquidityCustom is false (setter)");
     }
 
-    function testRequireAddCustomLiquidityEnabled() public pure {
+    function testRequireAddLiquidityCustomEnabled() public pure {
         PoolConfigBits config;
         config = config.setAddLiquidityCustom(true);
 
-        config.requireAddCustomLiquidityEnabled();
+        config.requireAddLiquidityCustomEnabled();
     }
 
-    function testRequireAddCustomLiquidityRevertIfIsDisabled() public {
+    function testRequireAddLiquidityCustomRevertIfIsDisabled() public {
         PoolConfigBits config;
 
         vm.expectRevert(IVaultErrors.DoesNotSupportAddLiquidityCustom.selector);
-        config.requireAddCustomLiquidityEnabled();
+        config.requireAddLiquidityCustomEnabled();
     }
 
     function testSupportsRemoveLiquidityCustom() public pure {
@@ -173,18 +173,18 @@ contract PoolConfigLibTest is Test {
         assertTrue(config.supportsRemoveLiquidityCustom(), "supportsRemoveLiquidityCustom is false (setter)");
     }
 
-    function testRequireRemoveCustomLiquidityEnabled() public pure {
+    function testRequireRemoveLiquidityCustomEnabled() public pure {
         PoolConfigBits config;
         config = config.setRemoveLiquidityCustom(true);
 
-        config.requireRemoveCustomLiquidityEnabled();
+        config.requireRemoveLiquidityCustomEnabled();
     }
 
-    function testRequireRemoveCustomLiquidityReveryIfIsDisabled() public {
+    function testRequireRemoveLiquidityCustomReveryIfIsDisabled() public {
         PoolConfigBits config;
 
         vm.expectRevert(IVaultErrors.DoesNotSupportRemoveLiquidityCustom.selector);
-        config.requireRemoveCustomLiquidityEnabled();
+        config.requireRemoveLiquidityCustomEnabled();
     }
 
     function testSupportsDonation() public pure {


### PR DESCRIPTION
# Description

Per Certora I-08:

In all locations the naming “LiquidityCustom” is used except for requireRemoveCustomLiquidityEnabled and requireAddCustomLiquidityEnabled where the order of words is “CustomLiquidity”

This renames to Add/RemoveLiquidityCustom

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
