### PR TITLE
Avoid wrapper.asset() calls.

### DIFF
--- a/pkg/interfaces/contracts/vault/IVaultExtension.sol
+++ b/pkg/interfaces/contracts/vault/IVaultExtension.sol
@@ -314,6 +314,9 @@ interface IVaultExtension {
      */
     function isERC4626BufferInitialized(IERC4626 wrappedToken) external view returns (bool isBufferInitialized);
 
+    /// @notice Gets registered asset for a given buffer. Returns `address(0)` if not initialized.
+    function getERC4626BufferAsset(IERC4626 wrappedToken) external view returns (address asset);
+
     /*******************************************************************************
                                           Fees
     *******************************************************************************/

--- a/pkg/vault/contracts/BufferRouter.sol
+++ b/pkg/vault/contracts/BufferRouter.sol
@@ -88,7 +88,9 @@ contract BufferRouter is IBufferRouter, RouterCommon {
             minIssuedShares,
             sharesOwner
         );
-        _takeTokenIn(sharesOwner, IERC20(wrappedToken.asset()), exactAmountUnderlyingIn, false);
+
+        address asset = _vault.getERC4626BufferAsset(wrappedToken);
+        _takeTokenIn(sharesOwner, IERC20(asset), exactAmountUnderlyingIn, false);
         _takeTokenIn(sharesOwner, IERC20(address(wrappedToken)), exactAmountWrappedIn, false);
     }
 
@@ -146,7 +148,9 @@ contract BufferRouter is IBufferRouter, RouterCommon {
             exactSharesToIssue,
             sharesOwner
         );
-        _takeTokenIn(sharesOwner, IERC20(wrappedToken.asset()), amountUnderlyingIn, false);
+
+        address asset = _vault.getERC4626BufferAsset(wrappedToken);
+        _takeTokenIn(sharesOwner, IERC20(asset), amountUnderlyingIn, false);
         _takeTokenIn(sharesOwner, IERC20(address(wrappedToken)), amountWrappedIn, false);
     }
 

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -585,7 +585,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
      * this set with the resulting amount of wrapped tokens from the operation.
      */
     function _wrapAndUpdateTokenInAmounts(IERC4626 wrappedToken) private returns (uint256 wrappedAmountOut) {
-        address underlyingToken = wrappedToken.asset();
+        address underlyingToken = _vault.getERC4626BufferAsset(wrappedToken);
 
         // Get the amountIn of underlying tokens informed by the sender.
         uint256 underlyingAmountIn = _currentSwapTokenInAmounts().tGet(underlyingToken);
@@ -788,7 +788,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
 
         // The transient sets `_currentSwapTokensOut` and `_currentSwapTokenOutAmounts` must be updated, so
         // `_settlePaths` function will be able to send the token out amounts to the sender.
-        address underlyingToken = wrappedToken.asset();
+        address underlyingToken = _vault.getERC4626BufferAsset(wrappedToken);
         _currentSwapTokensOut().add(underlyingToken);
         _currentSwapTokenOutAmounts().tAdd(underlyingToken, underlyingAmountOut);
     }

--- a/pkg/vault/contracts/VaultExtension.sol
+++ b/pkg/vault/contracts/VaultExtension.sol
@@ -635,6 +635,11 @@ contract VaultExtension is IVaultExtension, VaultCommon, Proxy {
         return _bufferAssets[wrappedToken] != address(0);
     }
 
+    /// @inheritdoc IVaultExtension
+    function getERC4626BufferAsset(IERC4626 wrappedToken) external view onlyVaultDelegateCall returns (address asset) {
+        return _bufferAssets[wrappedToken];
+    }
+
     /*******************************************************************************
                                      Pool Pausing
     *******************************************************************************/

--- a/pkg/vault/test/foundry/mutation/vault/VaultExtension.t.sol
+++ b/pkg/vault/test/foundry/mutation/vault/VaultExtension.t.sol
@@ -240,4 +240,14 @@ contract VaultExtensionMutationTest is BaseVaultTest {
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolNotRegistered.selector, address(this)));
         vault.emitAuxiliaryEvent("", bytes(""));
     }
+
+    function testIsERC4626BufferInitializedWhenNotVault() public {
+        vm.expectRevert(IVaultErrors.NotVaultDelegateCall.selector);
+        vaultExtension.isERC4626BufferInitialized(IERC4626(address(1)));
+    }
+
+    function testGetERC4626BufferAssetWhenNotVault() public {
+        vm.expectRevert(IVaultErrors.NotVaultDelegateCall.selector);
+        vaultExtension.getERC4626BufferAsset(IERC4626(address(1)));
+    }
 }

--- a/pkg/vault/test/foundry/unit/VaultBufferUnit.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultBufferUnit.t.sol
@@ -38,7 +38,10 @@ contract VaultBufferUnitTest is BaseVaultTest {
     }
 
     function testGetERC4626BufferAsset() public view {
-        assertEq(vault.getERC4626BufferAsset(IERC4626(address(wDaiInitialized))), IERC4626(address(wDaiInitialized)).asset());
+        assertEq(
+            vault.getERC4626BufferAsset(IERC4626(address(wDaiInitialized))),
+            IERC4626(address(wDaiInitialized)).asset()
+        );
         assertEq(vault.getERC4626BufferAsset(IERC4626(address(wUSDCNotInitialized))), address(0));
     }
 

--- a/pkg/vault/test/foundry/unit/VaultBufferUnit.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultBufferUnit.t.sol
@@ -32,6 +32,16 @@ contract VaultBufferUnitTest is BaseVaultTest {
         _initializeBuffer();
     }
 
+    function testIsERC4626BufferInitialized() public view {
+        assertTrue(vault.isERC4626BufferInitialized(IERC4626(address(wDaiInitialized))));
+        assertFalse(vault.isERC4626BufferInitialized(IERC4626(address(wUSDCNotInitialized))));
+    }
+
+    function testGetERC4626BufferAsset() public view {
+        assertEq(vault.getERC4626BufferAsset(IERC4626(address(wDaiInitialized))), IERC4626(address(wDaiInitialized)).asset());
+        assertEq(vault.getERC4626BufferAsset(IERC4626(address(wUSDCNotInitialized))), address(0));
+    }
+
     function testUnderlyingImbalanceBalanceZero() public view {
         int256 imbalance = vault.internalGetBufferUnderlyingImbalance(IERC4626(address(wUSDCNotInitialized)));
         assertEq(imbalance, int256(0), "Wrong underlying imbalance");


### PR DESCRIPTION
# Description

Use registered asset address from the vault instead.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #1120 