### PR TITLE
Small query fix for `BatchRouter`

### DIFF
--- a/pkg/vault/contracts/BatchRouter.sol
+++ b/pkg/vault/contracts/BatchRouter.sol
@@ -225,8 +225,8 @@ contract BatchRouter is IBatchRouter, BatchRouterCommon, ReentrancyGuardTransien
                     // required amount when performing the operation. These tokens might be the output of a previous
                     // step, in which case the user will have a BPT credit.
 
-                    if (stepLocals.isFirstStep && params.sender != address(this)) {
-                        if (stepExactAmountIn > 0) {
+                    if (stepLocals.isFirstStep) {
+                        if (stepExactAmountIn > 0 && params.sender != address(this)) {
                             // If this is the first step, the sender must have the tokens. Therefore, we can transfer
                             // them to the Router, which acts as an intermediary. If the sender is the Router, we just
                             // skip this step (useful for queries).

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity ^0.8.26;
+pragma solidity ^0.8.24;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IPermit2 } from "permit2/src/interfaces/IPermit2.sol";

--- a/pkg/vault/test/foundry/BatchRouter.t.sol
+++ b/pkg/vault/test/foundry/BatchRouter.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 import { IBatchRouter } from "@balancer-labs/v3-interfaces/contracts/vault/IBatchRouter.sol";
 
 import { MOCK_BATCH_ROUTER_VERSION } from "../../contracts/test/BatchRouterMock.sol";
@@ -31,5 +33,30 @@ contract BatchRouterTest is BaseVaultTest {
 
     function testBatchRouterVersion() public view {
         assertEq(batchRouter.version(), MOCK_BATCH_ROUTER_VERSION, "BatchRouter version mismatch");
+    }
+
+    function testQuerySingleStepRemove() public {
+        // create a swap step and query the batch router, where the first token is the bpt.
+        IBatchRouter.SwapPathStep[] memory step = new IBatchRouter.SwapPathStep[](1);
+        step[0] = IBatchRouter.SwapPathStep(address(pool), IERC20(address(dai)), false);
+
+        uint256 totalSupply = IERC20(pool).totalSupply();
+        console.log("total BPT supply", totalSupply);
+        uint256 bptAmountIn = 1e18;
+
+        require(bptAmountIn < totalSupply);
+
+        IBatchRouter.SwapPathExactAmountIn memory path = IBatchRouter.SwapPathExactAmountIn(
+            IERC20(address(pool)),
+            step,
+            bptAmountIn,
+            0
+        );
+
+        IBatchRouter.SwapPathExactAmountIn[] memory paths = new IBatchRouter.SwapPathExactAmountIn[](1);
+        paths[0] = path;
+
+        vm.prank(alice, address(0));
+        batchRouter.querySwapExactIn(paths, address(0), bytes(""));
     }
 }


### PR DESCRIPTION
# Description

Small fix for batch router queries when the first step is an exit (and there are no nested pools).

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A