### PR TITLE
Fix `CompositeLiquidityRouter` queries

### DIFF
--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -136,7 +136,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                 abi.encodeCall(
                     CompositeLiquidityRouter.addLiquidityERC4626PoolUnbalancedHook,
                     AddLiquidityHookParams({
-                        sender: msg.sender,
+                        sender: address(this),
                         pool: pool,
                         maxAmountsIn: exactUnderlyingAmountsIn,
                         minBptAmountOut: 0,
@@ -162,7 +162,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                 abi.encodeCall(
                     CompositeLiquidityRouter.addLiquidityERC4626PoolProportionalHook,
                     AddLiquidityHookParams({
-                        sender: msg.sender,
+                        sender: address(this),
                         pool: pool,
                         maxAmountsIn: _maxTokenLimits(pool),
                         minBptAmountOut: exactBptAmountOut,
@@ -188,7 +188,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                 abi.encodeCall(
                     CompositeLiquidityRouter.removeLiquidityERC4626PoolProportionalHook,
                     RemoveLiquidityHookParams({
-                        sender: msg.sender,
+                        sender: address(this),
                         pool: pool,
                         minAmountsOut: new uint256[](2),
                         maxBptAmountIn: exactBptAmountIn,
@@ -422,7 +422,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                         CompositeLiquidityRouter.addLiquidityUnbalancedNestedPoolHook.selector,
                         AddLiquidityHookParams({
                             pool: parentPool,
-                            sender: msg.sender,
+                            sender: address(this),
                             maxAmountsIn: exactAmountsIn,
                             minBptAmountOut: 0,
                             kind: AddLiquidityKind.UNBALANCED,
@@ -622,7 +622,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                 abi.encodeWithSelector(
                     CompositeLiquidityRouter.removeLiquidityProportionalNestedPoolHook.selector,
                     RemoveLiquidityHookParams({
-                        sender: msg.sender,
+                        sender: address(this),
                         pool: parentPool,
                         minAmountsOut: new uint256[](tokensOut.length),
                         maxBptAmountIn: exactBptAmountIn,

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	21.338
-InitCode	22.884
+Bytecode	21.433
+InitCode	22.979

--- a/pkg/vault/test/foundry/CompositeLiquidityRouterERC4626Pool.t.sol
+++ b/pkg/vault/test/foundry/CompositeLiquidityRouterERC4626Pool.t.sol
@@ -178,7 +178,7 @@ contract CompositeLiquidityRouterERC4626PoolTest is BaseERC4626BufferTest {
         uint256 operationAmount = bufferInitialAmount / 2;
         uint256[] memory exactUnderlyingAmountsIn = [operationAmount, operationAmount].toMemoryArray();
 
-        vm.prank(alice, address(0));
+        _prankStaticCall();
         compositeLiquidityRouter.queryAddLiquidityUnbalancedToERC4626Pool(
             erc4626Pool,
             exactUnderlyingAmountsIn,
@@ -192,7 +192,7 @@ contract CompositeLiquidityRouterERC4626PoolTest is BaseERC4626BufferTest {
         uint256[] memory exactUnderlyingAmountsIn = [operationAmount, operationAmount].toMemoryArray();
 
         uint256 snapshotId = vm.snapshot();
-        vm.prank(alice, address(0));
+        _prankStaticCall();
         uint256 queryBptAmountOut = compositeLiquidityRouter.queryAddLiquidityUnbalancedToERC4626Pool(
             erc4626Pool,
             exactUnderlyingAmountsIn,
@@ -218,7 +218,7 @@ contract CompositeLiquidityRouterERC4626PoolTest is BaseERC4626BufferTest {
         uint256[] memory exactUnderlyingAmountsIn = [operationAmount, operationAmount].toMemoryArray();
 
         uint256 snapshotId = vm.snapshot();
-        vm.prank(alice, address(0));
+        _prankStaticCall();
         uint256 queryBptAmountOut = compositeLiquidityRouter.queryAddLiquidityUnbalancedToERC4626Pool(
             partialErc4626Pool,
             exactUnderlyingAmountsIn,
@@ -354,7 +354,7 @@ contract CompositeLiquidityRouterERC4626PoolTest is BaseERC4626BufferTest {
     function testAddLiquidityProportionalToERC4626PoolWhenStaticCall() public checkBuffersWhenStaticCall(alice) {
         uint256 operationAmount = bufferInitialAmount / 2;
 
-        vm.prank(alice, address(0));
+        _prankStaticCall();
         compositeLiquidityRouter.queryAddLiquidityProportionalToERC4626Pool(
             erc4626Pool,
             operationAmount,
@@ -369,7 +369,7 @@ contract CompositeLiquidityRouterERC4626PoolTest is BaseERC4626BufferTest {
         uint256 exactBptAmountOut = operationAmount;
 
         uint256 snapshotId = vm.snapshot();
-        vm.prank(alice, address(0));
+        _prankStaticCall();
         uint256[] memory queryUnderlyingAmountsIn = compositeLiquidityRouter.queryAddLiquidityProportionalToERC4626Pool(
             erc4626Pool,
             exactBptAmountOut,
@@ -402,7 +402,7 @@ contract CompositeLiquidityRouterERC4626PoolTest is BaseERC4626BufferTest {
         uint256 exactBptAmountOut = operationAmount;
 
         uint256 snapshotId = vm.snapshot();
-        vm.prank(alice, address(0));
+        _prankStaticCall();
         uint256[] memory queryUnderlyingAmountsIn = compositeLiquidityRouter.queryAddLiquidityProportionalToERC4626Pool(
             partialErc4626Pool,
             exactBptAmountOut,
@@ -544,7 +544,7 @@ contract CompositeLiquidityRouterERC4626PoolTest is BaseERC4626BufferTest {
     function testRemoveLiquidityProportionalFromERC4626PoolWhenStaticCall() public checkBuffersWhenStaticCall(bob) {
         uint256 exactBptAmountIn = bufferInitialAmount / 2;
 
-        vm.prank(bob, address(0));
+        _prankStaticCall();
         compositeLiquidityRouter.queryRemoveLiquidityProportionalFromERC4626Pool(
             erc4626Pool,
             exactBptAmountIn,
@@ -571,7 +571,7 @@ contract CompositeLiquidityRouterERC4626PoolTest is BaseERC4626BufferTest {
         minUnderlyingAmountsOut[waDaiIdx] = waDAI.previewRedeem(expectedWrappedAmountsOut[waDaiIdx]);
 
         uint256 snapshotId = vm.snapshot();
-        vm.prank(bob, address(0));
+        _prankStaticCall();
         uint256[] memory queryUnderlyingAmountsOut = compositeLiquidityRouter
             .queryRemoveLiquidityProportionalFromERC4626Pool(erc4626Pool, exactBptAmountIn, address(this), bytes(""));
         vm.revertTo(snapshotId);
@@ -613,7 +613,7 @@ contract CompositeLiquidityRouterERC4626PoolTest is BaseERC4626BufferTest {
         minUnderlyingAmountsOut[partialWaDaiIdx] = waDAI.previewRedeem(expectedWrappedAmountsOut[partialWaDaiIdx]);
 
         uint256 snapshotId = vm.snapshot();
-        vm.prank(bob, address(0));
+        _prankStaticCall();
         uint256[] memory queryUnderlyingAmountsOut = compositeLiquidityRouter
             .queryRemoveLiquidityProportionalFromERC4626Pool(
                 partialErc4626Pool,

--- a/pkg/vault/test/foundry/CompositeLiquidityRouterNestedPools.t.sol
+++ b/pkg/vault/test/foundry/CompositeLiquidityRouterNestedPools.t.sol
@@ -1304,7 +1304,7 @@ contract CompositeLiquidityRouterNestedPoolsTest is BaseERC4626BufferTest {
         );
 
         uint256 snapshotId = vm.snapshot();
-        vm.prank(lp, address(0));
+        _prankStaticCall();
         uint256[] memory queryAmountsOut = compositeLiquidityRouter.queryRemoveLiquidityProportionalNestedPool(
             parentPoolWithWrapper,
             exactBptIn,


### PR DESCRIPTION
# Description

In `Router` and `BatchRouter` we use the router itself as the sender address for the queries.
This is not the case for `CompositeLiquidityRouter`, and that brings some problems when working with libraries that can't prank `msg.sender` while setting `tx.origin` to `address(0)` to simulate the static call.

This PR addresses this issue, so that queries can be used more widely.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Supersedes #1070 