### PR TITLE
Rename revokePermit to be more descriptive

### DIFF
--- a/pkg/vault/contracts/BalancerPoolToken.sol
+++ b/pkg/vault/contracts/BalancerPoolToken.sol
@@ -156,7 +156,7 @@ contract BalancerPoolToken is IERC20, IERC20Metadata, IERC20Permit, IRateProvide
     }
 
     /// @notice Increment the sender's nonce to revoke any currently granted (but not yet executed) `permit`.
-    function revokePermit() external {
+    function incrementNonce() external {
         _useNonce(msg.sender);
     }
 

--- a/pkg/vault/test/foundry/BalancerPoolTokenTest.t.sol
+++ b/pkg/vault/test/foundry/BalancerPoolTokenTest.t.sol
@@ -173,9 +173,9 @@ contract BalancerPoolTokenTest is BaseVaultTest {
         poolToken.permit(user, address(0xCAFE), defaultAmount, block.timestamp, v, r, s);
 
         vm.prank(user);
-        poolToken.revokePermit();
+        poolToken.incrementNonce();
 
-        // Note that `revokePermit` doesn't affect allowances already granted by executed permits.
+        // Note that `incrementNonce` doesn't affect allowances already granted by executed permits.
         // It just invalidates signatures for permits that have not yet been executed.
         assertEq(poolToken.allowance(user, address(0xCAFE)), defaultAmount, "allowance mismatch");
 
@@ -197,7 +197,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
         poolToken.permit(user, address(0xCAFE), defaultAmount, block.timestamp, v, r, s);
 
         vm.prank(user);
-        poolToken.revokePermit();
+        poolToken.incrementNonce();
 
         // Would have to pull in the OZ libraries to compute this, so just did it externally. This is the signer
         // recovered from the incremented nonce, which of course will not match the original signer.
@@ -239,7 +239,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
         poolToken.permit(user, address(0xCAFE), defaultAmount, block.timestamp, v, r, s);
 
         vm.prank(user);
-        poolToken.revokePermit();
+        poolToken.incrementNonce();
 
         (uint8 v2, bytes32 r2, bytes32 s2) = getPermitSignature(
             IEIP712(address(poolToken)),
@@ -266,7 +266,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
         );
 
         vm.prank(user);
-        poolToken.revokePermit();
+        poolToken.incrementNonce();
 
         vm.expectRevert(bytes(""));
         poolToken.permit(user, address(0xCAFE), defaultAmount, block.timestamp, v, r, s);
@@ -284,7 +284,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
         );
 
         vm.prank(user);
-        poolToken.revokePermit();
+        poolToken.incrementNonce();
 
         (uint8 v2, bytes32 r2, bytes32 s2) = getPermitSignature(
             IEIP712(address(poolToken)),


### PR DESCRIPTION
# Description

`revokePermit` technically doesn't "revoke" a permit; rename to just say exactly what it does.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
