### PR TITLE
Consistency in assert statements

### DIFF
--- a/pkg/pool-utils/test/foundry/BasePoolFactory.t.sol
+++ b/pkg/pool-utils/test/foundry/BasePoolFactory.t.sol
@@ -152,11 +152,11 @@ contract BasePoolFactoryTest is BaseVaultTest {
 
         vm.prank(bob);
         address bobAddress = testFactory.getDeploymentAddress(salt);
-        assertTrue(bobAddress != predictedAddress, "Different sender generates the same address");
+        assertNotEq(bobAddress, predictedAddress, "Different sender generates the same address");
 
         vm.chainId(10000);
         address chainAddress = testFactory.getDeploymentAddress(salt);
-        assertTrue(chainAddress != predictedAddress, "Different chain generates the same address");
+        assertNotEq(chainAddress, predictedAddress, "Different chain generates the same address");
     }
 
     function testGetDefaultPoolHooksContract() public view {

--- a/pkg/pool-weighted/test/foundry/WeightedPool8020Factory.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedPool8020Factory.t.sol
@@ -82,7 +82,8 @@ contract WeightedPool8020FactoryTest is WeightedPoolContractsDeployer, VaultCont
         WeightedPool invertedPool = _createPool(tokenB, tokenA);
 
         assertNotEq(
-            address(pool), address(invertedPool),
+            address(pool),
+            address(invertedPool),
             "Pools with same tokens but different weights should be different"
         );
     }

--- a/pkg/pool-weighted/test/foundry/WeightedPool8020Factory.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedPool8020Factory.t.sol
@@ -81,8 +81,8 @@ contract WeightedPool8020FactoryTest is WeightedPoolContractsDeployer, VaultCont
         WeightedPool pool = _createPool(tokenA, tokenB);
         WeightedPool invertedPool = _createPool(tokenB, tokenA);
 
-        assertFalse(
-            address(pool) == address(invertedPool),
+        assertNotEq(
+            address(pool), address(invertedPool),
             "Pools with same tokens but different weights should be different"
         );
     }
@@ -123,6 +123,6 @@ contract WeightedPool8020FactoryTest is WeightedPoolContractsDeployer, VaultCont
         WeightedPool poolL2 = _createPool(tokenA, tokenB);
 
         // Same salt parameters, should still be different because of the chainId.
-        assertFalse(address(poolL2) == address(poolMainnet), "L2 and mainnet pool addresses are equal");
+        assertNotEq(address(poolL2), address(poolMainnet), "L2 and mainnet pool addresses are equal");
     }
 }

--- a/pkg/vault/test/foundry/BufferVaultPrimitive.t.sol
+++ b/pkg/vault/test/foundry/BufferVaultPrimitive.t.sol
@@ -404,7 +404,7 @@ contract BufferVaultPrimitiveTest is BaseVaultTest {
 
         // After a wrap operation, even if the erc4626 token didn't take all the assets it was supposed to deposit,
         // the allowance should be 0 to avoid a malicious wrapper from draining the underlying balance of the Vault.
-        assertTrue(dai.allowance(address(vault), address(waDAI)) == 0, "Wrong allowance");
+        assertEq(dai.allowance(address(vault), address(waDAI)), 0, "Wrong allowance");
     }
 
     /********************************************************************************

--- a/pkg/vault/test/foundry/ProtocolFeeController.t.sol
+++ b/pkg/vault/test/foundry/ProtocolFeeController.t.sol
@@ -969,12 +969,12 @@ contract ProtocolFeeControllerTest is BaseVaultTest {
     function _verifyPoolProtocolFeePercentages(address pool) internal view {
         (uint256 feePercentage, bool isOverride) = feeController.getPoolProtocolSwapFeeInfo(pool);
 
-        assertEq(feePercentage, MAX_PROTOCOL_SWAP_FEE_PCT);
-        assertFalse(isOverride);
+        assertEq(feePercentage, MAX_PROTOCOL_SWAP_FEE_PCT, "Wrong protocol swap fee percentage");
+        assertFalse(isOverride, "swap fee percentage override is true");
 
         (feePercentage, isOverride) = feeController.getPoolProtocolYieldFeeInfo(pool);
 
-        assertEq(feePercentage, MAX_PROTOCOL_YIELD_FEE_PCT);
-        assertFalse(isOverride);
+        assertEq(feePercentage, MAX_PROTOCOL_YIELD_FEE_PCT, "Wrong protocol yield fee percentage");
+        assertFalse(isOverride, "yield fee percentage override is true");
     }
 }

--- a/pkg/vault/test/foundry/RecoveryMode.t.sol
+++ b/pkg/vault/test/foundry/RecoveryMode.t.sol
@@ -89,7 +89,7 @@ contract RecoveryModeTest is BaseVaultTest {
         for (uint256 i = 0; i < currentLiveBalances.length; ++i) {
             bool areEqual = currentLiveBalances[i] == lastBalancesLiveScaled18[i];
 
-            shouldBeEqual ? assertTrue(areEqual) : assertFalse(areEqual);
+            shouldBeEqual ? assertTrue(areEqual, "areEqual is false") : assertFalse(areEqual, "areEqual is true");
         }
     }
 

--- a/pkg/vault/test/foundry/VaultLiquidityFees.t.sol
+++ b/pkg/vault/test/foundry/VaultLiquidityFees.t.sol
@@ -36,9 +36,9 @@ contract VaultLiquidityWithFeesTest is BaseVaultTest {
     }
 
     function testPrerequisites() public view {
-        assertTrue(swapFeePercentage > 0);
-        assertTrue(protocolSwapFeePercentage > 0);
-        assertTrue(poolCreatorFeePercentage > 0);
+        assertTrue(swapFeePercentage > 0, "swapFeePercentage is zero");
+        assertTrue(protocolSwapFeePercentage > 0, "protocolSwapFeePercentage is zero");
+        assertTrue(poolCreatorFeePercentage > 0, "poolCreatorFeePercentage is zero");
 
         PoolConfig memory config = vault.getPoolConfig(pool);
 


### PR DESCRIPTION
# Description

Noted in previous PR, we are sometimes using True/False assertions when Eq/NotEq would be more appropriate. Also missing some error statements. (Not sure I got them all - there were too many `assertEq` to review manually.)

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
