### PR TITLE
Truncate high precision aggregate fees

### DIFF
--- a/pkg/interfaces/contracts/vault/IProtocolFeeController.sol
+++ b/pkg/interfaces/contracts/vault/IProtocolFeeController.sol
@@ -179,10 +179,11 @@ interface IProtocolFeeController {
 
     /**
      * @notice Returns a calculated aggregate percentage from protocol and pool creator fee percentages.
-     * @dev Not tied to any particular pool; this just performs the low-level "additive fee" calculation.
-     * Note that pool creator fees are calculated based on creatorAndLpFees, and not in totalFees.
-     * Since aggregate fees are stored in the Vault with 24-bit precision, this will revert if greater
-     * precision would be required.
+     * @dev Not tied to any particular pool; this just performs the low-level "additive fee" calculation. Note that
+     * pool creator fees are calculated based on creatorAndLpFees, and not in totalFees. Since aggregate fees are
+     * stored in the Vault with 24-bit precision, this will truncate any values that require greater precision.
+     * It is expected that pool creators will negotiate with the DAO and agree on reasonable values for these fee
+     * components, but the truncation ensures it will not revert for any valid set of fee percentages.
      *
      * See example below:
      *

--- a/pkg/vault/contracts/ProtocolFeeController.sol
+++ b/pkg/vault/contracts/ProtocolFeeController.sol
@@ -180,7 +180,9 @@ contract ProtocolFeeController is
      * @notice Settle fee credits from the Vault.
      * @dev This must be called after calling `collectAggregateFees` in the Vault. Note that since charging protocol
      * fees (i.e., distributing tokens between pool and fee balances) occurs in the Vault, but fee collection
-     * happens in the ProtocolFeeController, the swap fees reported here may encompass multiple operations.
+     * happens in the ProtocolFeeController, the swap fees reported here may encompass multiple operations. The Vault
+     * differentiates between swap and yield fees (since they can have different percentage values); the Controller
+     * combines swap and yield fees, then allocates the total between the protocol and pool creator.
      *
      * @param pool The address of the pool on which the swap fees were charged
      * @param swapFeeAmounts An array with the total swap fees collected, sorted in token registration order
@@ -231,8 +233,11 @@ contract ProtocolFeeController is
                 }
 
                 if (needToSplitFees) {
-                    uint256 totalVolume = feeAmounts[i].divUp(aggregateFeePercentage);
-                    uint256 protocolPortion = totalVolume.mulUp(protocolFeePercentage);
+                    // The Vault took a single "cut" for the aggregate total percentage (protocol + pool creator) for
+                    // this fee type (swap or yield). Now we need to "disaggregate" the total fee amount and divide
+                    // it between the protocol and pool creator, according to their individual percentages.
+                    uint256 totalAggregateFeeCollected = feeAmounts[i].divUp(aggregateFeePercentage);
+                    uint256 protocolPortion = totalAggregateFeeCollected.mulUp(protocolFeePercentage);
 
                     _protocolFeeAmounts[pool][token] += protocolPortion;
                     _poolCreatorFeeAmounts[pool][token] += feeAmounts[i] - protocolPortion;
@@ -343,7 +348,14 @@ contract ProtocolFeeController is
             protocolFeePercentage +
             protocolFeePercentage.complement().mulDown(poolCreatorFeePercentage);
 
-        _ensureValidPrecision(aggregateFeePercentage);
+        // Protocol fee percentages are limited to 24-bit precision for performance reasons (i.e., to fit all the fees
+        // in a single slot), and because high precision is not needed. Generally we expect protocol fees set by
+        // governance to be simple integers.
+        //
+        // However, the pool creator fee is entirely controlled by the pool creator, and it is possible to craft a
+        // valid pool creator fee percentage that would cause the aggregate fee percentage to fail the precision check.
+        // This case should be rare, so we ensure this can't happen by truncating the final value.
+        aggregateFeePercentage = (aggregateFeePercentage / FEE_SCALING_FACTOR) * FEE_SCALING_FACTOR;
     }
 
     function _ensureCallerIsPoolCreator(address pool) internal view {

--- a/pkg/vault/contracts/ProtocolFeeController.sol
+++ b/pkg/vault/contracts/ProtocolFeeController.sol
@@ -234,10 +234,12 @@ contract ProtocolFeeController is
 
                 if (needToSplitFees) {
                     // The Vault took a single "cut" for the aggregate total percentage (protocol + pool creator) for
-                    // this fee type (swap or yield). Now we need to "disaggregate" the total fee amount and divide
-                    // it between the protocol and pool creator, according to their individual percentages.
-                    uint256 totalAggregateFeeCollected = feeAmounts[i].divUp(aggregateFeePercentage);
-                    uint256 protocolPortion = totalAggregateFeeCollected.mulUp(protocolFeePercentage);
+                    // this fee type (swap or yield). The first step is to reconstruct this total fee amount. Then we
+                    // need to "disaggregate" this total, dividing it between the protocol and pool creator according
+                    // to their individual percentages. We do this by computing the protocol portion first, then
+                    // assigning the remainder to the pool creator.
+                    uint256 totalFeeAmountRaw = feeAmounts[i].divUp(aggregateFeePercentage);
+                    uint256 protocolPortion = totalFeeAmountRaw.mulUp(protocolFeePercentage);
 
                     _protocolFeeAmounts[pool][token] += protocolPortion;
                     _poolCreatorFeeAmounts[pool][token] += feeAmounts[i] - protocolPortion;

--- a/pkg/vault/test/.contract-sizes/BatchRouter
+++ b/pkg/vault/test/.contract-sizes/BatchRouter
@@ -1,2 +1,2 @@
-Bytecode	17.543
-InitCode	19.341
+Bytecode	17.544
+InitCode	19.342

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	21.753
-InitCode	23.609
+Bytecode	21.842
+InitCode	23.698

--- a/pkg/vault/test/foundry/ProtocolFeeController.t.sol
+++ b/pkg/vault/test/foundry/ProtocolFeeController.t.sol
@@ -965,11 +965,11 @@ contract ProtocolFeeControllerTest is BaseVaultTest {
             CUSTOM_PROTOCOL_SWAP_FEE_PCT.complement().mulDown(FEE_SCALING_FACTOR);
 
         // Full precision should not equal the nominal value
-        assertFalse(fullPrecisionAggregateFeePercentage == CUSTOM_PROTOCOL_SWAP_FEE_PCT, "Fee precision lost");
+        assertNotEq(fullPrecisionAggregateFeePercentage, CUSTOM_PROTOCOL_SWAP_FEE_PCT, "Fee precision lost");
 
         uint256 correctedFeePercentage = (fullPrecisionAggregateFeePercentage / FEE_SCALING_FACTOR) *
             FEE_SCALING_FACTOR;
-        assertTrue(correctedFeePercentage == CUSTOM_PROTOCOL_SWAP_FEE_PCT, "Fee precision not adjusted");
+        assertEq(correctedFeePercentage, CUSTOM_PROTOCOL_SWAP_FEE_PCT, "Fee precision not adjusted");
 
         // Retrieve it from the Vault - should be the same as we set.
         PoolConfig memory config = vault.getPoolConfig(pool);

--- a/pkg/vault/test/foundry/ProtocolFeeController.t.sol
+++ b/pkg/vault/test/foundry/ProtocolFeeController.t.sol
@@ -973,7 +973,11 @@ contract ProtocolFeeControllerTest is BaseVaultTest {
 
         // Retrieve it from the Vault - should be the same as we set.
         PoolConfig memory config = vault.getPoolConfig(pool);
-        assertEq(config.aggregateSwapFeePercentage, CUSTOM_PROTOCOL_SWAP_FEE_PCT);
+        assertEq(
+            config.aggregateSwapFeePercentage,
+            CUSTOM_PROTOCOL_SWAP_FEE_PCT,
+            "Wrong aggregate swap fee percentage"
+        );
     }
 
     function testAdjustedYieldFeePrecision() public {
@@ -993,15 +997,19 @@ contract ProtocolFeeControllerTest is BaseVaultTest {
             CUSTOM_PROTOCOL_YIELD_FEE_PCT.complement().mulDown(FEE_SCALING_FACTOR);
 
         // Full precision should not equal the nominal value
-        assertFalse(fullPrecisionAggregateFeePercentage == CUSTOM_PROTOCOL_YIELD_FEE_PCT, "Fee precision lost");
+        assertNotEq(fullPrecisionAggregateFeePercentage, CUSTOM_PROTOCOL_YIELD_FEE_PCT, "Fee precision lost");
 
         uint256 correctedFeePercentage = (fullPrecisionAggregateFeePercentage / FEE_SCALING_FACTOR) *
             FEE_SCALING_FACTOR;
-        assertTrue(correctedFeePercentage == CUSTOM_PROTOCOL_YIELD_FEE_PCT, "Fee precision not adjusted");
+        assertEq(correctedFeePercentage, CUSTOM_PROTOCOL_YIELD_FEE_PCT, "Fee precision not adjusted");
 
         // Retrieve it from the Vault - should be the same as we set.
         PoolConfig memory config = vault.getPoolConfig(pool);
-        assertEq(config.aggregateYieldFeePercentage, CUSTOM_PROTOCOL_YIELD_FEE_PCT);
+        assertEq(
+            config.aggregateYieldFeePercentage,
+            CUSTOM_PROTOCOL_YIELD_FEE_PCT,
+            "Wrong aggregate yield fee percentage"
+        );
     }
 
     function _registerPoolWithMaxProtocolFees() internal {


### PR DESCRIPTION
# Description

It is possible for the aggregate fee calculation to result in higher precision than the Vault supports, even if the individual components all have low enough precision. This can always be remedied, but is annoying. To avoid this, simply truncate the high precision bits in this edge case.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Resolves #1095 
