### PR TITLE
Swap event order for try / catch emits.

### DIFF
--- a/pkg/vault/contracts/token/ERC20MultiToken.sol
+++ b/pkg/vault/contracts/token/ERC20MultiToken.sol
@@ -138,14 +138,15 @@ abstract contract ERC20MultiToken is IERC20Errors, IERC20MultiTokenErrors {
 
         _totalSupplyOf[pool] = newTotalSupply;
 
-        emit Transfer(pool, from, address(0), amount);
-
         // We also emit the "transfer" event on the pool token to ensure full compliance with the ERC20 standard.
         // If this function fails we keep going, as this is used in recovery mode.
         // Well-behaved pools will just emit an event here, so they should never fail.
         try BalancerPoolToken(pool).emitTransfer(from, address(0), amount) {} catch {
             // solhint-disable-previous-line no-empty-blocks
         }
+
+        // Emit the internal event last to spend some gas after try / catch.
+        emit Transfer(pool, from, address(0), amount);
     }
 
     function _transfer(address pool, address from, address to, uint256 amount) internal {
@@ -186,13 +187,15 @@ abstract contract ERC20MultiToken is IERC20Errors, IERC20MultiTokenErrors {
 
         _allowances[pool][owner][spender] = amount;
 
-        emit Approval(pool, owner, spender, amount);
         // We also emit the "approve" event on the pool token to ensure full compliance with the ERC20 standard.
         // If this function fails we keep going, as this is used in recovery mode.
         // Well-behaved pools will just emit an event here, so they should never fail.
         try BalancerPoolToken(pool).emitApproval(owner, spender, amount) {} catch {
             // solhint-disable-previous-line no-empty-blocks
         }
+
+        // Emit the internal event last to spend some gas after try / catch.
+        emit Approval(pool, owner, spender, amount);
     }
 
     function _spendAllowance(address pool, address owner, address spender, uint256 amount) internal {


### PR DESCRIPTION
# Description

See https://cantina.xyz/code/d9a77a0d-c21e-4f49-8889-fbfae22419a7/comments#comment-992ff86d-16a8-48e9-b387-27eb3fd7da74.

There doesn't seem to be a way to call `approve` in a way that the external event is not emitted (out of gas) but the tx succeeds with the current mainnet values.

In general, spending more gas after `try / catch` should add more protection against this minor attack vector. Since this doesn't really affect anything onchain, and events don't have any impact offchain until the tx lands, swapping the order should make no real difference, while offering a bit more protection against weird calls with crafted gas limits in case gas costs ever change.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A