### PR TITLE
fix coverage flag

### DIFF
--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	24.183* (187 over)
-InitCode	25.817
+Bytecode	21.151
+InitCode	22.690

--- a/pvt/common/hardhat-base-config.ts
+++ b/pvt/common/hardhat-base-config.ts
@@ -19,7 +19,7 @@ type SolcConfig = {
 };
 
 // The coverage report doesn't work well with via-ir flags, so we disable it
-const viaIR = !process.env.COVERAGE;
+const viaIR = !(process.env.COVERAGE === 'true' ? true : false);
 const optimizerSteps =
   'dhfoDgvulfnTUtnIf [ xa[r]EscLM cCTUtTOntnfDIul Lcul Vcul [j] Tpeul xa[rul] xa[r]cL gvif CTUca[r]LSsTFOtfDnca[r]Iulc ] jmul[jul] VcTOcul jmul : fDnTOcmu';
 
@@ -70,12 +70,12 @@ const contractSettings: ContractSettings = {
   '@balancer-labs/v3-vault/contracts/CompositeLiquidityRouter.sol': {
     version: '0.8.26',
     runs: 500,
-    viaIR: false,
+    viaIR,
   },
   '@balancer-labs/v3-vault/contracts/test/CompositeLiquidityRouterMock.sol': {
     version: '0.8.26',
     runs: 9999,
-    viaIR: false,
+    viaIR,
   },
   '@balancer-labs/v3-vault/contracts/VaultExplorer.sol': {
     version: '0.8.24',

--- a/pvt/common/hardhat-base-config.ts
+++ b/pvt/common/hardhat-base-config.ts
@@ -67,16 +67,6 @@ const contractSettings: ContractSettings = {
     runs: 500,
     viaIR,
   },
-  '@balancer-labs/v3-vault/contracts/CompositeLiquidityRouter.sol': {
-    version: '0.8.26',
-    runs: 500,
-    viaIR,
-  },
-  '@balancer-labs/v3-vault/contracts/test/CompositeLiquidityRouterMock.sol': {
-    version: '0.8.26',
-    runs: 9999,
-    viaIR,
-  },
   '@balancer-labs/v3-vault/contracts/VaultExplorer.sol': {
     version: '0.8.24',
     runs: 9999,


### PR DESCRIPTION
# Description

The COVERAGE flag is interpreted as a string, so it will always be true. Because of this, when we want to compile with viaIr we will get the size of contracts without viaIr.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
