### PR TITLE
Fix rounding of pvt helpers to match Vault's enum

### DIFF
--- a/pvt/helpers/src/math/stable.ts
+++ b/pvt/helpers/src/math/stable.ts
@@ -3,8 +3,8 @@ import { BigNumberish } from 'ethers';
 import { decimal, bn, fp, fromFp, toFp } from '../numbers';
 
 export enum Rounding {
-  ROUND_DOWN,
   ROUND_UP,
+  ROUND_DOWN,
 }
 
 export function calculateInvariant(


### PR DESCRIPTION
# Description

`pvt/helpers/src/math/stable.ts` file had a Rounding enum that did not match with VaultType.sol enum. This PR fixes it, to avoid any confusion.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge
