### PR TITLE
Expand docs on yield fees in Recovery Mode

### DIFF
--- a/pkg/interfaces/contracts/vault/IVaultAdmin.sol
+++ b/pkg/interfaces/contracts/vault/IVaultAdmin.sol
@@ -225,7 +225,9 @@ interface IVaultAdmin {
     /**
      * @notice Enable recovery mode for a pool.
      * @dev This is a permissioned function. It enables a safe proportional withdrawal, with no external calls.
-     * Since there are no external calls, live balances cannot be updated while in Recovery Mode.
+     * Since there are no external calls, ensuring that entering Recovery Mode cannot fail, we cannot compute and so
+     * must forfeit any yield fees between the last operation and enabling Recovery Mode. For the same reason, live
+     * balances cannot be updated while in Recovery Mode, as doing so might cause withdrawals to fail.
      *
      * @param pool The address of the pool
      */


### PR DESCRIPTION
# Description

For the same reason we can't update live balances during Recovery Mode (i.e., the operation cannot fail), we also can't compute (and therefore must forfeit) any yield fees that would have accrued since the last operation.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [X] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
