### PR TITLE
Fix Tau validations in ECLP Math

### DIFF
--- a/pkg/pool-gyro/contracts/lib/GyroECLPMath.sol
+++ b/pkg/pool-gyro/contracts/lib/GyroECLPMath.sol
@@ -92,8 +92,9 @@ library GyroECLPMath {
         IGyroECLPPool.EclpParams memory params,
         IGyroECLPPool.DerivedEclpParams memory derived
     ) internal pure {
-        require(derived.tauAlpha.y >= 0, DerivedTauAlphaYWrong());
-        require(derived.tauBeta.y >= 0, DerivedTauBetaYWrong());
+        // If tau is not within the range below, the pool math may be messed.
+        require(derived.tauAlpha.y > 0, DerivedTauAlphaYWrong());
+        require(derived.tauBeta.y > 0, DerivedTauBetaYWrong());
         require(derived.tauBeta.x > derived.tauAlpha.x, DerivedTauXWrong());
 
         int256 norm2;

--- a/pkg/pool-gyro/contracts/lib/GyroECLPMath.sol
+++ b/pkg/pool-gyro/contracts/lib/GyroECLPMath.sol
@@ -31,6 +31,9 @@ library GyroECLPMath {
     error DerivedTauAlphaNotNormalized();
     error DerivedTauBetaNotNormalized();
     error StretchingFactorWrong();
+    error DerivedTauAlphaYWrong();
+    error DerivedTauBetaYWrong();
+    error DerivedTauXWrong();
     error DerivedUWrong();
     error DerivedVWrong();
     error DerivedWWrong();
@@ -89,6 +92,10 @@ library GyroECLPMath {
         IGyroECLPPool.EclpParams memory params,
         IGyroECLPPool.DerivedEclpParams memory derived
     ) internal pure {
+        require(derived.tauAlpha.y >= 0, DerivedTauAlphaYWrong());
+        require(derived.tauBeta.y >= 0, DerivedTauBetaYWrong());
+        require(derived.tauBeta.x > derived.tauAlpha.x, DerivedTauXWrong());
+
         int256 norm2;
         norm2 = scalarProdXp(derived.tauAlpha, derived.tauAlpha);
 


### PR DESCRIPTION
# Description

Certora found some validations were missing for ECLP pool: 
* `tauAlpha.y > 0`
* `tauBeta.y > 0`
* `tauBeta.x > tauAlpha.x`

Without these validations, the pool math may be very messed, like the example below:

`int256 internal _tauBetaY =   -92846388265400743995957747409218517601;`

    alice usdc 400000000000000000000
    alice dai  400000000000000000000

    addLiquidityProportional ==============
    exactBptAmount 400000000000000000000
    amountsIn[0] 100000000000000000000
    amountsIn[1] 100000000000000000000

    alice usdc 300000000000000000000
    alice dai  300000000000000000000

    removeLiquiditySingleTokenExactIn ==============
    exactBptAmount 400000000000000000000
    amountOut usdc 703546354221259914550023
    alice usdc 703846354221259914550023
    alice dai  300000000000000000000

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge
