### PR TITLE
Fix computeBalance in stable pool math

### DIFF
--- a/pkg/solidity-utils/contracts/math/StableMath.sol
+++ b/pkg/solidity-utils/contracts/math/StableMath.sol
@@ -237,7 +237,7 @@ library StableMath {
         uint256 inv2 = invariant * invariant;
         // We remove the balance from c by multiplying it.
         uint256 c = (inv2 * AMP_PRECISION).divUpRaw(ampTimesTotal * P_D) * balances[tokenIndex];
-        uint256 b = sum + ((invariant / ampTimesTotal) * AMP_PRECISION);
+        uint256 b = sum + ((invariant * AMP_PRECISION) / ampTimesTotal);
         // We iterate to find the balance.
         uint256 prevTokenBalance = 0;
         // We multiply the first iteration outside the loop with the invariant to set the value of the

--- a/pkg/solidity-utils/contracts/test/StableMathMock.sol
+++ b/pkg/solidity-utils/contracts/test/StableMathMock.sol
@@ -244,7 +244,7 @@ contract StableMathMock {
         uint256 inv2 = invariant * invariant;
         uint256 c = (inv2 * StableMath.AMP_PRECISION).mockDivRaw(ampTimesTotal * P_D, roundingPermutation[0]) *
             balances[tokenIndex];
-        uint256 b = sum + ((invariant / ampTimesTotal) * StableMath.AMP_PRECISION);
+        uint256 b = sum + (((invariant * StableMath.AMP_PRECISION) / ampTimesTotal));
         uint256 prevTokenBalance = 0;
         uint256 tokenBalance = (inv2 + c).mockDivRaw(invariant + b, roundingPermutation[1]);
 

--- a/pkg/solidity-utils/contracts/test/StableMathMock.sol
+++ b/pkg/solidity-utils/contracts/test/StableMathMock.sol
@@ -244,7 +244,7 @@ contract StableMathMock {
         uint256 inv2 = invariant * invariant;
         uint256 c = (inv2 * StableMath.AMP_PRECISION).mockDivRaw(ampTimesTotal * P_D, roundingPermutation[0]) *
             balances[tokenIndex];
-        uint256 b = sum + (((invariant * StableMath.AMP_PRECISION) / ampTimesTotal));
+        uint256 b = sum + ((invariant * StableMath.AMP_PRECISION) / ampTimesTotal);
         uint256 prevTokenBalance = 0;
         uint256 tokenBalance = (inv2 + c).mockDivRaw(invariant + b, roundingPermutation[1]);
 

--- a/pkg/solidity-utils/test/foundry/StableMath.t.sol
+++ b/pkg/solidity-utils/test/foundry/StableMath.t.sol
@@ -68,6 +68,10 @@ contract StableMathTest is Test {
         amp = boundAmp(amp);
         uint256[] memory balances = boundBalances(rawBalances);
 
+        try stableMathMock.computeInvariant(amp, balances) returns (uint256) {} catch {
+            vm.assume(false);
+        }
+
         stableMathMock.computeInvariant(amp, balances);
     }
 
@@ -83,6 +87,11 @@ contract StableMathTest is Test {
         uint256[] memory balances = boundBalances(rawBalances);
         (tokenIndexIn, tokenIndexOut) = boundTokenIndexes(tokenIndexIn, tokenIndexOut);
         tokenAmountIn = boundAmount(tokenAmountIn, balances[tokenIndexIn]);
+
+        try stableMathMock.computeInvariant(amp, balances) returns (uint256) {} catch {
+            vm.assume(false);
+        }
+
         uint256 invariant = stableMathMock.computeInvariant(amp, balances);
 
         uint256 outGivenExactIn = stableMathMock.computeOutGivenExactIn(
@@ -132,6 +141,11 @@ contract StableMathTest is Test {
         uint256[] memory balances = boundBalances(rawBalances);
         (tokenIndexIn, tokenIndexOut) = boundTokenIndexes(tokenIndexIn, tokenIndexOut);
         tokenAmountOut = boundAmount(tokenAmountOut, balances[tokenIndexOut]);
+
+        try stableMathMock.computeInvariant(amp, balances) returns (uint256) {} catch {
+            vm.assume(false);
+        }
+
         uint256 invariant = stableMathMock.computeInvariant(amp, balances);
 
         uint256 inGivenExactOut = stableMathMock.computeInGivenExactOut(
@@ -177,6 +191,11 @@ contract StableMathTest is Test {
     ) external view {
         amp = boundAmp(amp);
         uint256[] memory balances = boundBalances(rawBalances);
+
+        try stableMathMock.computeInvariant(amp, balances) returns (uint256) {} catch {
+            vm.assume(false);
+        }
+
         uint256 invariant = stableMathMock.computeInvariant(amp, balances);
         tokenIndex = boundTokenIndex(tokenIndex);
 
@@ -204,9 +223,9 @@ contract StableMathTest is Test {
         amp = boundAmp(amp);
         uint256[] memory balances = boundBalances(rawBalances);
         tokenIndex = bound(tokenIndex, 0, NUM_TOKENS - 1);
-        invariantDiff = bound(invariantDiff, 4, 100000);
+        invariantDiff = bound(invariantDiff, 1, 100000);
 
-        try stableMathMock.computeInvariant(amp, balances) returns (uint256 invariant) {} catch {
+        try stableMathMock.computeInvariant(amp, balances) returns (uint256) {} catch {
             vm.assume(false);
         }
 
@@ -214,7 +233,6 @@ contract StableMathTest is Test {
         uint256 balanceOne = stableMathMock.computeBalance(amp, balances, invariant, tokenIndex);
         uint256 balanceTwo = stableMathMock.computeBalance(amp, balances, invariant + invariantDiff, tokenIndex);
 
-        console.log("invariantDiff: %d", invariantDiff);
-        assertGt(balanceTwo, balanceOne, "The balance should be greater when the invariant is greater.");
+        assertGe(balanceTwo, balanceOne, "The balance should be greater or eq when the invariant is greater.");
     }
 }

--- a/pkg/solidity-utils/test/foundry/StableMath.t.sol
+++ b/pkg/solidity-utils/test/foundry/StableMath.t.sol
@@ -67,8 +67,8 @@ contract StableMathTest is Test {
     function testComputeInvariant__Fuzz(uint256 amp, uint256[NUM_TOKENS] calldata rawBalances) external view {
         amp = boundAmp(amp);
         uint256[] memory balances = boundBalances(rawBalances);
-
-        try stableMathMock.computeInvariant(amp, balances) returns (uint256) {} catch {
+        try stableMathMock.computeInvariant(amp, balances) returns (uint256) {} catch (bytes memory result) {
+            assertEq(bytes4(result), StableMath.StableInvariantDidNotConverge.selector, "Unexpected error");
             vm.assume(false);
         }
 
@@ -88,7 +88,8 @@ contract StableMathTest is Test {
         (tokenIndexIn, tokenIndexOut) = boundTokenIndexes(tokenIndexIn, tokenIndexOut);
         tokenAmountIn = boundAmount(tokenAmountIn, balances[tokenIndexIn]);
 
-        try stableMathMock.computeInvariant(amp, balances) returns (uint256) {} catch {
+        try stableMathMock.computeInvariant(amp, balances) returns (uint256) {} catch (bytes memory result) {
+            assertEq(bytes4(result), StableMath.StableInvariantDidNotConverge.selector, "Unexpected error");
             vm.assume(false);
         }
 
@@ -142,7 +143,8 @@ contract StableMathTest is Test {
         (tokenIndexIn, tokenIndexOut) = boundTokenIndexes(tokenIndexIn, tokenIndexOut);
         tokenAmountOut = boundAmount(tokenAmountOut, balances[tokenIndexOut]);
 
-        try stableMathMock.computeInvariant(amp, balances) returns (uint256) {} catch {
+        try stableMathMock.computeInvariant(amp, balances) returns (uint256) {} catch (bytes memory result) {
+            assertEq(bytes4(result), StableMath.StableInvariantDidNotConverge.selector, "Unexpected error");
             vm.assume(false);
         }
 
@@ -192,7 +194,8 @@ contract StableMathTest is Test {
         amp = boundAmp(amp);
         uint256[] memory balances = boundBalances(rawBalances);
 
-        try stableMathMock.computeInvariant(amp, balances) returns (uint256) {} catch {
+        try stableMathMock.computeInvariant(amp, balances) returns (uint256) {} catch (bytes memory result) {
+            assertEq(bytes4(result), StableMath.StableInvariantDidNotConverge.selector, "Unexpected error");
             vm.assume(false);
         }
 
@@ -225,7 +228,8 @@ contract StableMathTest is Test {
         tokenIndex = bound(tokenIndex, 0, NUM_TOKENS - 1);
         invariantDiff = bound(invariantDiff, 1, 100000);
 
-        try stableMathMock.computeInvariant(amp, balances) returns (uint256) {} catch {
+        try stableMathMock.computeInvariant(amp, balances) returns (uint256) {} catch (bytes memory result) {
+            assertEq(bytes4(result), StableMath.StableInvariantDidNotConverge.selector, "Unexpected error");
             vm.assume(false);
         }
 


### PR DESCRIPTION
# Description

The `computeBalance` function with a higher invariant can give a result smaller than that of `computeBalance` with a lower invariant. The issue arises due to precision loss during the computation of `computeBalance`.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [X] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
