### PR TITLE
Remove unused codec

### DIFF
--- a/pkg/solidity-utils/contracts/helpers/WordCodec.sol
+++ b/pkg/solidity-utils/contracts/helpers/WordCodec.sol
@@ -60,25 +60,6 @@ library WordCodec {
     }
 
     /**
-     * @dev Inserts an address (160 bits), shifted by an offset, into a 256 bit word,
-     * replacing the old value. Returns the new word.
-     */
-    function insertAddress(bytes32 word, address value, uint256 offset) internal pure returns (bytes32 result) {
-        uint256 addressBitLength = 160;
-        _validateEncodingParams(uint256(uint160(value)), offset, addressBitLength);
-        // Equivalent to:
-        // uint256 mask = (1 << bitLength) - 1;
-        // bytes32 clearedWord = bytes32(uint256(word) & ~(mask << offset));
-        // result = clearedWord | bytes32(value << offset);
-
-        assembly ("memory-safe") {
-            let mask := sub(shl(addressBitLength, 1), 1)
-            let clearedWord := and(word, not(shl(offset, mask)))
-            result := or(clearedWord, shl(offset, value))
-        }
-    }
-
-    /**
      * @dev Inserts a signed integer shifted by an offset into a 256 bit word, replacing the old value. Returns
      * the new word.
      *


### PR DESCRIPTION
# Description

This is left over from v2, when we were packing addresses. It's not hurting anything or costing bytecode, but is dead code nonetheless. If we think leaving it in might be useful for future partners or something, we could just add a comment that we know it's currently unused, but deliberately left in for future use.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
