### PR TITLE
add pools array to factory

### DIFF
--- a/pkg/interfaces/contracts/vault/IBasePoolFactory.sol
+++ b/pkg/interfaces/contracts/vault/IBasePoolFactory.sol
@@ -30,6 +30,14 @@ interface IBasePoolFactory is IAuthentication {
     function isPoolFromFactory(address pool) external view returns (bool);
 
     /**
+     * @notice Return a subset of the list of pools deployed by this factory
+     * @param start The index of the first pool to return
+     * @param count The number of pools to return
+     * @return result The list of pools deployed by this factory, starting at `start` and returning `count` pools
+     */
+    function getPools(uint256 start, uint256 count) external view returns (address[] memory result);
+
+    /**
      * @notice Return the address where a new pool will be deployed, based on the factory address and salt.
      * @param salt The salt used to deploy the pool
      * @return deploymentAddress The predicted address of the pool, given the salt

--- a/pkg/pool-utils/contracts/BasePoolFactory.sol
+++ b/pkg/pool-utils/contracts/BasePoolFactory.sol
@@ -32,6 +32,8 @@ import { CREATE3 } from "@balancer-labs/v3-solidity-utils/contracts/solmate/CREA
  */
 abstract contract BasePoolFactory is IBasePoolFactory, SingletonAuthentication, FactoryWidePauseWindow {
     mapping(address pool => bool isFromFactory) private _isPoolFromFactory;
+    address[] private _pools;
+
     bool private _disabled;
 
     // Store the creationCode of the contract to be deployed by create3.
@@ -51,6 +53,24 @@ abstract contract BasePoolFactory is IBasePoolFactory, SingletonAuthentication, 
     /// @inheritdoc IBasePoolFactory
     function isPoolFromFactory(address pool) external view returns (bool) {
         return _isPoolFromFactory[pool];
+    }
+
+    /// @inheritdoc IBasePoolFactory
+    function getPools(uint256 start, uint256 count) external view returns (address[] memory result) {
+        uint256 length = _pools.length;
+        require(start < length, "BasePoolFactory: start out of bounds");
+
+        uint256 end = start + count;
+        if (end > length) {
+            count = length - start;
+        }
+
+        result = new address[](count);
+        for (uint256 i = 0; i < count; i++) {
+            result[i] = _pools[start + i];
+        }
+
+        return result;
     }
 
     /// @inheritdoc IBasePoolFactory
@@ -82,6 +102,7 @@ abstract contract BasePoolFactory is IBasePoolFactory, SingletonAuthentication, 
         _ensureEnabled();
 
         _isPoolFromFactory[pool] = true;
+        _pools.push(pool);
 
         emit PoolCreated(pool);
     }

--- a/pkg/pool-utils/test/foundry/BasePoolFactory.t.sol
+++ b/pkg/pool-utils/test/foundry/BasePoolFactory.t.sol
@@ -103,6 +103,27 @@ contract BasePoolFactoryTest is BaseVaultTest {
         testFactory.manualRegisterPoolWithFactory(newPool);
 
         assertTrue(testFactory.isPoolFromFactory(newPool), "Pool is not registered with factory");
+        assertEq(testFactory.getPools(0, 1)[0], newPool, "Pools list does not contain the new pool");
+    }
+
+    function testRegisterMultiplePools() public {
+        uint256 count = 30;
+        address[] memory pools = new address[](count);
+        for (uint256 i = 0; i < count; i++) {
+            pools[i] = address(deployPoolMock(IVault(address(vault)), "Test Pool", "TEST"));
+        }
+
+        for (uint256 i = 0; i < count; i++) {
+            assertFalse(testFactory.isPoolFromFactory(pools[i]), "Pool is already registered with factory");
+            testFactory.manualRegisterPoolWithFactory(pools[i]);
+            assertTrue(testFactory.isPoolFromFactory(pools[i]), "Pool is not registered with factory");
+        }
+
+        address[] memory registeredPools = testFactory.getPools(0, 100000);
+        assertEq(registeredPools.length, count, "Pools list has wrong length");
+        for (uint256 i = 0; i < count; i++) {
+            assertEq(registeredPools[i], pools[i], "Pools list does not contain the new pool");
+        }
     }
 
     function testRegisterPoolWithVault() public {

--- a/pkg/pool-utils/test/foundry/BasePoolFactory.t.sol
+++ b/pkg/pool-utils/test/foundry/BasePoolFactory.t.sol
@@ -119,10 +119,21 @@ contract BasePoolFactoryTest is BaseVaultTest {
             assertTrue(testFactory.isPoolFromFactory(pools[i]), "Pool is not registered with factory");
         }
 
-        address[] memory registeredPools = testFactory.getPools(0, 100000);
-        assertEq(registeredPools.length, count, "Pools list has wrong length");
+        _compareArrays(testFactory.getPools(0, count), pools);
+        _compareArrays(testFactory.getPools(0, 100000), pools);
         for (uint256 i = 0; i < count; i++) {
-            assertEq(registeredPools[i], pools[i], "Pools list does not contain the new pool");
+            assertEq(testFactory.getPools(i, 1)[0], pools[i], "Pools list does not contain the new pool");
+        }
+
+        address[] memory firstHalf = testFactory.getPools(0, count / 2);
+        address[] memory secondHalf = testFactory.getPools(count / 2, count);
+
+        for (uint256 i = 0; i < count; i++) {
+            if (i < count / 2) {
+                assertEq(firstHalf[i], pools[i], "First half does not contain the new pool");
+            } else {
+                assertEq(secondHalf[i - count / 2], pools[i], "Second half does not contain the new pool");
+            }
         }
     }
 
@@ -191,5 +202,12 @@ contract BasePoolFactoryTest is BaseVaultTest {
         assertFalse(liquidityManagement.disableUnbalancedLiquidity, "disableUnbalancedLiquidity is true");
         assertFalse(liquidityManagement.enableAddLiquidityCustom, "enableAddLiquidityCustom is true");
         assertFalse(liquidityManagement.enableRemoveLiquidityCustom, "enableRemoveLiquidityCustom is true");
+    }
+
+    function _compareArrays(address[] memory a, address[] memory b) internal pure {
+        assertEq(a.length, b.length, "Arrays have different lengths");
+        for (uint256 i = 0; i < a.length; i++) {
+            assertEq(a[i], b[i], "Arrays have different elements");
+        }
     }
 }

--- a/pkg/vault/contracts/test/PoolFactoryMock.sol
+++ b/pkg/vault/contracts/test/PoolFactoryMock.sol
@@ -179,6 +179,10 @@ contract PoolFactoryMock is IBasePoolFactory, SingletonAuthentication, FactoryWi
         return _isPoolFromFactory[pool];
     }
 
+    function getPools(uint256, uint256) external pure returns (address[] memory) {
+        revert("Not implemented");
+    }
+
     /// @inheritdoc IBasePoolFactory
     function isDisabled() public view returns (bool) {
         return _disabled;


### PR DESCRIPTION
# Description

The SDK team asked to be able to get a list of pool addresses from factories. The `getPools(uint256 start, uint256 count)` function allows you to get a list with pagination. Pagination is needed to avoid going over the gas limit when receiving data. The returned list will never exceed the length of the array, so if we want to get the entire array list, we can pass count as MAX_UINT_256.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #1112

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
