### PR TITLE
Stable math medusa test

### DIFF
--- a/pkg/solidity-utils/medusa.json
+++ b/pkg/solidity-utils/medusa.json
@@ -1,0 +1,76 @@
+{
+  "fuzzing": {
+    "workers": 10,
+    "workerResetLimit": 50,
+    "timeout": 0,
+    "testLimit": 100000,
+    "shrinkLimit": 5000,
+    "callSequenceLength": 10,
+    "corpusDirectory": "medusa-corpus",
+    "coverageEnabled": true,
+    "targetContracts": ["StableMathInvariantMedusaTest"],
+    "predeployedContracts": {},
+    "targetContractsBalances": [],
+    "constructorArgs": {},
+    "deployerAddress": "0x30000",
+    "senderAddresses": ["0x10000", "0x20000", "0x30000"],
+    "blockNumberDelayMax": 60480,
+    "blockTimestampDelayMax": 604800,
+    "blockGasLimit": 1250000000,
+    "transactionGasLimit": 125000000,
+    "testing": {
+      "stopOnFailedTest": false,
+      "stopOnFailedContractMatching": false,
+      "stopOnNoTests": true,
+      "testAllContracts": false,
+      "traceAll": false,
+      "assertionTesting": {
+        "enabled": true,
+        "testViewMethods": false,
+        "panicCodeConfig": {
+          "failOnCompilerInsertedPanic": false,
+          "failOnAssertion": true,
+          "failOnArithmeticUnderflow": false,
+          "failOnDivideByZero": false,
+          "failOnEnumTypeConversionOutOfBounds": false,
+          "failOnIncorrectStorageAccess": false,
+          "failOnPopEmptyArray": false,
+          "failOnOutOfBoundsArrayAccess": false,
+          "failOnAllocateTooMuchMemory": false,
+          "failOnCallUninitializedVariable": false
+        }
+      },
+      "propertyTesting": {
+        "enabled": true,
+        "testPrefixes": ["property_"]
+      },
+      "optimizationTesting": {
+        "enabled": true,
+        "testPrefixes": ["optimize_"]
+      },
+      "targetFunctionSignatures": [],
+      "excludeFunctionSignatures": []
+    },
+    "chainConfig": {
+      "codeSizeCheckDisabled": true,
+      "cheatCodes": {
+        "cheatCodesEnabled": true,
+        "enableFFI": true
+      }
+    }
+  },
+  "compilation": {
+    "platform": "crytic-compile",
+    "platformConfig": {
+      "target": ".",
+      "solcVersion": "",
+      "exportDirectory": "",
+      "args": ["--foundry-out-directory=forge-artifacts", "--foundry-compile-all"]
+    }
+  },
+  "logging": {
+    "level": "info",
+    "logDirectory": "",
+    "noColor": false
+  }
+}

--- a/pkg/solidity-utils/package.json
+++ b/pkg/solidity-utils/package.json
@@ -28,6 +28,7 @@
     "test:hardhat": "hardhat test",
     "test:forge": "forge test --no-match-test \"FFI\" -vvv",
     "test:stress": "FOUNDRY_PROFILE=intense forge test --ffi -vvv",
+    "test:medusa": "medusa fuzz --config medusa.json",
     "coverage": "./coverage.sh forge",
     "coverage:hardhat": "./coverage.sh hardhat",
     "coverage:all": "./coverage.sh all",

--- a/pkg/solidity-utils/test/foundry/fuzz/StableMathInvariant.medusa.sol
+++ b/pkg/solidity-utils/test/foundry/fuzz/StableMathInvariant.medusa.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IBasePool } from "@balancer-labs/v3-interfaces/contracts/vault/IBasePool.sol";
+import { Rounding } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+
+import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
+import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
+
+import { BaseMedusaTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseMedusaTest.sol";
+import { Rounding } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+
+import { StableMathMock } from "../../../contracts/test/StableMathMock.sol";
+
+contract StableMathInvariantMedusaTest is BaseMedusaTest {
+    uint256 constant MIN_TOKENS = 2;
+    uint256 constant MAX_TOKENS = 8;
+    uint256 constant DEFAULT_AMP_FACTOR = 200;
+
+    StableMathMock public stableMath;
+
+    uint256 tokenCount;
+    uint256[] balances;
+
+    int256 internal initInvariant;
+    int256 internal currentInvariant;
+
+    constructor() BaseMedusaTest() {
+        stableMath = new StableMathMock();
+        currentInvariant = type(int256).max;
+    }
+
+    function optimize_currentInvariant() public view returns (int256) {
+        return -int256(currentInvariant);
+    }
+
+    function property_currentInvariant() public returns (bool) {
+        return currentInvariant >= initInvariant;
+    }
+
+    function initBalances(uint256 tokenCountRaw, uint256[8] memory balancesRaw) external {
+        uint256 prevTokenCount = tokenCount;
+        uint256[] memory prevBalances = balances;
+        delete balances;
+
+        tokenCount = bound(tokenCountRaw, MIN_TOKENS, MAX_TOKENS);
+
+        for (uint256 i = 0; i < tokenCount; i++) {
+            balances.push(bound(balancesRaw[i], 1, type(uint128).max));
+            emit Debug("initBalances", balancesRaw[i]);
+        }
+
+        try stableMath.computeInvariant(DEFAULT_AMP_FACTOR, balances, Rounding.ROUND_DOWN) returns (uint256 invariant) {
+            initInvariant = int256(invariant);
+            currentInvariant = initInvariant;
+        } catch {
+            tokenCount = prevTokenCount;
+            balances = prevBalances;
+        }
+    }
+
+    function addDeltaToBalances(uint256 deltaCount, uint256[8] memory indexes, uint256[8] memory deltas) external {
+        deltaCount = bound(deltaCount, 1, tokenCount);
+
+        uint256[] memory newBalances = balances;
+        for (uint256 i = 0; i < deltaCount; i++) {
+            uint256 tokenIndex = bound(indexes[i], 0, tokenCount - 1);
+            uint256 delta = bound(deltas[i], 0, type(uint128).max - newBalances[tokenIndex]);
+            newBalances[tokenIndex] += delta;
+            emit Debug("delta", delta);
+        }
+
+        try stableMath.computeInvariant(DEFAULT_AMP_FACTOR, balances, Rounding.ROUND_DOWN) returns (uint256 invariant) {
+            currentInvariant = int256(invariant);
+        } catch {}
+    }
+}


### PR DESCRIPTION
# Description

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

Added  a medusa test for stable mathto check that `computeInvariant(balances) `<= `computeInvariant(balances + deltas)
`

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [X] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
