### PR TITLE
Graceful failure on unsupported decimals

### DIFF
--- a/pkg/interfaces/contracts/vault/IVaultErrors.sol
+++ b/pkg/interfaces/contracts/vault/IVaultErrors.sol
@@ -64,6 +64,9 @@ interface IVaultErrors {
     /// @notice The data in a TokenConfig struct is inconsistent or unsupported.
     error InvalidTokenConfiguration();
 
+    /// @notice Tokens with more than 18 decimals are not supported.
+    error InvalidTokenDecimals();
+
     /**
      * @notice The token list passed into an operation does not match the pool tokens in the pool.
      * @param pool Address of the pool

--- a/pkg/solidity-utils/contracts/helpers/ScalingHelpers.sol
+++ b/pkg/solidity-utils/contracts/helpers/ScalingHelpers.sol
@@ -15,6 +15,9 @@ import { InputHelpers } from "./InputHelpers.sol";
  * represented as 1e18. This allows us to not consider differences in token decimals in the internal Pool
  * math, simplifying it greatly.
  *
+ * The Vault does not support tokens with more than 18 decimals (see `_MAX_TOKEN_DECIMALS` in `VaultStorage`),
+ * or tokens that do not implement `IERC20Metadata.decimals`.
+ *
  * These helpers can also be used to scale amounts by other 18-decimal floating point values, such as rates.
  */
 library ScalingHelpers {

--- a/pkg/solidity-utils/contracts/helpers/ScalingHelpers.sol
+++ b/pkg/solidity-utils/contracts/helpers/ScalingHelpers.sol
@@ -201,23 +201,6 @@ library ScalingHelpers {
     }
 
     /**
-     * @notice Convert the token `decimals` into a scaling factor.
-     * @dev Called during registration, this reads the `decimals` from the token contract and constructs a conversion
-     * factor to be used when scaling up to full precision and back down to native decimals.
-     *
-     * As noted below, the Vault does not support tokens with more than 18 decimals, or tokens that do not implement
-     * `IERC20Metadata`.
-     */
-    function computeScalingFactor(IERC20 token) internal view returns (uint256) {
-        // Tokens that don't implement the `decimals` method are not supported.
-        uint256 tokenDecimals = IERC20Metadata(address(token)).decimals();
-
-        // Tokens with more than 18 decimals are not supported.
-        uint256 decimalsDifference = 18 - tokenDecimals;
-        return FixedPoint.ONE * 10 ** decimalsDifference;
-    }
-
-    /**
      * @notice Rounds up a rate informed by a rate provider.
      * @dev Rates calculated by an external rate provider have rounding errors. Intuitively, a rate provider
      * rounds the rate down so the pool math is executed with conservative amounts. However, when upscaling or

--- a/pkg/vault/contracts/VaultExtension.sol
+++ b/pkg/vault/contracts/VaultExtension.sol
@@ -232,7 +232,15 @@ contract VaultExtension is IVaultExtension, VaultCommon, Proxy {
                 revert InvalidTokenType();
             }
 
-            tokenDecimalDiffs[i] = uint8(18) - IERC20Metadata(address(token)).decimals();
+            uint8 tokenDecimals = IERC20Metadata(address(token)).decimals();
+
+            if (tokenDecimals > _MAX_TOKEN_DECIMALS) {
+                revert InvalidTokenDecimals();
+            } else {
+                unchecked {
+                    tokenDecimalDiffs[i] = _MAX_TOKEN_DECIMALS - tokenDecimals;
+                }
+            }
 
             // Store token and seed the next iteration.
             _poolTokens[pool].push(token);

--- a/pkg/vault/contracts/VaultExtension.sol
+++ b/pkg/vault/contracts/VaultExtension.sol
@@ -232,6 +232,7 @@ contract VaultExtension is IVaultExtension, VaultCommon, Proxy {
                 revert InvalidTokenType();
             }
 
+            // Store the token decimal conversion factor as a 5-bit delta from the maximum supported value.
             uint8 tokenDecimals = IERC20Metadata(address(token)).decimals();
 
             if (tokenDecimals > _MAX_TOKEN_DECIMALS) {

--- a/pkg/vault/contracts/VaultExtension.sol
+++ b/pkg/vault/contracts/VaultExtension.sol
@@ -232,7 +232,7 @@ contract VaultExtension is IVaultExtension, VaultCommon, Proxy {
                 revert InvalidTokenType();
             }
 
-            // Store the token decimal conversion factor as a 5-bit delta from the maximum supported value.
+            // Store the token decimal conversion factor as a delta from the maximum supported value.
             uint8 tokenDecimals = IERC20Metadata(address(token)).decimals();
 
             if (tokenDecimals > _MAX_TOKEN_DECIMALS) {

--- a/pkg/vault/contracts/VaultStorage.sol
+++ b/pkg/vault/contracts/VaultStorage.sol
@@ -39,6 +39,8 @@ contract VaultStorage {
     uint256 internal constant _MIN_TOKENS = 2;
     // This maximum token count is also implicitly hard-coded in `PoolConfigLib` (through packing `tokenDecimalDiffs`).
     uint256 internal constant _MAX_TOKENS = 8;
+    // Tokens with more than 18 decimals are not supported.
+    uint8 internal constant _MAX_TOKEN_DECIMALS = 18;
 
     // Maximum pause and buffer period durations.
     uint256 internal constant _MAX_PAUSE_WINDOW_DURATION = 365 days * 4;

--- a/pkg/vault/contracts/VaultStorage.sol
+++ b/pkg/vault/contracts/VaultStorage.sol
@@ -39,7 +39,7 @@ contract VaultStorage {
     uint256 internal constant _MIN_TOKENS = 2;
     // This maximum token count is also implicitly hard-coded in `PoolConfigLib` (through packing `tokenDecimalDiffs`).
     uint256 internal constant _MAX_TOKENS = 8;
-    // Tokens with more than 18 decimals are not supported.
+    // Tokens with more than 18 decimals are not supported. Tokens must also implement `IERC20Metadata.decimals`.
     uint8 internal constant _MAX_TOKEN_DECIMALS = 18;
 
     // Maximum pause and buffer period durations.

--- a/pkg/vault/test/.contract-sizes/VaultExtension
+++ b/pkg/vault/test/.contract-sizes/VaultExtension
@@ -1,2 +1,2 @@
-Bytecode	19.380
-InitCode	20.525
+Bytecode	19.350
+InitCode	20.495

--- a/pkg/vault/test/foundry/Registration.t.sol
+++ b/pkg/vault/test/foundry/Registration.t.sol
@@ -205,7 +205,7 @@ contract RegistrationTest is BaseVaultTest {
         LiquidityManagement memory liquidityManagement;
         vm.mockCall(address(dai), abi.encodeWithSelector(IERC20Metadata.decimals.selector), abi.encode(19));
 
-        vm.expectRevert(stdError.arithmeticError);
+        vm.expectRevert(IVaultErrors.InvalidTokenDecimals.selector);
         vault.registerPool(pool, tokenConfig, 0, 0, false, roleAccounts, address(0), liquidityManagement);
     }
 

--- a/pkg/vault/test/foundry/VaultTokens.t.sol
+++ b/pkg/vault/test/foundry/VaultTokens.t.sol
@@ -18,6 +18,7 @@ import {
 } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
 import { ERC4626TestToken } from "@balancer-labs/v3-solidity-utils/contracts/test/ERC4626TestToken.sol";
+import { ERC20TestToken } from "@balancer-labs/v3-solidity-utils/contracts/test/ERC20TestToken.sol";
 
 import { PoolFactoryMock } from "../../contracts/test/PoolFactoryMock.sol";
 import { PoolHooksMock } from "../../contracts/test/PoolHooksMock.sol";
@@ -96,6 +97,20 @@ contract VaultTokenTest is BaseVaultTest {
         tokenConfig[localUsdcIdx].token = IERC20(usdc);
 
         vm.expectRevert(IVaultErrors.InvalidTokenConfiguration.selector);
+        _registerPool(tokenConfig);
+    }
+
+    function testInvalidTokenDecimals() public {
+        TokenConfig[] memory tokenConfig = new TokenConfig[](2);
+        ERC20TestToken invalidToken = createERC20("INV", 19);
+        uint256 invalidIdx;
+
+        (invalidIdx, usdcIdx) = getSortedIndexes(address(invalidToken), address(usdc));
+
+        tokenConfig[invalidIdx].token = IERC20(invalidToken);
+        tokenConfig[usdcIdx].token = IERC20(usdc);
+
+        vm.expectRevert(IVaultErrors.InvalidTokenDecimals.selector);
         _registerPool(tokenConfig);
     }
 

--- a/pkg/vault/test/foundry/VaultTokens.t.sol
+++ b/pkg/vault/test/foundry/VaultTokens.t.sol
@@ -101,6 +101,8 @@ contract VaultTokenTest is BaseVaultTest {
     }
 
     function testInvalidTokenDecimals() public {
+        // This is technically a duplicate test (see `testRegisterSetWrongTokenDecimalDiffs` in Registration.t.sol),
+        // but doesn't use a mockCall.
         TokenConfig[] memory tokenConfig = new TokenConfig[](2);
         ERC20TestToken invalidToken = createERC20("INV", 19);
         uint256 invalidIdx;


### PR DESCRIPTION
# Description

Per auditor comment, there are some tokens out there (e.g., using ray math) that have > 18 decimals. We say these are unsupported, but if you try to register them, it will fail with a numeric underflow, which isn't very informative.

This defines a maximum number of decimals, and fails gracefully if it is exceeded. Also removes a function that we no longer use.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Resolves #1050 
