### PR TITLE
Round trip fee guardrail in Recovery Mode

### DIFF
--- a/pkg/vault/contracts/VaultExtension.sol
+++ b/pkg/vault/contracts/VaultExtension.sol
@@ -744,7 +744,7 @@ contract VaultExtension is IVaultExtension, VaultCommon, Proxy {
         return _isPoolInRecoveryMode(pool);
     }
 
-    // Needed to avoid stack-too-deep.apply
+    // Needed to avoid stack-too-deep.
     struct RecoveryLocals {
         bool chargeRoundtripFee;
         uint256[] swapFeeAmountsRaw;
@@ -792,7 +792,7 @@ contract VaultExtension is IVaultExtension, VaultCommon, Proxy {
 
         // Don't make the call to retrieve the fee unless we have to.
         if (locals.chargeRoundtripFee) {
-            locals.swapFeePercentage = _vault.getStaticSwapFeePercentage(pool);
+            locals.swapFeePercentage = _poolConfigBits[pool].getStaticSwapFeePercentage();
         }
 
         for (uint256 i = 0; i < locals.numTokens; ++i) {


### PR DESCRIPTION
# Description

Apply the same roundtrip fee guardrail on recovery mode that we do with regular proportional withdrawals. If there was a preceding add liquidity operation (which there wouldn't normally be in a recovery mode withdrawal), charge the pool's static swap fee.

To keep recovery mode as simple as possible, this fee is charged to the user (i.e., they receive fewer tokens for their BPT), but the tokens simply remain in the pool, accruing value to the other LPs.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Resolves #1094
