### PR TITLE
Use sender in the router queries (2)

### DIFF
--- a/pkg/vault/contracts/BatchRouter.sol
+++ b/pkg/vault/contracts/BatchRouter.sol
@@ -618,7 +618,7 @@ contract BatchRouter is IBatchRouter, BatchRouterCommon, ReentrancyGuardTransien
                     abi.encodeCall(
                         BatchRouter.querySwapExactInHook,
                         SwapExactInHookParams({
-                            sender: address(this),
+                            sender: sender,
                             paths: paths,
                             deadline: type(uint256).max,
                             wethIsEth: false,
@@ -650,7 +650,7 @@ contract BatchRouter is IBatchRouter, BatchRouterCommon, ReentrancyGuardTransien
                     abi.encodeCall(
                         BatchRouter.querySwapExactOutHook,
                         SwapExactOutHookParams({
-                            sender: address(this),
+                            sender: sender,
                             paths: paths,
                             deadline: type(uint256).max,
                             wethIsEth: false,

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity ^0.8.26;
+pragma solidity ^0.8.24;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IPermit2 } from "permit2/src/interfaces/IPermit2.sol";
@@ -136,7 +136,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                 abi.encodeCall(
                     CompositeLiquidityRouter.addLiquidityERC4626PoolUnbalancedHook,
                     AddLiquidityHookParams({
-                        sender: msg.sender,
+                        sender: sender,
                         pool: pool,
                         maxAmountsIn: exactUnderlyingAmountsIn,
                         minBptAmountOut: 0,
@@ -162,7 +162,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                 abi.encodeCall(
                     CompositeLiquidityRouter.addLiquidityERC4626PoolProportionalHook,
                     AddLiquidityHookParams({
-                        sender: msg.sender,
+                        sender: sender,
                         pool: pool,
                         maxAmountsIn: _maxTokenLimits(pool),
                         minBptAmountOut: exactBptAmountOut,
@@ -188,7 +188,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                 abi.encodeCall(
                     CompositeLiquidityRouter.removeLiquidityERC4626PoolProportionalHook,
                     RemoveLiquidityHookParams({
-                        sender: msg.sender,
+                        sender: sender,
                         pool: pool,
                         minAmountsOut: new uint256[](2),
                         maxBptAmountIn: exactBptAmountIn,
@@ -422,7 +422,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                         CompositeLiquidityRouter.addLiquidityUnbalancedNestedPoolHook.selector,
                         AddLiquidityHookParams({
                             pool: parentPool,
-                            sender: msg.sender,
+                            sender: sender,
                             maxAmountsIn: exactAmountsIn,
                             minBptAmountOut: 0,
                             kind: AddLiquidityKind.UNBALANCED,
@@ -622,7 +622,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                 abi.encodeWithSelector(
                     CompositeLiquidityRouter.removeLiquidityProportionalNestedPoolHook.selector,
                     RemoveLiquidityHookParams({
-                        sender: msg.sender,
+                        sender: sender,
                         pool: parentPool,
                         minAmountsOut: new uint256[](tokensOut.length),
                         maxBptAmountIn: exactBptAmountIn,

--- a/pkg/vault/contracts/Router.sol
+++ b/pkg/vault/contracts/Router.sol
@@ -777,9 +777,7 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
                 abi.encodeCall(
                     Router.queryAddLiquidityHook,
                     AddLiquidityHookParams({
-                        // We use the Router as a sender to simplify basic query functions,
-                        // but it is possible to add liquidity to any recipient.
-                        sender: address(this),
+                        sender: sender,
                         pool: pool,
                         maxAmountsIn: _maxTokenLimits(pool),
                         minBptAmountOut: exactBptAmountOut,
@@ -805,9 +803,7 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
                 abi.encodeCall(
                     Router.queryAddLiquidityHook,
                     AddLiquidityHookParams({
-                        // We use the Router as a sender to simplify basic query functions,
-                        // but it is possible to add liquidity to any recipient.
-                        sender: address(this),
+                        sender: sender,
                         pool: pool,
                         maxAmountsIn: exactAmountsIn,
                         minBptAmountOut: 0,
@@ -840,9 +836,7 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
                 abi.encodeCall(
                     Router.queryAddLiquidityHook,
                     AddLiquidityHookParams({
-                        // We use the Router as a sender to simplify basic query functions,
-                        // but it is possible to add liquidity to any recipient.
-                        sender: address(this),
+                        sender: sender,
                         pool: pool,
                         maxAmountsIn: maxAmountsIn,
                         minBptAmountOut: exactBptAmountOut,
@@ -872,9 +866,7 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
                     abi.encodeCall(
                         Router.queryAddLiquidityHook,
                         AddLiquidityHookParams({
-                            // We use the Router as a sender to simplify basic query functions,
-                            // but it is possible to add liquidity to any recipient.
-                            sender: address(this),
+                            sender: sender,
                             pool: pool,
                             maxAmountsIn: maxAmountsIn,
                             minBptAmountOut: minBptAmountOut,
@@ -924,9 +916,7 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
                 abi.encodeCall(
                     Router.queryRemoveLiquidityHook,
                     RemoveLiquidityHookParams({
-                        // We use the Router as a sender to simplify basic query functions,
-                        // but it is possible to remove liquidity from any sender.
-                        sender: address(this),
+                        sender: sender,
                         pool: pool,
                         minAmountsOut: minAmountsOut,
                         maxBptAmountIn: exactBptAmountIn,
@@ -956,9 +946,7 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
                 abi.encodeCall(
                     Router.queryRemoveLiquidityHook,
                     RemoveLiquidityHookParams({
-                        // We use the Router as a sender to simplify basic query functions,
-                        // but it is possible to remove liquidity from any sender.
-                        sender: address(this),
+                        sender: sender,
                         pool: pool,
                         minAmountsOut: minAmountsOut,
                         maxBptAmountIn: exactBptAmountIn,
@@ -989,9 +977,7 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
                 abi.encodeCall(
                     Router.queryRemoveLiquidityHook,
                     RemoveLiquidityHookParams({
-                        // We use the Router as a sender to simplify basic query functions,
-                        // but it is possible to remove liquidity from any sender.
-                        sender: address(this),
+                        sender: sender,
                         pool: pool,
                         minAmountsOut: minAmountsOut,
                         maxBptAmountIn: _MAX_AMOUNT,
@@ -1021,9 +1007,7 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
                     abi.encodeCall(
                         Router.queryRemoveLiquidityHook,
                         RemoveLiquidityHookParams({
-                            // We use the Router as a sender to simplify basic query functions,
-                            // but it is possible to remove liquidity from any sender.
-                            sender: address(this),
+                            sender: sender,
                             pool: pool,
                             minAmountsOut: minAmountsOut,
                             maxBptAmountIn: maxBptAmountIn,
@@ -1106,7 +1090,7 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
                     abi.encodeCall(
                         Router.querySwapHook,
                         SwapSingleTokenHookParams({
-                            sender: msg.sender,
+                            sender: sender,
                             kind: SwapKind.EXACT_IN,
                             pool: pool,
                             tokenIn: tokenIn,
@@ -1138,7 +1122,7 @@ contract Router is IRouter, RouterCommon, ReentrancyGuardTransient {
                     abi.encodeCall(
                         Router.querySwapHook,
                         SwapSingleTokenHookParams({
-                            sender: msg.sender,
+                            sender: sender,
                             kind: SwapKind.EXACT_OUT,
                             pool: pool,
                             tokenIn: tokenIn,

--- a/pkg/vault/test/.contract-sizes/BatchRouter
+++ b/pkg/vault/test/.contract-sizes/BatchRouter
@@ -1,2 +1,2 @@
-Bytecode	17.223
-InitCode	18.710
+Bytecode	17.320
+InitCode	18.814

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	21.338
-InitCode	22.884
+Bytecode	21.439
+InitCode	22.985

--- a/pkg/vault/test/.contract-sizes/Router
+++ b/pkg/vault/test/.contract-sizes/Router
@@ -1,2 +1,2 @@
-Bytecode	23.679
-InitCode	24.652
+Bytecode	23.722
+InitCode	24.695

--- a/pkg/vault/test/BatchSwap.test.ts
+++ b/pkg/vault/test/BatchSwap.test.ts
@@ -189,7 +189,7 @@ describe('BatchSwap', function () {
           tokensOut: string[];
           amountsOut: bigint[];
         };
-      runQuery = async () => router.connect(zero).querySwapExactIn.staticCall(paths, zero.address, '0x');
+      runQuery = async () => router.connect(zero).querySwapExactIn.staticCall(paths, router, '0x');
     }
 
     function itTestsBatchSwap(singleTransferIn = true, singleTransferOut = true) {
@@ -996,7 +996,7 @@ describe('BatchSwap', function () {
           tokensIn: string[];
           amountsIn: bigint[];
         };
-      runQuery = async () => router.connect(zero).querySwapExactOut.staticCall(paths, zero.address, '0x');
+      runQuery = async () => router.connect(zero).querySwapExactOut.staticCall(paths, router, '0x');
     }
 
     function itTestsBatchSwap(singleTransferIn = true, singleTransferOut = true) {

--- a/pkg/vault/test/Queries.test.ts
+++ b/pkg/vault/test/Queries.test.ts
@@ -86,26 +86,26 @@ describe('Queries', function () {
     it('queries a swap exact in correctly', async () => {
       const amountCalculated = await router
         .connect(zero)
-        .querySwapSingleTokenExactIn.staticCall(pool, USDC, DAI, USDC_AMOUNT_IN, zero.address, '0x');
+        .querySwapSingleTokenExactIn.staticCall(pool, USDC, DAI, USDC_AMOUNT_IN, alice, '0x');
       expect(amountCalculated).to.be.eq(DAI_AMOUNT_IN);
     });
 
     it('queries a swap exact out correctly', async () => {
       const amountCalculated = await router
         .connect(zero)
-        .querySwapSingleTokenExactOut.staticCall(pool, USDC, DAI, DAI_AMOUNT_OUT, zero.address, '0x');
+        .querySwapSingleTokenExactOut.staticCall(pool, USDC, DAI, DAI_AMOUNT_OUT, alice, '0x');
       expect(amountCalculated).to.be.eq(DAI_AMOUNT_OUT);
     });
 
     it('reverts if not a static call (exact in)', async () => {
       await expect(
-        router.querySwapSingleTokenExactIn.staticCall(pool, USDC, DAI, USDC_AMOUNT_IN, zero.address, '0x')
+        router.querySwapSingleTokenExactIn.staticCall(pool, USDC, DAI, USDC_AMOUNT_IN, alice, '0x')
       ).to.be.revertedWithCustomError(vault, 'NotStaticCall');
     });
 
     it('reverts if not a static call (exact out)', async () => {
       await expect(
-        router.querySwapSingleTokenExactOut.staticCall(pool, USDC, DAI, DAI_AMOUNT_OUT, zero.address, '0x')
+        router.querySwapSingleTokenExactOut.staticCall(pool, USDC, DAI, DAI_AMOUNT_OUT, alice, '0x')
       ).to.be.revertedWithCustomError(vault, 'NotStaticCall');
     });
   });
@@ -114,13 +114,13 @@ describe('Queries', function () {
     it('queries addLiquidityProportional correctly', async () => {
       const amountsIn = await router
         .connect(zero)
-        .queryAddLiquidityProportional.staticCall(pool, BPT_AMOUNT, zero.address, '0x');
+        .queryAddLiquidityProportional.staticCall(pool, BPT_AMOUNT, alice, '0x');
       expect(amountsIn).to.be.deep.eq([DAI_AMOUNT_IN, USDC_AMOUNT_IN]);
     });
 
     it('reverts if not a static call', async () => {
       await expect(
-        router.queryAddLiquidityProportional.staticCall(pool, BPT_AMOUNT, zero.address, '0x')
+        router.queryAddLiquidityProportional.staticCall(pool, BPT_AMOUNT, alice, '0x')
       ).to.be.revertedWithCustomError(vault, 'NotStaticCall');
     });
   });
@@ -129,13 +129,13 @@ describe('Queries', function () {
     it('queries addLiquidityUnbalanced correctly', async () => {
       const bptAmountOut = await router
         .connect(zero)
-        .queryAddLiquidityUnbalanced.staticCall(pool, [DAI_AMOUNT_IN, USDC_AMOUNT_IN], zero.address, '0x');
+        .queryAddLiquidityUnbalanced.staticCall(pool, [DAI_AMOUNT_IN, USDC_AMOUNT_IN], alice, '0x');
       expect(bptAmountOut).to.be.eq(BPT_AMOUNT - 2n); // addLiquidity unbalanced has rounding error favoring the Vault.
     });
 
     it('reverts if not a static call', async () => {
       await expect(
-        router.queryAddLiquidityUnbalanced.staticCall(pool, [DAI_AMOUNT_IN, USDC_AMOUNT_IN], zero.address, '0x')
+        router.queryAddLiquidityUnbalanced.staticCall(pool, [DAI_AMOUNT_IN, USDC_AMOUNT_IN], alice, '0x')
       ).to.be.revertedWithCustomError(vault, 'NotStaticCall');
     });
   });
@@ -144,13 +144,13 @@ describe('Queries', function () {
     it('queries addLiquiditySingleTokenExactOut correctly', async () => {
       const amountsIn = await router
         .connect(zero)
-        .queryAddLiquiditySingleTokenExactOut.staticCall(pool, DAI, DAI_AMOUNT_IN * 2n, zero.address, '0x');
+        .queryAddLiquiditySingleTokenExactOut.staticCall(pool, DAI, DAI_AMOUNT_IN * 2n, alice, '0x');
       expect(amountsIn).to.be.eq(DAI_AMOUNT_IN * 2n);
     });
 
     it('reverts if not a static call', async () => {
       await expect(
-        router.queryAddLiquiditySingleTokenExactOut.staticCall(pool, DAI, DAI_AMOUNT_IN * 2n, zero.address, '0x')
+        router.queryAddLiquiditySingleTokenExactOut.staticCall(pool, DAI, DAI_AMOUNT_IN * 2n, alice, '0x')
       ).to.be.revertedWithCustomError(vault, 'NotStaticCall');
     });
   });
@@ -159,7 +159,7 @@ describe('Queries', function () {
     it('queries addLiquidityCustom correctly', async () => {
       const { amountsIn, bptAmountOut, returnData } = await router
         .connect(zero)
-        .queryAddLiquidityCustom.staticCall(pool, [DAI_AMOUNT_IN, USDC_AMOUNT_IN], BPT_AMOUNT, zero.address, '0xbeef');
+        .queryAddLiquidityCustom.staticCall(pool, [DAI_AMOUNT_IN, USDC_AMOUNT_IN], BPT_AMOUNT, alice, '0xbeef');
       expect(amountsIn).to.be.deep.eq([DAI_AMOUNT_IN, USDC_AMOUNT_IN]);
       expect(bptAmountOut).to.be.eq(BPT_AMOUNT);
       expect(returnData).to.be.eq('0xbeef');
@@ -171,7 +171,7 @@ describe('Queries', function () {
           pool,
           [DAI_AMOUNT_IN, USDC_AMOUNT_IN],
           BPT_AMOUNT,
-          zero.address,
+          alice,
           '0xbeef'
         )
       ).to.be.revertedWithCustomError(vault, 'NotStaticCall');
@@ -182,7 +182,7 @@ describe('Queries', function () {
     it('queries removeLiquidityProportional correctly', async () => {
       const amountsOut = await router
         .connect(zero)
-        .queryRemoveLiquidityProportional.staticCall(pool, BPT_AMOUNT, zero.address, '0x');
+        .queryRemoveLiquidityProportional.staticCall(pool, BPT_AMOUNT, alice, '0x');
 
       expect(amountsOut[0]).to.be.eq(DAI_AMOUNT_IN);
       expect(amountsOut[1]).to.be.eq(USDC_AMOUNT_IN);
@@ -190,7 +190,7 @@ describe('Queries', function () {
 
     it('reverts if not a static call', async () => {
       await expect(
-        router.queryRemoveLiquidityProportional.staticCall(pool, BPT_AMOUNT, zero.address, '0x')
+        router.queryRemoveLiquidityProportional.staticCall(pool, BPT_AMOUNT, alice, '0x')
       ).to.be.revertedWithCustomError(vault, 'NotStaticCall');
     });
   });
@@ -199,14 +199,14 @@ describe('Queries', function () {
     it('queries removeLiquiditySingleTokenExactIn correctly', async () => {
       const amountOut = await router
         .connect(zero)
-        .queryRemoveLiquiditySingleTokenExactIn.staticCall(pool, BPT_AMOUNT, DAI, zero.address, '0x');
+        .queryRemoveLiquiditySingleTokenExactIn.staticCall(pool, BPT_AMOUNT, DAI, alice, '0x');
 
       expect(amountOut).to.be.eq(DAI_AMOUNT_IN * 2n);
     });
 
     it('reverts if not a static call', async () => {
       await expect(
-        router.queryRemoveLiquiditySingleTokenExactIn.staticCall(pool, BPT_AMOUNT, DAI, zero.address, '0x')
+        router.queryRemoveLiquiditySingleTokenExactIn.staticCall(pool, BPT_AMOUNT, DAI, alice, '0x')
       ).to.be.revertedWithCustomError(vault, 'NotStaticCall');
     });
   });
@@ -215,14 +215,14 @@ describe('Queries', function () {
     it('queries removeLiquiditySingleTokenExactOut correctly', async () => {
       const amountIn = await router
         .connect(zero)
-        .queryRemoveLiquiditySingleTokenExactOut.staticCall(pool, DAI, DAI_AMOUNT_IN, zero.address, '0x');
+        .queryRemoveLiquiditySingleTokenExactOut.staticCall(pool, DAI, DAI_AMOUNT_IN, alice, '0x');
 
       expect(amountIn).to.be.eq(BPT_AMOUNT / 2n + 2n); // Has rounding error favoring the Vault.
     });
 
     it('reverts if not a static call', async () => {
       await expect(
-        router.queryRemoveLiquiditySingleTokenExactOut.staticCall(pool, DAI, DAI_AMOUNT_IN, zero.address, '0x')
+        router.queryRemoveLiquiditySingleTokenExactOut.staticCall(pool, DAI, DAI_AMOUNT_IN, alice, '0x')
       ).to.be.revertedWithCustomError(vault, 'NotStaticCall');
     });
   });
@@ -235,7 +235,7 @@ describe('Queries', function () {
           pool,
           BPT_AMOUNT,
           [DAI_AMOUNT_IN, USDC_AMOUNT_IN],
-          zero.address,
+          alice,
           '0xbeef'
         );
 
@@ -250,7 +250,7 @@ describe('Queries', function () {
           pool,
           BPT_AMOUNT,
           [DAI_AMOUNT_IN, USDC_AMOUNT_IN],
-          zero.address,
+          alice,
           '0xbeef'
         )
       ).to.be.revertedWithCustomError(vault, 'NotStaticCall');

--- a/pkg/vault/test/Queries.test.ts
+++ b/pkg/vault/test/Queries.test.ts
@@ -167,13 +167,7 @@ describe('Queries', function () {
 
     it('reverts if not a static call', async () => {
       await expect(
-        router.queryAddLiquidityCustom.staticCall(
-          pool,
-          [DAI_AMOUNT_IN, USDC_AMOUNT_IN],
-          BPT_AMOUNT,
-          alice,
-          '0xbeef'
-        )
+        router.queryAddLiquidityCustom.staticCall(pool, [DAI_AMOUNT_IN, USDC_AMOUNT_IN], BPT_AMOUNT, alice, '0xbeef')
       ).to.be.revertedWithCustomError(vault, 'NotStaticCall');
     });
   });
@@ -231,13 +225,7 @@ describe('Queries', function () {
     it('queries removeLiquidityCustom correctly', async () => {
       const { bptAmountIn, amountsOut, returnData } = await router
         .connect(zero)
-        .queryRemoveLiquidityCustom.staticCall(
-          pool,
-          BPT_AMOUNT,
-          [DAI_AMOUNT_IN, USDC_AMOUNT_IN],
-          alice,
-          '0xbeef'
-        );
+        .queryRemoveLiquidityCustom.staticCall(pool, BPT_AMOUNT, [DAI_AMOUNT_IN, USDC_AMOUNT_IN], alice, '0xbeef');
 
       expect(bptAmountIn).to.be.eq(BPT_AMOUNT);
       expect(amountsOut).to.be.deep.eq([DAI_AMOUNT_IN, USDC_AMOUNT_IN]);
@@ -246,13 +234,7 @@ describe('Queries', function () {
 
     it('reverts if not a static call', async () => {
       await expect(
-        router.queryRemoveLiquidityCustom.staticCall(
-          pool,
-          BPT_AMOUNT,
-          [DAI_AMOUNT_IN, USDC_AMOUNT_IN],
-          alice,
-          '0xbeef'
-        )
+        router.queryRemoveLiquidityCustom.staticCall(pool, BPT_AMOUNT, [DAI_AMOUNT_IN, USDC_AMOUNT_IN], alice, '0xbeef')
       ).to.be.revertedWithCustomError(vault, 'NotStaticCall');
     });
   });


### PR DESCRIPTION
# Description

We're saving the sender but apparently in some cases it's important to actually pass the sender to the Vault.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A