### PR TITLE
Check array lengths in permitBatchAndCall

### DIFF
--- a/pkg/vault/contracts/RouterCommon.sol
+++ b/pkg/vault/contracts/RouterCommon.sol
@@ -15,6 +15,7 @@ import { IAllowanceTransfer } from "permit2/src/interfaces/IAllowanceTransfer.so
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 
 import { StorageSlotExtension } from "@balancer-labs/v3-solidity-utils/contracts/openzeppelin/StorageSlotExtension.sol";
+import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
 import { RevertCodec } from "@balancer-labs/v3-solidity-utils/contracts/helpers/RevertCodec.sol";
 import { Version } from "@balancer-labs/v3-solidity-utils/contracts/helpers/Version.sol";
 import {
@@ -152,6 +153,8 @@ abstract contract RouterCommon is IRouterCommon, VaultGuard, Version {
         bytes calldata permit2Signature,
         bytes[] calldata multicallData
     ) external payable virtual saveSender(msg.sender) returns (bytes[] memory results) {
+        InputHelpers.ensureInputLengthMatch(permitBatch.length, permitSignatures.length);
+
         // Use Permit (ERC-2612) to grant allowances to Permit2 for tokens to swap,
         // and grant allowances to Vault for BPT tokens.
         for (uint256 i = 0; i < permitBatch.length; ++i) {

--- a/pkg/vault/test/.contract-sizes/BatchRouter
+++ b/pkg/vault/test/.contract-sizes/BatchRouter
@@ -1,2 +1,2 @@
-Bytecode	17.548
-InitCode	19.346
+Bytecode	17.600
+InitCode	19.397

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	21.955
-InitCode	23.818
+Bytecode	21.971
+InitCode	23.834

--- a/pkg/vault/test/.contract-sizes/Router
+++ b/pkg/vault/test/.contract-sizes/Router
@@ -1,2 +1,2 @@
-Bytecode	24.003* (3 over)
-InitCode	25.355
+Bytecode	24.055* (56 over)
+InitCode	25.407

--- a/pkg/vault/test/foundry/Permit2.t.sol
+++ b/pkg/vault/test/foundry/Permit2.t.sol
@@ -13,6 +13,7 @@ import { IAllowanceTransfer } from "permit2/src/interfaces/IAllowanceTransfer.so
 import { IRouter } from "@balancer-labs/v3-interfaces/contracts/vault/IRouter.sol";
 import { IRouterCommon } from "@balancer-labs/v3-interfaces/contracts/vault/IRouterCommon.sol";
 
+import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
 import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/test/ArrayHelpers.sol";
 
 import { BaseVaultTest } from "./utils/BaseVaultTest.sol";
@@ -267,5 +268,21 @@ contract Permit2Test is BaseVaultTest {
             bytes(""),
             multicallData
         );
+    }
+
+    function testPermitBatchAndCallMismatch() public {
+        IRouterCommon.PermitApproval[] memory permitBatch = new IRouterCommon.PermitApproval[](2);
+        IAllowanceTransfer.PermitBatch memory permit2Batch;
+        bytes[] memory permitSignatures = new bytes[](1);
+        bytes[] memory multicallData = new bytes[](1);
+
+        multicallData[0] = abi.encodeCall(
+            IRouter.addLiquidityUnbalanced,
+            (pool, new uint256[](2), bptAmountOut, false, bytes(""))
+        );
+
+        vm.expectRevert(InputHelpers.InputLengthMismatch.selector);
+        vm.prank(alice);
+        router.permitBatchAndCall(permitBatch, permitSignatures, permit2Batch, bytes(""), multicallData);
     }
 }


### PR DESCRIPTION
# Description

Unlikely to occur in practice, but the function is missing a length check. Unfortunately, this adds to the bytecode (though it was already over). Since this is really a pre-condition, I tried require, but that increased the bytecode even more.

If we decide not to do this, we could add a comment to IRouterCommon instead of changing the code:
@dev This function assumes that the `permitBatch` and `permitSignatures` arrays are parallel; this is not verified, and must be guaranteed externally.

## Type of change

- [X] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
