### PR TITLE
Document order of operations in buffer/buffer pools

### DIFF
--- a/pkg/interfaces/contracts/vault/IBufferRouter.sol
+++ b/pkg/interfaces/contracts/vault/IBufferRouter.sol
@@ -17,6 +17,8 @@ interface IBufferRouter {
      * @notice Adds liquidity for the first time to an internal ERC4626 buffer in the Vault.
      * @dev Calling this method binds the wrapped token to its underlying asset internally; the asset in the wrapper
      * cannot change afterwards, or every other operation on that wrapper (add / remove / wrap / unwrap) will fail.
+     * To avoid unexpected behavior, always initialize buffers before creating or initializing any pools that contain
+     * the wrapped tokens to be used with them.
      *
      * @param wrappedToken Address of the wrapped token that implements IERC4626
      * @param exactAmountUnderlyingIn Amount of underlying tokens that will be deposited into the buffer

--- a/pkg/interfaces/contracts/vault/ICompositeLiquidityRouter.sol
+++ b/pkg/interfaces/contracts/vault/ICompositeLiquidityRouter.sol
@@ -24,7 +24,10 @@ interface ICompositeLiquidityRouter {
 
     /**
      * @notice Add arbitrary amounts of underlying tokens to an ERC4626 pool through the buffer.
-     * @dev An "ERC4626 pool" contains IERC4626 yield-bearing tokens (e.g., waDAI).
+     * @dev An "ERC4626 pool" contains IERC4626 yield-bearing tokens (e.g., waDAI). Ensure that any buffers associated
+     * with the wrapped tokens in the ERC4626 pool have been initialized before initializing or adding liquidity to
+     * the "parent" pool, and also make sure limits are set properly.
+     *
      * @param pool Address of the liquidity pool
      * @param exactUnderlyingAmountsIn Exact amounts of underlying tokens in, sorted in token registration order of
      * wrapped tokens in the pool
@@ -43,7 +46,10 @@ interface ICompositeLiquidityRouter {
 
     /**
      * @notice Add proportional amounts of underlying tokens to an ERC4626 pool through the buffer.
-     * @dev An "ERC4626 pool" contains IERC4626 yield-bearing tokens (e.g., waDAI).
+     * @dev An "ERC4626 pool" contains IERC4626 yield-bearing tokens (e.g., waDAI). Ensure that any buffers associated
+     * with the wrapped tokens in the ERC4626 pool have been initialized before initializing or adding liquidity to
+     * the "parent" pool, and also make sure limits are set properly.
+     *
      * @param pool Address of the liquidity pool
      * @param maxUnderlyingAmountsIn Maximum amounts of underlying tokens in, sorted in token registration order of
      * wrapped tokens in the pool


### PR DESCRIPTION
# Description

It is remotely possible for bad things to happen if you try to initialize a pool containing wrapped (buffer) tokens, without initializing the buffers first. Document best practices when creating buffers and ERC4626 pools.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [X] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
