### PR TITLE
Token decimals must be constant

### DIFF
--- a/pkg/interfaces/contracts/vault/VaultTypes.sol
+++ b/pkg/interfaces/contracts/vault/VaultTypes.sol
@@ -135,6 +135,9 @@ struct PoolRoleAccounts {
 //   decimals, so the Vault only supports tokens that implement `IERC20Metadata.decimals`, and return a value less than
 //   or equal to 18.
 //
+//  * Token decimals are checked and stored only once, on registration. Valid tokens store their decimals as immutable
+//    variables or constants. Malicious tokens that don't respect this basic property would not work anywhere in DeFi.
+//
 // These types of tokens are supported but discouraged, as they don't tend to play well with AMMs generally.
 //
 // * Very low-decimal tokens (e.g., GUSD). The Vault has been extensively tested with 6-decimal tokens (e.g., USDC),


### PR DESCRIPTION
# Description

Document the (obvious) fact that token decimals must be constant. Any token that varied its decimals over time would be considered malicious.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [X] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
