### PR TITLE
Allow overriding `onSwap` in Stable Pool

### DIFF
--- a/pkg/pool-stable/contracts/StablePool.sol
+++ b/pkg/pool-stable/contracts/StablePool.sol
@@ -171,7 +171,7 @@ contract StablePool is IStablePool, BalancerPoolToken, BasePoolAuthentication, P
     }
 
     /// @inheritdoc IBasePool
-    function onSwap(PoolSwapParams memory request) public view onlyVault returns (uint256) {
+    function onSwap(PoolSwapParams memory request) public view virtual onlyVault returns (uint256) {
         uint256 invariant = computeInvariant(request.balancesScaled18, Rounding.ROUND_DOWN);
         (uint256 currentAmp, ) = _getAmplificationParameter();
 

--- a/pkg/pool-stable/contracts/StablePoolFactory.sol
+++ b/pkg/pool-stable/contracts/StablePoolFactory.sol
@@ -23,8 +23,6 @@ import { StablePool } from "./StablePool.sol";
  * Since this limit is less than Vault's maximum of 8 tokens, we need to enforce this at the factory level.
  */
 contract StablePoolFactory is IPoolVersion, BasePoolFactory, Version {
-    // solhint-disable not-rely-on-time
-
     string private _poolVersion;
 
     constructor(


### PR DESCRIPTION
# Description

Inspired by the LBP example, in which a custom pool overrides the `onSwap` hook, it strikes me that people might similarly want to make custom Stable pools, and would run into the same problem if it were not virtual.

In both cases, I think we should **not** make the invariant functions virtual, as they directly call Weighted/Stable math. If a custom pool uses different math, then it's not really a Weighted/Stable pool, and shouldn't be derived from it anyway.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
