### PR TITLE
Cache v4 and checkout v4 in Github actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,11 +4,11 @@ runs:
   using: composite
   steps:
     - name: Install Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18.15
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache
       with:
         path: '**/node_modules'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   lint-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Lint
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: built-contracts
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
       - uses: actions/download-artifact@v4
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
       - uses: actions/download-artifact@v4
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
       - uses: actions/download-artifact@v4
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
       - uses: actions/download-artifact@v4
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
       - uses: actions/download-artifact@v4
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
       - uses: actions/download-artifact@v4
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
       - uses: actions/download-artifact@v4
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
       - uses: actions/download-artifact@v4
@@ -161,7 +161,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
       - uses: actions/download-artifact@v4
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
       - uses: actions/download-artifact@v4
@@ -189,7 +189,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
# Description

Update Github actions to use the latest versions of `cache` and `checkout`. V3 is not being deprecated yet, but this should kick that can down the road even further.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [x] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A