### PR TITLE
Document dependency on `symbol`

### DIFF
--- a/pkg/pool-weighted/contracts/WeightedPool8020Factory.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool8020Factory.sol
@@ -46,7 +46,10 @@ contract WeightedPool8020Factory is IPoolVersion, BasePoolFactory, Version {
 
     /**
      * @notice Deploys a new `WeightedPool`.
-     * @dev Since tokens must be sorted, pass in explicit 80/20 token config structs.
+     * @dev Since tokens must be sorted, pass in explicit 80/20 token config structs. This assumes both tokens support
+     * the `IERC20Metadata` interface with `symbol` that returns a string. Otherwise, use the regular
+     * `WeightedPoolFactory`.
+     *
      * @param highWeightTokenConfig The token configuration of the high weight token
      * @param lowWeightTokenConfig The token configuration of the low weight token
      * @param roleAccounts Addresses the Vault will allow to change certain pool settings


### PR DESCRIPTION
# Description

We provide the 80/20 factory as a convenience for building a common pool type with minimal arguments. It constructs the pool name and symbol according to the v2 naming convention (another convenience/consistency aspect), and calls `symbol` to do so. Since this is an optional interface, some tokens might not support it, in which case you couldn't use this factory, and would need to use the general `WeightedPoolFactory` instead.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [X] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
