### PR TITLE
Reconcile `VaultExplorer` with corresponding Vault interfaces

### DIFF
--- a/pkg/interfaces/contracts/vault/IVaultExplorer.sol
+++ b/pkg/interfaces/contracts/vault/IVaultExplorer.sol
@@ -105,7 +105,7 @@ interface IVaultExplorer {
      * @param pool Address of the pool to check
      * @return liquidityAdded True if liquidity has been added to this pool in the current transaction
      */
-    function getAddLiquidityCalledFlag(address pool) external view returns (bool);
+    function getAddLiquidityCalledFlag(address pool) external view returns (bool liquidityAdded);
 
     /*******************************************************************************
                                     Pool Registration
@@ -179,7 +179,7 @@ interface IVaultExplorer {
      * @return tokens The pool tokens, sorted in registration order
      * @return tokenInfo Token info, sorted in token registration order
      * @return balancesRaw Raw balances, sorted in token registration order
-     * @return lastLiveBalances Last saved live balances, sorted in token registration order
+     * @return lastBalancesLiveScaled18 Last saved live balances, sorted in token registration order
      */
     function getPoolTokenInfo(
         address pool
@@ -190,7 +190,7 @@ interface IVaultExplorer {
             IERC20[] memory tokens,
             TokenInfo[] memory tokenInfo,
             uint256[] memory balancesRaw,
-            uint256[] memory lastLiveBalances
+            uint256[] memory lastBalancesLiveScaled18
         );
 
     /**
@@ -232,26 +232,26 @@ interface IVaultExplorer {
     /**
      * @notice Gets the total supply of a given ERC20 token.
      * @param token The token address
-     * @return totalSupply Total supply of the token
+     * @return tokenTotalSupply Total supply of the token
      */
-    function totalSupply(address token) external view returns (uint256);
+    function totalSupply(address token) external view returns (uint256 tokenTotalSupply);
 
     /**
      * @notice Gets the balance of an account for a given ERC20 token.
      * @param token Address of the token
      * @param account Address of the account
-     * @return balance Balance of the account for the token
+     * @return tokenBalance Token balance of the account
      */
-    function balanceOf(address token, address account) external view returns (uint256 balance);
+    function balanceOf(address token, address account) external view returns (uint256 tokenBalance);
 
     /**
      * @notice Gets the allowance of a spender for a given ERC20 token and owner.
      * @param token Address of the token
      * @param owner Address of the owner
      * @param spender Address of the spender
-     * @return allowance Amount of tokens the spender is allowed to spend
+     * @return tokenAllowance Amount of tokens the spender is allowed to spend
      */
-    function allowance(address token, address owner, address spender) external view returns (uint256);
+    function allowance(address token, address owner, address spender) external view returns (uint256 tokenAllowance);
 
     /*******************************************************************************
                                     Pool Pausing
@@ -359,9 +359,9 @@ interface IVaultExplorer {
     /**
      * @notice Returns true if queries are disabled permanently; false if they are enabled.
      * @dev This is a one-way switch. Once queries are disabled permanently, they can never be re-enabled.
-     * @return queryDisabled If true, then queries are permanently disabled
+     * @return queryDisabledPermanently If true, then queries are permanently disabled
      */
-    function isQueryDisabledPermanently() external view returns (bool);
+    function isQueryDisabledPermanently() external view returns (bool queryDisabledPermanently);
 
     /***************************************************************************
                               Vault Admin Functions
@@ -486,7 +486,7 @@ interface IVaultExplorer {
 
     /**
      * @notice Collects accumulated aggregate swap and yield fees for the specified pool.
-     * @dev Fees are sent to the ProtocolFeeController address.
+     * @dev This function is called on the Vault's ProtocolFeeController, and fees are sent to that contract.
      * @param pool The pool on which all aggregate fees should be collected
      */
     function collectAggregateFees(address pool) external;

--- a/pkg/interfaces/contracts/vault/IVaultExtension.sol
+++ b/pkg/interfaces/contracts/vault/IVaultExtension.sol
@@ -245,26 +245,26 @@ interface IVaultExtension {
     /**
      * @notice Gets the total supply of a given ERC20 token.
      * @param token The token address
-     * @return totalSupply Total supply of the token
+     * @return tokenTotalSupply Total supply of the token
      */
-    function totalSupply(address token) external view returns (uint256);
+    function totalSupply(address token) external view returns (uint256 tokenTotalSupply);
 
     /**
      * @notice Gets the balance of an account for a given ERC20 token.
      * @param token Address of the token
      * @param account Address of the account
-     * @return balance Balance of the account for the token
+     * @return tokenBalance Token balance of the account
      */
-    function balanceOf(address token, address account) external view returns (uint256 balance);
+    function balanceOf(address token, address account) external view returns (uint256 tokenBalance);
 
     /**
      * @notice Gets the allowance of a spender for a given ERC20 token and owner.
      * @param token Address of the token
      * @param owner Address of the owner
      * @param spender Address of the spender
-     * @return allowance Amount of tokens the spender is allowed to spend
+     * @return tokenAllowance Amount of tokens the spender is allowed to spend
      */
-    function allowance(address token, address owner, address spender) external view returns (uint256);
+    function allowance(address token, address owner, address spender) external view returns (uint256 tokenAllowance);
 
     /**
      * @notice Approves a spender to spend pool tokens on behalf of sender.

--- a/pkg/vault/contracts/VaultExplorer.sol
+++ b/pkg/vault/contracts/VaultExplorer.sol
@@ -130,7 +130,7 @@ contract VaultExplorer is IVaultExplorer {
             IERC20[] memory tokens,
             TokenInfo[] memory tokenInfo,
             uint256[] memory balancesRaw,
-            uint256[] memory scalingFactors
+            uint256[] memory lastBalancesLiveScaled18
         )
     {
         return _vault.getPoolTokenInfo(pool);

--- a/pkg/vault/contracts/VaultExplorer.sol
+++ b/pkg/vault/contracts/VaultExplorer.sol
@@ -29,27 +29,27 @@ contract VaultExplorer is IVaultExplorer {
     ***************************************************************************/
 
     /// @inheritdoc IVaultExplorer
-    function getVault() external view returns (address) {
+    function getVault() external view returns (address vault) {
         return address(_vault);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getVaultExtension() external view returns (address) {
+    function getVaultExtension() external view returns (address vaultExtension) {
         return _vault.getVaultExtension();
     }
 
     /// @inheritdoc IVaultExplorer
-    function getVaultAdmin() external view returns (address) {
+    function getVaultAdmin() external view returns (address vaultAdmin) {
         return IVaultExtension(_vault.getVaultExtension()).getVaultAdmin();
     }
 
     /// @inheritdoc IVaultExplorer
-    function getAuthorizer() external view returns (address) {
+    function getAuthorizer() external view returns (address authorizer) {
         return address(_vault.getAuthorizer());
     }
 
     /// @inheritdoc IVaultExplorer
-    function getProtocolFeeController() external view returns (address) {
+    function getProtocolFeeController() external view returns (address protocolFeeController) {
         return address(_vault.getProtocolFeeController());
     }
 
@@ -58,27 +58,27 @@ contract VaultExplorer is IVaultExplorer {
     *******************************************************************************/
 
     /// @inheritdoc IVaultExplorer
-    function isUnlocked() external view returns (bool) {
+    function isUnlocked() external view returns (bool unlocked) {
         return _vault.isUnlocked();
     }
 
     /// @inheritdoc IVaultExplorer
-    function getNonzeroDeltaCount() external view returns (uint256) {
+    function getNonzeroDeltaCount() external view returns (uint256 nonzeroDeltaCount) {
         return _vault.getNonzeroDeltaCount();
     }
 
     /// @inheritdoc IVaultExplorer
-    function getTokenDelta(IERC20 token) external view returns (int256) {
+    function getTokenDelta(IERC20 token) external view returns (int256 tokenDelta) {
         return _vault.getTokenDelta(token);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getReservesOf(IERC20 token) external view returns (uint256) {
+    function getReservesOf(IERC20 token) external view returns (uint256 reserveAmount) {
         return _vault.getReservesOf(token);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getAddLiquidityCalledFlag(address pool) external view returns (bool) {
+    function getAddLiquidityCalledFlag(address pool) external view returns (bool liquidityAdded) {
         return _vault.getAddLiquidityCalledFlag(pool);
     }
 
@@ -87,7 +87,7 @@ contract VaultExplorer is IVaultExplorer {
     *******************************************************************************/
 
     /// @inheritdoc IVaultExplorer
-    function isPoolRegistered(address pool) external view returns (bool) {
+    function isPoolRegistered(address pool) external view returns (bool registered) {
         return _vault.isPoolRegistered(pool);
     }
 
@@ -96,27 +96,32 @@ contract VaultExplorer is IVaultExplorer {
     *******************************************************************************/
 
     /// @inheritdoc IVaultExplorer
-    function isPoolInitialized(address pool) external view returns (bool) {
+    function isPoolInitialized(address pool) external view returns (bool initialized) {
         return _vault.isPoolInitialized(pool);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getPoolTokens(address pool) external view returns (IERC20[] memory) {
+    function getPoolTokens(address pool) external view returns (IERC20[] memory tokens) {
         return _vault.getPoolTokens(pool);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getPoolTokenCountAndIndexOfToken(address pool, IERC20 token) external view returns (uint256, uint256) {
+    function getPoolTokenCountAndIndexOfToken(
+        address pool,
+        IERC20 token
+    ) external view returns (uint256 tokenCount, uint256 index) {
         return _vault.getPoolTokenCountAndIndexOfToken(pool, token);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getPoolTokenRates(address pool) external view returns (uint256[] memory, uint256[] memory) {
+    function getPoolTokenRates(
+        address pool
+    ) external view returns (uint256[] memory decimalScalingFactors, uint256[] memory tokenRates) {
         return _vault.getPoolTokenRates(pool);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getPoolData(address pool) external view returns (PoolData memory) {
+    function getPoolData(address pool) external view returns (PoolData memory poolData) {
         return _vault.getPoolData(pool);
     }
 
@@ -137,22 +142,22 @@ contract VaultExplorer is IVaultExplorer {
     }
 
     /// @inheritdoc IVaultExplorer
-    function getCurrentLiveBalances(address pool) external view returns (uint256[] memory) {
+    function getCurrentLiveBalances(address pool) external view returns (uint256[] memory balancesLiveScaled18) {
         return _vault.getCurrentLiveBalances(pool);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getPoolConfig(address pool) external view returns (PoolConfig memory) {
+    function getPoolConfig(address pool) external view returns (PoolConfig memory poolConfig) {
         return _vault.getPoolConfig(pool);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getHooksConfig(address pool) external view returns (HooksConfig memory) {
+    function getHooksConfig(address pool) external view returns (HooksConfig memory hooksConfig) {
         return _vault.getHooksConfig(pool);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getBptRate(address pool) external view returns (uint256) {
+    function getBptRate(address pool) external view returns (uint256 rate) {
         return _vault.getBptRate(pool);
     }
 
@@ -161,17 +166,17 @@ contract VaultExplorer is IVaultExplorer {
     *******************************************************************************/
 
     /// @inheritdoc IVaultExplorer
-    function totalSupply(address token) external view returns (uint256) {
+    function totalSupply(address token) external view returns (uint256 tokenTotalSupply) {
         return _vault.totalSupply(token);
     }
 
     /// @inheritdoc IVaultExplorer
-    function balanceOf(address token, address account) external view returns (uint256) {
+    function balanceOf(address token, address account) external view returns (uint256 tokenBalance) {
         return _vault.balanceOf(token, account);
     }
 
     /// @inheritdoc IVaultExplorer
-    function allowance(address token, address owner, address spender) external view returns (uint256) {
+    function allowance(address token, address owner, address spender) external view returns (uint256 tokenAllowance) {
         return _vault.allowance(token, owner, spender);
     }
 
@@ -180,12 +185,18 @@ contract VaultExplorer is IVaultExplorer {
     *******************************************************************************/
 
     /// @inheritdoc IVaultExplorer
-    function isPoolPaused(address pool) external view returns (bool) {
+    function isPoolPaused(address pool) external view returns (bool poolPaused) {
         return _vault.isPoolPaused(pool);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getPoolPausedState(address pool) external view returns (bool, uint32, uint32, address) {
+    function getPoolPausedState(
+        address pool
+    )
+        external
+        view
+        returns (bool poolPaused, uint32 poolPauseWindowEndTime, uint32 poolBufferPeriodEndTime, address pauseManager)
+    {
         return _vault.getPoolPausedState(pool);
     }
 
@@ -194,22 +205,22 @@ contract VaultExplorer is IVaultExplorer {
     *******************************************************************************/
 
     /// @inheritdoc IVaultExplorer
-    function getAggregateSwapFeeAmount(address pool, IERC20 token) external view returns (uint256) {
+    function getAggregateSwapFeeAmount(address pool, IERC20 token) external view returns (uint256 swapFeeAmount) {
         return _vault.getAggregateSwapFeeAmount(pool, token);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getAggregateYieldFeeAmount(address pool, IERC20 token) external view returns (uint256) {
+    function getAggregateYieldFeeAmount(address pool, IERC20 token) external view returns (uint256 yieldFeeAmount) {
         return _vault.getAggregateYieldFeeAmount(pool, token);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getStaticSwapFeePercentage(address pool) external view returns (uint256) {
+    function getStaticSwapFeePercentage(address pool) external view returns (uint256 swapFeePercentage) {
         return _vault.getStaticSwapFeePercentage(pool);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getPoolRoleAccounts(address pool) external view returns (PoolRoleAccounts memory) {
+    function getPoolRoleAccounts(address pool) external view returns (PoolRoleAccounts memory roleAccounts) {
         return _vault.getPoolRoleAccounts(pool);
     }
 
@@ -217,7 +228,7 @@ contract VaultExplorer is IVaultExplorer {
     function computeDynamicSwapFeePercentage(
         address pool,
         PoolSwapParams memory swapParams
-    ) external view returns (uint256 dynamicSwapFee) {
+    ) external view returns (uint256 dynamicSwapFeePercentage) {
         return _vault.computeDynamicSwapFeePercentage(pool, swapParams);
     }
 
@@ -226,7 +237,7 @@ contract VaultExplorer is IVaultExplorer {
     *******************************************************************************/
 
     /// @inheritdoc IVaultExplorer
-    function isPoolInRecoveryMode(address pool) external view returns (bool) {
+    function isPoolInRecoveryMode(address pool) external view returns (bool inRecoveryMode) {
         return _vault.isPoolInRecoveryMode(pool);
     }
 
@@ -235,12 +246,12 @@ contract VaultExplorer is IVaultExplorer {
     *******************************************************************************/
 
     /// @inheritdoc IVaultExplorer
-    function isQueryDisabled() external view returns (bool) {
+    function isQueryDisabled() external view returns (bool queryDisabled) {
         return _vault.isQueryDisabled();
     }
 
     /// @inheritdoc IVaultExplorer
-    function isQueryDisabledPermanently() external view returns (bool) {
+    function isQueryDisabledPermanently() external view returns (bool queryDisabledPermanently) {
         return _vault.isQueryDisabledPermanently();
     }
 
@@ -249,47 +260,47 @@ contract VaultExplorer is IVaultExplorer {
     ***************************************************************************/
 
     /// @inheritdoc IVaultExplorer
-    function getPauseWindowEndTime() external view returns (uint32) {
+    function getPauseWindowEndTime() external view returns (uint32 pauseWindowEndTime) {
         return _vault.getPauseWindowEndTime();
     }
 
     /// @inheritdoc IVaultExplorer
-    function getBufferPeriodDuration() external view returns (uint32) {
+    function getBufferPeriodDuration() external view returns (uint32 bufferPeriodDuration) {
         return _vault.getBufferPeriodDuration();
     }
 
     /// @inheritdoc IVaultExplorer
-    function getBufferPeriodEndTime() external view returns (uint32) {
+    function getBufferPeriodEndTime() external view returns (uint32 bufferPeriodEndTime) {
         return _vault.getBufferPeriodEndTime();
     }
 
     /// @inheritdoc IVaultExplorer
-    function getMinimumPoolTokens() external view returns (uint256) {
+    function getMinimumPoolTokens() external view returns (uint256 minTokens) {
         return _vault.getMinimumPoolTokens();
     }
 
     /// @inheritdoc IVaultExplorer
-    function getMaximumPoolTokens() external view returns (uint256) {
+    function getMaximumPoolTokens() external view returns (uint256 maxTokens) {
         return _vault.getMaximumPoolTokens();
     }
 
     /// @inheritdoc IVaultExplorer
-    function getMinimumTradeAmount() external view returns (uint256) {
+    function getMinimumTradeAmount() external view returns (uint256 minimumTradeAmount) {
         return _vault.getMinimumTradeAmount();
     }
 
     /// @inheritdoc IVaultExplorer
-    function getMinimumWrapAmount() external view returns (uint256) {
+    function getMinimumWrapAmount() external view returns (uint256 minimumWrapAmount) {
         return _vault.getMinimumWrapAmount();
     }
 
     /// @inheritdoc IVaultExplorer
-    function getPoolMinimumTotalSupply() external view returns (uint256) {
+    function getPoolMinimumTotalSupply() external view returns (uint256 poolMinimumTotalSupply) {
         return _vault.getPoolMinimumTotalSupply();
     }
 
     /// @inheritdoc IVaultExplorer
-    function getBufferMinimumTotalSupply() external view returns (uint256) {
+    function getBufferMinimumTotalSupply() external view returns (uint256 bufferMinimumTotalSupply) {
         return _vault.getBufferMinimumTotalSupply();
     }
 
@@ -298,12 +309,16 @@ contract VaultExplorer is IVaultExplorer {
     *******************************************************************************/
 
     /// @inheritdoc IVaultExplorer
-    function isVaultPaused() external view returns (bool) {
+    function isVaultPaused() external view returns (bool vaultPaused) {
         return _vault.isVaultPaused();
     }
 
     /// @inheritdoc IVaultExplorer
-    function getVaultPausedState() external view returns (bool, uint32, uint32) {
+    function getVaultPausedState()
+        external
+        view
+        returns (bool vaultPaused, uint32 vaultPauseWindowEndTime, uint32 vaultBufferPeriodEndTime)
+    {
         return _vault.getVaultPausedState();
     }
 
@@ -312,7 +327,9 @@ contract VaultExplorer is IVaultExplorer {
     *******************************************************************************/
 
     /// @inheritdoc IVaultExplorer
-    function getAggregateFeePercentages(address pool) external view returns (uint256, uint256) {
+    function getAggregateFeePercentages(
+        address pool
+    ) external view returns (uint256 aggregateSwapFeePercentage, uint256 aggregateYieldFeePercentage) {
         PoolConfig memory poolConfig = _vault.getPoolConfig(pool);
 
         return (poolConfig.aggregateSwapFeePercentage, poolConfig.aggregateYieldFeePercentage);
@@ -320,7 +337,7 @@ contract VaultExplorer is IVaultExplorer {
 
     /// @inheritdoc IVaultExplorer
     function collectAggregateFees(address pool) external {
-        return _vault.getProtocolFeeController().collectAggregateFees(pool);
+        _vault.getProtocolFeeController().collectAggregateFees(pool);
     }
 
     /*******************************************************************************
@@ -328,27 +345,32 @@ contract VaultExplorer is IVaultExplorer {
     *******************************************************************************/
 
     /// @inheritdoc IVaultExplorer
-    function areBuffersPaused() external view returns (bool) {
+    function areBuffersPaused() external view returns (bool buffersPaused) {
         return _vault.areBuffersPaused();
     }
 
     /// @inheritdoc IVaultExplorer
-    function getBufferAsset(IERC4626 wrappedToken) external view returns (address) {
+    function getBufferAsset(IERC4626 wrappedToken) external view returns (address underlyingToken) {
         return _vault.getBufferAsset(wrappedToken);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getBufferOwnerShares(IERC4626 token, address user) external view returns (uint256) {
-        return _vault.getBufferOwnerShares(token, user);
+    function getBufferOwnerShares(
+        IERC4626 wrappedToken,
+        address liquidityOwner
+    ) external view returns (uint256 ownerShares) {
+        return _vault.getBufferOwnerShares(wrappedToken, liquidityOwner);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getBufferTotalShares(IERC4626 token) external view returns (uint256) {
-        return _vault.getBufferTotalShares(token);
+    function getBufferTotalShares(IERC4626 wrappedToken) external view returns (uint256 bufferShares) {
+        return _vault.getBufferTotalShares(wrappedToken);
     }
 
     /// @inheritdoc IVaultExplorer
-    function getBufferBalance(IERC4626 token) external view returns (uint256, uint256) {
-        return _vault.getBufferBalance(token);
+    function getBufferBalance(
+        IERC4626 wrappedToken
+    ) external view returns (uint256 underlyingBalanceRaw, uint256 wrappedBalanceRaw) {
+        return _vault.getBufferBalance(wrappedToken);
     }
 }


### PR DESCRIPTION
# Description

Very minor issue I just noticed while querying the VaultExplorer. I wonder if we could specify the return for other functions to make devs life easier.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

