### PR TITLE
Fix addLiquidityUnbalancerToNested when one of the child pools receives 0 tokens

### DIFF
--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -502,8 +502,8 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                 );
 
                 if (childPoolAmountsEmpty == false) {
-                    // Add Liquidity will mint childTokens to the Vault, so the insertion of liquidity in the parent pool
-                    // will be a logic insertion, not a token transfer.
+                    // Add Liquidity will mint childTokens to the Vault, so the insertion of liquidity in the parent
+                    // pool will be a logic insertion, not a token transfer.
                     (, uint256 exactChildBptAmountOut, ) = _vault.addLiquidity(
                         AddLiquidityParams({
                             pool: childToken,

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -534,7 +534,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
             }
         }
 
-        (uint256[] memory parentPoolAmountsIn,) = _getPoolAmountsIn(parentPoolTokens, params.sender, params.wethIsEth);
+        (uint256[] memory parentPoolAmountsIn, ) = _getPoolAmountsIn(parentPoolTokens, params.sender, params.wethIsEth);
 
         // Adds liquidity to the parent pool, mints parentPool's BPT to the sender and checks the minimum BPT out.
         (, exactBptAmountOut, ) = _vault.addLiquidity(

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -495,32 +495,34 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                 // Token is a BPT, so add liquidity to the child pool.
 
                 IERC20[] memory childPoolTokens = _vault.getPoolTokens(childToken);
-                uint256[] memory childPoolAmountsIn = _getPoolAmountsIn(
+                (uint256[] memory childPoolAmountsIn, bool childPoolAmountsEmpty) = _getPoolAmountsIn(
                     childPoolTokens,
                     params.sender,
                     params.wethIsEth
                 );
 
-                // Add Liquidity will mint childTokens to the Vault, so the insertion of liquidity in the parent pool
-                // will be a logic insertion, not a token transfer.
-                (, uint256 exactChildBptAmountOut, ) = _vault.addLiquidity(
-                    AddLiquidityParams({
-                        pool: childToken,
-                        to: address(_vault),
-                        maxAmountsIn: childPoolAmountsIn,
-                        minBptAmountOut: 0,
-                        kind: params.kind,
-                        userData: params.userData
-                    })
-                );
+                if (!childPoolAmountsEmpty) {
+                    // Add Liquidity will mint childTokens to the Vault, so the insertion of liquidity in the parent pool
+                    // will be a logic insertion, not a token transfer.
+                    (, uint256 exactChildBptAmountOut, ) = _vault.addLiquidity(
+                        AddLiquidityParams({
+                            pool: childToken,
+                            to: address(_vault),
+                            maxAmountsIn: childPoolAmountsIn,
+                            minBptAmountOut: 0,
+                            kind: params.kind,
+                            userData: params.userData
+                        })
+                    );
 
-                // Sets the amount in of child BPT to the exactBptAmountOut of the child pool, so all the minted BPT
-                // will be added to the parent pool.
-                _currentSwapTokenInAmounts().tSet(childToken, exactChildBptAmountOut);
+                    // Sets the amount in of child BPT to the exactBptAmountOut of the child pool, so all the minted BPT
+                    // will be added to the parent pool.
+                    _currentSwapTokenInAmounts().tSet(childToken, exactChildBptAmountOut);
 
-                // Since the BPT will be inserted into the parent pool, gets the credit from the inserted BPTs in
-                // advance.
-                _vault.settle(IERC20(childToken), exactChildBptAmountOut);
+                    // Since the BPT will be inserted into the parent pool, gets the credit from the inserted BPTs in
+                    // advance.
+                    _vault.settle(IERC20(childToken), exactChildBptAmountOut);
+                }
             } else if (
                 _vault.isERC4626BufferInitialized(IERC4626(childToken)) &&
                 _currentSwapTokenInAmounts().tGet(childToken) == 0 // wrapped amount in was not specified
@@ -532,7 +534,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
             }
         }
 
-        uint256[] memory parentPoolAmountsIn = _getPoolAmountsIn(parentPoolTokens, params.sender, params.wethIsEth);
+        (uint256[] memory parentPoolAmountsIn,) = _getPoolAmountsIn(parentPoolTokens, params.sender, params.wethIsEth);
 
         // Adds liquidity to the parent pool, mints parentPool's BPT to the sender and checks the minimum BPT out.
         (, exactBptAmountOut, ) = _vault.addLiquidity(
@@ -575,8 +577,9 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
         IERC20[] memory poolTokens,
         address sender,
         bool wethIsEth
-    ) private returns (uint256[] memory poolAmountsIn) {
+    ) private returns (uint256[] memory poolAmountsIn, bool amountsEmpty) {
         poolAmountsIn = new uint256[](poolTokens.length);
+        amountsEmpty = true;
 
         for (uint256 j = 0; j < poolTokens.length; j++) {
             address poolToken = address(poolTokens[j]);
@@ -595,6 +598,10 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                 // the amount in of the child pool token to 0. If the same token appears more times, the amount in
                 // will be 0 for any other pool.
                 _currentSwapTokenInAmounts().tSet(poolToken, 0);
+            }
+
+            if (poolAmountsIn[j] > 0) {
+                amountsEmpty = false;
             }
         }
     }

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -501,7 +501,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                     params.wethIsEth
                 );
 
-                if (!childPoolAmountsEmpty) {
+                if (childPoolAmountsEmpty == false) {
                     // Add Liquidity will mint childTokens to the Vault, so the insertion of liquidity in the parent pool
                     // will be a logic insertion, not a token transfer.
                     (, uint256 exactChildBptAmountOut, ) = _vault.addLiquidity(

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	21.616
-InitCode	23.435
+Bytecode	21.675
+InitCode	23.493


### PR DESCRIPTION
# Description

CompositeLiquidityRouter's `addLiquidityUnbalancedNestedPool()` fails when someone tries to add liquidity to the parent pool, but don't add liquidity to the child pool (or one of the child pools).

This PR inserts a flag to make sure an empty child pool is ignored.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge
