### PR TITLE
8020 refactor; test tweaks

### DIFF
--- a/pkg/pool-weighted/contracts/WeightedPool8020Factory.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool8020Factory.sol
@@ -54,6 +54,7 @@ contract WeightedPool8020Factory is IPoolVersion, BasePoolFactory, Version {
      * @param lowWeightTokenConfig The token configuration of the low weight token
      * @param roleAccounts Addresses the Vault will allow to change certain pool settings
      * @param swapFeePercentage Initial swap fee percentage
+     * @return pool The pool address
      */
     function create(
         TokenConfig memory highWeightTokenConfig,
@@ -80,22 +81,10 @@ contract WeightedPool8020Factory is IPoolVersion, BasePoolFactory, Version {
         tokenConfig[highWeightTokenIdx] = highWeightTokenConfig;
         tokenConfig[lowWeightTokenIdx] = lowWeightTokenConfig;
 
-        string memory highWeightTokenSymbol = IERC20Metadata(address(highWeightToken)).symbol();
-        string memory lowWeightTokenSymbol = IERC20Metadata(address(lowWeightToken)).symbol();
+        bytes memory constructorArgs = _calculateConstructorArgs(highWeightToken, lowWeightToken);
+        bytes32 salt = _calculateSalt(highWeightToken, lowWeightToken);
 
-        pool = _create(
-            abi.encode(
-                WeightedPool.NewPoolParams({
-                    name: string.concat("Balancer 80 ", highWeightTokenSymbol, " 20 ", lowWeightTokenSymbol),
-                    symbol: string.concat("B-80", highWeightTokenSymbol, "-20", lowWeightTokenSymbol),
-                    numTokens: 2,
-                    normalizedWeights: weights,
-                    version: _poolVersion
-                }),
-                getVault()
-            ),
-            _calculateSalt(highWeightToken, lowWeightToken)
-        );
+        pool = _create(constructorArgs, salt);
 
         // Using empty pool hooks for standard 80/20 pool.
         _registerPoolWithVault(
@@ -113,20 +102,34 @@ contract WeightedPool8020Factory is IPoolVersion, BasePoolFactory, Version {
      * @notice Gets the address of the pool with the respective tokens and weights.
      * @param highWeightToken The token with 80% weight in the pool.
      * @param lowWeightToken The token with 20% weight in the pool.
+     * @return pool Address of the pool
      */
     function getPool(IERC20 highWeightToken, IERC20 lowWeightToken) external view returns (address pool) {
-        uint256[] memory weights = new uint256[](2);
+        bytes memory constructorArgs = _calculateConstructorArgs(highWeightToken, lowWeightToken);
+        bytes32 salt = _calculateSalt(highWeightToken, lowWeightToken);
 
+        pool = getDeploymentAddress(constructorArgs, salt);
+    }
+
+    function _calculateSalt(IERC20 highWeightToken, IERC20 lowWeightToken) internal view returns (bytes32 salt) {
+        salt = keccak256(abi.encode(block.chainid, highWeightToken, lowWeightToken));
+    }
+
+    function _calculateConstructorArgs(
+        IERC20 highWeightToken,
+        IERC20 lowWeightToken
+    ) private view returns (bytes memory constructorArgs) {
         // Tokens must be sorted.
         (uint256 highWeightTokenIdx, uint256 lowWeightTokenIdx) = highWeightToken > lowWeightToken ? (1, 0) : (0, 1);
-
-        weights[highWeightTokenIdx] = _EIGHTY;
-        weights[lowWeightTokenIdx] = _TWENTY;
 
         string memory highWeightTokenSymbol = IERC20Metadata(address(highWeightToken)).symbol();
         string memory lowWeightTokenSymbol = IERC20Metadata(address(lowWeightToken)).symbol();
 
-        bytes memory poolArgs = abi.encode(
+        uint256[] memory weights = new uint256[](2);
+        weights[highWeightTokenIdx] = _EIGHTY;
+        weights[lowWeightTokenIdx] = _TWENTY;
+
+        constructorArgs = abi.encode(
             WeightedPool.NewPoolParams({
                 name: string.concat("Balancer 80 ", highWeightTokenSymbol, " 20 ", lowWeightTokenSymbol),
                 symbol: string.concat("B-80", highWeightTokenSymbol, "-20", lowWeightTokenSymbol),
@@ -136,13 +139,6 @@ contract WeightedPool8020Factory is IPoolVersion, BasePoolFactory, Version {
             }),
             getVault()
         );
-
-        bytes32 salt = _calculateSalt(highWeightToken, lowWeightToken);
-        pool = getDeploymentAddress(poolArgs, salt);
-    }
-
-    function _calculateSalt(IERC20 highWeightToken, IERC20 lowWeightToken) internal view returns (bytes32 salt) {
-        salt = keccak256(abi.encode(block.chainid, highWeightToken, lowWeightToken));
     }
 
     /**

--- a/pkg/vault/contracts/test/PoolFactoryMock.sol
+++ b/pkg/vault/contracts/test/PoolFactoryMock.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.24;
 
+import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
+
 import { IBasePoolFactory } from "@balancer-labs/v3-interfaces/contracts/vault/IBasePoolFactory.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
@@ -204,18 +206,7 @@ contract PoolFactoryMock is IBasePoolFactory, SingletonAuthentication, FactoryWi
         bytes32 creationCodeHash = keccak256(creationCode);
         bytes32 finalSalt = _computeFinalSalt(salt);
 
-        address contractAddress = address(this);
-
-        assembly {
-            let ptr := mload(0x40)
-
-            mstore(add(ptr, 0x40), creationCodeHash)
-            mstore(add(ptr, 0x20), finalSalt)
-            mstore(ptr, contractAddress)
-            let start := add(ptr, 0x0b)
-            mstore8(start, 0xff)
-            deployAddress := keccak256(start, 85)
-        }
+        return Create2.computeAddress(finalSalt, creationCodeHash, address(this));
     }
 
     /// @inheritdoc IBasePoolFactory

--- a/pkg/vault/test/foundry/DynamicFeePoolTest.t.sol
+++ b/pkg/vault/test/foundry/DynamicFeePoolTest.t.sol
@@ -76,7 +76,7 @@ contract DynamicFeePoolTest is BaseVaultTest {
             liquidityManagement
         );
 
-        poolArguments = abi.encode(vault, name, symbol);
+        poolArgs = abi.encode(vault, name, symbol);
     }
 
     function initPool() internal override {

--- a/pkg/vault/test/foundry/LiquidityApproximation.t.sol
+++ b/pkg/vault/test/foundry/LiquidityApproximation.t.sol
@@ -107,6 +107,7 @@ contract LiquidityApproximationTest is BaseVaultTest {
         (swapPool, ) = _createPool(tokens, "swapPool");
 
         // NOTE: return is empty, because this test does not use the `pool` variable.
+        return (address(0), bytes(""));
     }
 
     function initPool() internal override {

--- a/pkg/vault/test/foundry/LiquidityApproximation.t.sol
+++ b/pkg/vault/test/foundry/LiquidityApproximation.t.sol
@@ -100,7 +100,7 @@ contract LiquidityApproximationTest is BaseVaultTest {
         assertEq(dai.balanceOf(alice), dai.balanceOf(bob), "Bob and Alice DAI balances are not equal");
     }
 
-    function createPool() internal virtual override returns (address poolAddress, bytes memory poolArgs) {
+    function createPool() internal virtual override returns (address, bytes memory) {
         address[] memory tokens = [address(dai), address(usdc)].toMemoryArray();
 
         (liquidityPool, ) = _createPool(tokens, "liquidityPool");

--- a/pkg/vault/test/foundry/Registration.t.sol
+++ b/pkg/vault/test/foundry/Registration.t.sol
@@ -41,6 +41,7 @@ contract RegistrationTest is BaseVaultTest {
     // Do not register the pool in the base test.
     function createPool() internal pure override returns (address newPool, bytes memory poolArgs) {
         newPool = address(0);
+        poolArgs = bytes("");
     }
 
     function initPool() internal override {}

--- a/pkg/vault/test/foundry/VaultLiquidityRate.t.sol
+++ b/pkg/vault/test/foundry/VaultLiquidityRate.t.sol
@@ -61,7 +61,7 @@ contract VaultLiquidityWithRatesTest is BaseVaultTest {
         tokens[wstethIdx] = wsteth;
 
         factoryMock.registerTestPool(newPool, vault.buildTokenConfig(tokens, rateProviders), poolHooksContract, lp);
-        poolArguments = abi.encode(vault, name, symbol);
+        poolArgs = abi.encode(vault, name, symbol);
     }
 
     function testLastLiveBalanceInitialization() public {

--- a/pkg/vault/test/foundry/YieldFees.t.sol
+++ b/pkg/vault/test/foundry/YieldFees.t.sol
@@ -67,7 +67,7 @@ contract YieldFeesTest is BaseVaultTest {
         );
 
         vm.label(newPool, "pool");
-        poolArguments = abi.encode(vault, name, symbol);
+        poolArgs = abi.encode(vault, name, symbol);
     }
 
     function testPoolDataAfterInitialization__Fuzz(bool roundUp) public {

--- a/pvt/benchmarks/test/foundry/WeightedPoolSwaps.t.sol
+++ b/pvt/benchmarks/test/foundry/WeightedPoolSwaps.t.sol
@@ -82,19 +82,18 @@ contract WeightedPoolSwaps is BaseVaultTest {
             )
         );
 
-        newPool =
-            factory.create(
-                name,
-                symbol,
-                vault.buildTokenConfig([address(dai), address(wsteth)].toMemoryArray().asIERC20()),
-                weights,
-                poolRoleAccounts,
-                swapFee,
-                address(0),
-                false,
-                false,
-                bytes32(uint256(1))
-            );
+        newPool = factory.create(
+            name,
+            symbol,
+            vault.buildTokenConfig([address(dai), address(wsteth)].toMemoryArray().asIERC20()),
+            weights,
+            poolRoleAccounts,
+            swapFee,
+            address(0),
+            false,
+            false,
+            bytes32(uint256(1))
+        );
 
         poolArgs = abi.encode(
             WeightedPool.NewPoolParams({

--- a/pvt/benchmarks/test/foundry/YieldFees.t.sol
+++ b/pvt/benchmarks/test/foundry/YieldFees.t.sol
@@ -72,23 +72,22 @@ contract YieldFeesTest is BaseVaultTest {
 
         PoolRoleAccounts memory poolRoleAccounts;
 
-        newPool =
-            factory.create(
-                name,
-                symbol,
-                vault.buildTokenConfig(
-                    [address(wsteth), address(dai)].toMemoryArray().asIERC20(),
-                    rateProviders,
-                    yieldFeeFlags
-                ),
-                weights,
-                poolRoleAccounts,
-                swapFee,
-                address(0),
-                false,
-                false,
-                bytes32(0)
-            );
+        newPool = factory.create(
+            name,
+            symbol,
+            vault.buildTokenConfig(
+                [address(wsteth), address(dai)].toMemoryArray().asIERC20(),
+                rateProviders,
+                yieldFeeFlags
+            ),
+            weights,
+            poolRoleAccounts,
+            swapFee,
+            address(0),
+            false,
+            false,
+            bytes32(0)
+        );
 
         vm.label(newPool, "weightedPoolWithRate");
 

--- a/pvt/benchmarks/test/foundry/YieldFees.t.sol
+++ b/pvt/benchmarks/test/foundry/YieldFees.t.sol
@@ -50,8 +50,13 @@ contract YieldFeesTest is BaseVaultTest {
     }
 
     // Create wsteth / dai pool, with rate providers on wsteth (non-exempt), and dai (exempt)
-    function createPool() internal override returns (address) {
+    function createPool() internal override returns (address newPool, bytes memory poolArgs) {
         factory = new WeightedPoolFactory(IVault(address(vault)), 365 days, "Factory v1", "Pool v1");
+
+        string memory name = "ERC20 Pool";
+        string memory symbol = "ERC20POOL";
+
+        uint256[] memory weights = [uint256(50e16), uint256(50e16)].toMemoryArray();
 
         wstETHRateProvider = deployRateProviderMock();
         daiRateProvider = deployRateProviderMock();
@@ -67,27 +72,36 @@ contract YieldFeesTest is BaseVaultTest {
 
         PoolRoleAccounts memory poolRoleAccounts;
 
-        weightedPoolWithRate = WeightedPool(
+        newPool =
             factory.create(
-                "ERC20 Pool",
-                "ERC20POOL",
+                name,
+                symbol,
                 vault.buildTokenConfig(
                     [address(wsteth), address(dai)].toMemoryArray().asIERC20(),
                     rateProviders,
                     yieldFeeFlags
                 ),
-                [uint256(50e16), uint256(50e16)].toMemoryArray(),
+                weights,
                 poolRoleAccounts,
                 swapFee,
                 address(0),
                 false,
                 false,
                 bytes32(0)
-            )
-        );
+            );
 
-        vm.label(address(weightedPoolWithRate), "weightedPoolWithRate");
-        return address(weightedPoolWithRate);
+        vm.label(newPool, "weightedPoolWithRate");
+
+        poolArgs = abi.encode(
+            WeightedPool.NewPoolParams({
+                name: name,
+                symbol: symbol,
+                numTokens: 2,
+                normalizedWeights: weights,
+                version: "Pool Version 1"
+            }),
+            vault
+        );
     }
 
     function testSwapWithoutYieldFeesSnapshot() public {
@@ -150,7 +164,7 @@ contract YieldFeesTest is BaseVaultTest {
     }
 
     function _initializePoolAndRateProviders(uint256 wstethRate, uint256 daiRate) private {
-        pool = createPool();
+        (pool, ) = createPool();
         wstETHRateProvider.mockRate(wstethRate);
         daiRateProvider.mockRate(daiRate);
 


### PR DESCRIPTION
# Description

Based on #1142, there is duplicated code in 8020 after the refactor, which this removes. (It was easier to do a follow-on than describe it.)

Also noticed some cases where tests were directly overwriting the BaseVaultTest storage instead of using the return values. And there was still some unnecessary assembly.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
