### PR TITLE
Add liquidity nested: stack too deep

### DIFF
--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	17.290
-InitCode	18.877
+Bytecode	23.796
+InitCode	25.498

--- a/pvt/common/hardhat-base-config.ts
+++ b/pvt/common/hardhat-base-config.ts
@@ -70,12 +70,12 @@ const contractSettings: ContractSettings = {
   '@balancer-labs/v3-vault/contracts/CompositeLiquidityRouter.sol': {
     version: '0.8.26',
     runs: 9999,
-    viaIR,
+    viaIR: false,
   },
   '@balancer-labs/v3-vault/contracts/test/CompositeLiquidityRouterMock.sol': {
     version: '0.8.26',
     runs: 9999,
-    viaIR,
+    viaIR: false,
   },
   '@balancer-labs/v3-vault/contracts/VaultExplorer.sol': {
     version: '0.8.24',

--- a/pvt/common/hardhat-base-config.ts
+++ b/pvt/common/hardhat-base-config.ts
@@ -67,6 +67,16 @@ const contractSettings: ContractSettings = {
     runs: 500,
     viaIR,
   },
+  '@balancer-labs/v3-vault/contracts/CompositeLiquidityRouter.sol': {
+    version: '0.8.26',
+    runs: 9999,
+    viaIR,
+  },
+  '@balancer-labs/v3-vault/contracts/test/CompositeLiquidityRouterMock.sol': {
+    version: '0.8.26',
+    runs: 9999,
+    viaIR,
+  },
   '@balancer-labs/v3-vault/contracts/VaultExplorer.sol': {
     version: '0.8.24',
     runs: 9999,


### PR DESCRIPTION
# Description

Unless I'm missing something obvious, this seems like a compiler bug. No matter how hard you try packing variables into locals or separate functions / scopes, the code just doesn't compile with via IR. It only compiles by removing the call to `_vault.settle`, which doesn't make any sense.

This is a temporary fix; the code does compile with the legacy pipeline. Also tried 0.8.27 with via IR, same result.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A