### PR TITLE
Encapsulation of initialization variables and minor refactoring of BaseTest

### DIFF
--- a/pkg/pool-weighted/test/foundry/BigWeightedPool.t.sol
+++ b/pkg/pool-weighted/test/foundry/BigWeightedPool.t.sol
@@ -55,8 +55,8 @@ contract BigWeightedPoolTest is WeightedPoolContractsDeployer, BasePoolTest {
         for (uint256 i = 0; i < numTokens; ++i) {
             // Use all 18-decimal tokens, for simplicity.
             bigPoolTokens[i] = createERC20(string.concat("TKN", Strings.toString(i)), 18);
-            ERC20TestToken(address(bigPoolTokens[i])).mint(lp, defaultBalance);
-            ERC20TestToken(address(bigPoolTokens[i])).mint(bob, defaultBalance);
+            ERC20TestToken(address(bigPoolTokens[i])).mint(lp, defaultAccountBalance());
+            ERC20TestToken(address(bigPoolTokens[i])).mint(bob, defaultAccountBalance());
             weights[i] = 1e18 / numTokens;
         }
 

--- a/pkg/pool-weighted/test/foundry/WeightedPoolLimits.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedPoolLimits.t.sol
@@ -332,7 +332,7 @@ contract WeightedPoolLimitsTest is BaseVaultTest, WeightedPoolContractsDeployer 
     }
 
     function _testAddLiquidityUnbalanced(uint256 swapFeePercentage) public {
-        uint256[] memory maxAmountsIn = [defaultBalance, defaultBalance].toMemoryArray();
+        uint256[] memory maxAmountsIn = [defaultAccountBalance(), defaultAccountBalance()].toMemoryArray();
         // Enlarge the pool so that adding liquidity unbalanced does not hit the invariant ratio limit.
         uint256 currentBPTSupply = IERC20(weightedPool).totalSupply();
         vm.prank(alice);

--- a/pkg/solidity-utils/test/foundry/utils/BaseTest.sol
+++ b/pkg/solidity-utils/test/foundry/utils/BaseTest.sol
@@ -19,6 +19,8 @@ import { WETHTestToken } from "../../../contracts/test/WETHTestToken.sol";
 abstract contract BaseTest is Test, GasSnapshot {
     using CastingHelpers for *;
 
+    uint256 internal constant DEFAULT_BALANCE = 1e9 * 1e18;
+
     // Reasonable block.timestamp `MAY_1_2023`
     uint32 internal constant START_TIMESTAMP = 1_682_899_200;
 
@@ -65,9 +67,12 @@ abstract contract BaseTest is Test, GasSnapshot {
     // List of all ERC4626 tokens
     IERC4626[] internal erc4626Tokens;
 
-    // Default balance for accounts
-    uint256 internal defaultBalance = 1e9 * 1e18;
+    bool private _initialized;
 
+    // Default balance for accounts
+    uint256 private _defaultAccountBalance = DEFAULT_BALANCE;
+
+    // ------------------------------ Initialization ------------------------------
     function setUp() public virtual {
         // Set timestamp only if testing locally
         if (block.chainid == 31337) {
@@ -75,6 +80,29 @@ abstract contract BaseTest is Test, GasSnapshot {
             vm.warp(START_TIMESTAMP);
         }
 
+        _initTokens();
+        _initAccounts();
+
+        // Must mock rates after giving wrapped tokens to users, but before creating pools and initializing buffers.
+        mockERC4626TokenRates();
+    }
+
+    function setDefaultAccountBalance(uint256 balance) internal {
+        if (_initialized) {
+            revert("Cannot change default account balance after initialization");
+        }
+        _defaultAccountBalance = balance;
+    }
+
+    function defaultAccountBalance() internal view returns (uint256) {
+        return _defaultAccountBalance;
+    }
+
+    function isInitialized() internal view returns (bool) {
+        return _initialized;
+    }
+
+    function _initTokens() private {
         // Deploy the base test contracts.
         dai = createERC20("DAI", 18);
         // "USDC" is deliberately 18 decimals to test one thing at a time.
@@ -100,7 +128,9 @@ abstract contract BaseTest is Test, GasSnapshot {
         erc4626Tokens.push(waDAI);
         erc4626Tokens.push(waWETH);
         erc4626Tokens.push(waUSDC);
+    }
 
+    function _initAccounts() private {
         // Create users for testing.
         (admin, adminKey) = createUser("admin");
         (lp, lpKey) = createUser("lp");
@@ -111,9 +141,6 @@ abstract contract BaseTest is Test, GasSnapshot {
         (brokeNonPay, brokeUserKey) = makeAddrAndKey("broke");
         broke = payable(brokeNonPay);
         vm.label(broke, "broke");
-
-        // Must mock rates after giving wrapped tokens to users, but before creating pools and initializing buffers.
-        mockERC4626TokenRates();
 
         // Fill the users list
         users.push(admin);
@@ -128,14 +155,16 @@ abstract contract BaseTest is Test, GasSnapshot {
         userKeys.push(brokeUserKey);
     }
 
+    // ------------------------------ Helpers ------------------------------
+
     /**
      * @notice Manipulate rates of ERC4626 tokens.
      * @dev It's important to not have a 1:1 rate when testing ERC4626 tokens, so we can differentiate between
      * wrapped and underlying amounts. For certain tests, we may need to override these rates for simplicity.
      */
     function mockERC4626TokenRates() internal virtual {
-        waDAI.inflateUnderlyingOrWrapped(0, 6 * defaultBalance);
-        waUSDC.inflateUnderlyingOrWrapped(23 * defaultBalance, 0);
+        waDAI.inflateUnderlyingOrWrapped(0, 6 * _defaultAccountBalance);
+        waUSDC.inflateUnderlyingOrWrapped(23 * _defaultAccountBalance, 0);
     }
 
     function getSortedIndexes(
@@ -188,27 +217,27 @@ abstract contract BaseTest is Test, GasSnapshot {
     function createUser(string memory name) internal returns (address payable, uint256) {
         (address user, uint256 key) = makeAddrAndKey(name);
         vm.label(user, name);
-        vm.deal(payable(user), defaultBalance);
+        vm.deal(payable(user), _defaultAccountBalance);
 
         for (uint256 i = 0; i < tokens.length; ++i) {
-            deal(address(tokens[i]), user, defaultBalance);
+            deal(address(tokens[i]), user, _defaultAccountBalance);
         }
 
         for (uint256 i = 0; i < erc4626Tokens.length; ++i) {
             // Give underlying tokens to the user, for depositing in the wrapped token.
             if (erc4626Tokens[i].asset() == address(weth)) {
-                vm.deal(user, user.balance + defaultBalance);
+                vm.deal(user, user.balance + _defaultAccountBalance);
 
                 vm.prank(user);
-                weth.deposit{ value: defaultBalance }();
+                weth.deposit{ value: _defaultAccountBalance }();
             } else {
-                ERC20TestToken(erc4626Tokens[i].asset()).mint(user, defaultBalance);
+                ERC20TestToken(erc4626Tokens[i].asset()).mint(user, _defaultAccountBalance);
             }
 
             // Deposit underlying to mint wrapped tokens to the user.
             vm.startPrank(user);
-            IERC20(erc4626Tokens[i].asset()).approve(address(erc4626Tokens[i]), defaultBalance);
-            erc4626Tokens[i].deposit(defaultBalance, user);
+            IERC20(erc4626Tokens[i].asset()).approve(address(erc4626Tokens[i]), _defaultAccountBalance);
+            erc4626Tokens[i].deposit(_defaultAccountBalance, user);
             vm.stopPrank();
         }
 

--- a/pkg/vault/test/foundry/DynamicFeePoolTest.t.sol
+++ b/pkg/vault/test/foundry/DynamicFeePoolTest.t.sol
@@ -30,7 +30,8 @@ contract DynamicFeePoolTest is BaseVaultTest {
     uint256 internal usdcIdx;
 
     function setUp() public virtual override {
-        defaultBalance = 1e10 * 1e18;
+        setDefaultAccountBalance(1e10 * 1e18);
+
         // We will use min trade amount in this test.
         vaultMockMinTradeAmount = PRODUCTION_MIN_TRADE_AMOUNT;
 

--- a/pkg/vault/test/foundry/LiquidityApproximation.t.sol
+++ b/pkg/vault/test/foundry/LiquidityApproximation.t.sol
@@ -89,7 +89,8 @@ contract LiquidityApproximationTest is BaseVaultTest {
 
     function setUp() public virtual override {
         poolInitAmount = 1e9 * 1e18;
-        defaultBalance = 1e10 * 1e18;
+        setDefaultAccountBalance(1e10 * 1e18);
+
         BaseVaultTest.setUp();
 
         approveForPool(IERC20(liquidityPool));
@@ -226,7 +227,7 @@ contract LiquidityApproximationTest is BaseVaultTest {
 
         assertEq(dai.balanceOf(alice), dai.balanceOf(bob), "Bob and Alice DAI balances are not equal");
 
-        if (usdc.balanceOf(alice) <= defaultBalance) {
+        if (usdc.balanceOf(alice) <= defaultAccountBalance()) {
             // No amount out (trade too small, rounding ate the difference).
             // Dai balances are the same, so we just check that the USDC balances are better for Bob (direct swap).
             // There's no point in continuing the test in this case.
@@ -234,8 +235,8 @@ contract LiquidityApproximationTest is BaseVaultTest {
             return;
         }
 
-        uint256 aliceAmountOut = usdc.balanceOf(alice) - defaultBalance;
-        uint256 bobAmountOut = usdc.balanceOf(bob) - defaultBalance;
+        uint256 aliceAmountOut = usdc.balanceOf(alice) - defaultAccountBalance();
+        uint256 bobAmountOut = usdc.balanceOf(bob) - defaultAccountBalance();
         uint256 bobToAliceRatio = bobAmountOut.divDown(aliceAmountOut);
 
         // Early returns:
@@ -267,7 +268,7 @@ contract LiquidityApproximationTest is BaseVaultTest {
 
         assertEq(dai.balanceOf(alice), dai.balanceOf(bob), "Bob and Alice DAI balances are not equal");
 
-        if (usdc.balanceOf(alice) <= defaultBalance) {
+        if (usdc.balanceOf(alice) <= defaultAccountBalance()) {
             // No amount out (trade too small, rounding ate the difference).
             // Dai balances are the same, so we just check that the USDC balances are better for Bob (direct swap).
             // There's no point in continuing the test in this case.
@@ -275,8 +276,8 @@ contract LiquidityApproximationTest is BaseVaultTest {
             return;
         }
 
-        uint256 aliceAmountOut = usdc.balanceOf(alice) - defaultBalance;
-        uint256 bobAmountOut = usdc.balanceOf(bob) - defaultBalance;
+        uint256 aliceAmountOut = usdc.balanceOf(alice) - defaultAccountBalance();
+        uint256 bobAmountOut = usdc.balanceOf(bob) - defaultAccountBalance();
         uint256 bobToAliceRatio = bobAmountOut.divDown(aliceAmountOut);
 
         uint256 liquidityTaxPercentage = liquidityPercentageDelta.mulDown(swapFeePercentage);
@@ -416,7 +417,7 @@ contract LiquidityApproximationTest is BaseVaultTest {
             address(swapPool),
             dai,
             usdc,
-            defaultBalance - dai.balanceOf(alice),
+            defaultAccountBalance() - dai.balanceOf(alice),
             0,
             MAX_UINT256,
             false,
@@ -465,7 +466,7 @@ contract LiquidityApproximationTest is BaseVaultTest {
             address(swapPool),
             dai,
             usdc,
-            defaultBalance - dai.balanceOf(alice),
+            defaultAccountBalance() - dai.balanceOf(alice),
             0,
             MAX_UINT256,
             false,
@@ -517,7 +518,7 @@ contract LiquidityApproximationTest is BaseVaultTest {
             address(swapPool),
             dai,
             usdc,
-            defaultBalance - dai.balanceOf(alice),
+            defaultAccountBalance() - dai.balanceOf(alice),
             0,
             MAX_UINT256,
             false,
@@ -570,7 +571,7 @@ contract LiquidityApproximationTest is BaseVaultTest {
             address(swapPool),
             dai,
             usdc,
-            defaultBalance - dai.balanceOf(alice),
+            defaultAccountBalance() - dai.balanceOf(alice),
             0,
             MAX_UINT256,
             false,

--- a/pkg/vault/test/foundry/Router.t.sol
+++ b/pkg/vault/test/foundry/Router.t.sol
@@ -224,7 +224,7 @@ contract RouterTest is BaseVaultTest {
         );
 
         // Weth was deposited, pool tokens were minted to Alice.
-        assertEq(weth.balanceOf(alice), defaultBalance - ethAmountIn, "Wrong WETH balance");
+        assertEq(weth.balanceOf(alice), defaultAccountBalance() - ethAmountIn, "Wrong WETH balance");
         assertEq(wethPoolNoInit.balanceOf(alice), bptAmountOut, "Wrong WETH pool balance");
         assertGt(bptAmountOut, 0, "bptAmountOut is zero");
     }
@@ -253,7 +253,7 @@ contract RouterTest is BaseVaultTest {
         );
 
         // Weth was deposited, pool tokens were minted to Alice.
-        assertEq(alice.balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
+        assertEq(alice.balance, defaultAccountBalance() - ethAmountIn, "Wrong ETH balance");
         assertEq(wethPoolNoInit.balanceOf(alice), bptAmountOut, "Wrong WETH pool balance");
         assertGt(bptAmountOut, 0, "bptAmountOut is zero");
     }
@@ -263,7 +263,7 @@ contract RouterTest is BaseVaultTest {
 
         bool wethIsEth = true;
         vm.prank(alice);
-        bptAmountOut = router.initialize{ value: defaultBalance }(
+        bptAmountOut = router.initialize{ value: defaultAccountBalance() }(
             address(wethPoolNoInit),
             wethDaiTokens,
             wethDaiAmountsIn,
@@ -273,7 +273,7 @@ contract RouterTest is BaseVaultTest {
         );
 
         // Weth was deposited, excess ETH was returned, pool tokens were minted to Alice.
-        assertEq(alice.balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
+        assertEq(alice.balance, defaultAccountBalance() - ethAmountIn, "Wrong ETH balance");
         assertEq(wethPoolNoInit.balanceOf(alice), bptAmountOut, "Wrong WETH pool balance");
         assertGt(bptAmountOut, 0, "bptAmountOut is zero");
     }
@@ -294,7 +294,7 @@ contract RouterTest is BaseVaultTest {
         router.addLiquidityCustom(address(wethPool), wethDaiAmountsIn, bptAmountOut, false, bytes(""));
 
         // Weth was deposited, pool tokens were minted to Alice.
-        assertEq(defaultBalance - weth.balanceOf(alice), ethAmountIn, "Wrong ETH balance");
+        assertEq(defaultAccountBalance() - weth.balanceOf(alice), ethAmountIn, "Wrong ETH balance");
         assertEq(wethPool.balanceOf(alice), bptAmountOut, "Wrong WETH pool balance");
     }
 
@@ -320,7 +320,7 @@ contract RouterTest is BaseVaultTest {
         );
 
         // Weth was deposited, pool tokens were minted to Alice.
-        assertEq(alice.balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
+        assertEq(alice.balance, defaultAccountBalance() - ethAmountIn, "Wrong ETH balance");
         assertEq(wethPool.balanceOf(alice), bptAmountOut, "Wrong WETH pool balance");
     }
 
@@ -328,7 +328,7 @@ contract RouterTest is BaseVaultTest {
         checkAddLiquidityPreConditions();
 
         vm.prank(alice);
-        router.addLiquidityCustom{ value: defaultBalance }(
+        router.addLiquidityCustom{ value: defaultAccountBalance() }(
             address(wethPool),
             wethDaiAmountsIn,
             bptAmountOut,
@@ -337,7 +337,7 @@ contract RouterTest is BaseVaultTest {
         );
 
         // Weth was deposited, excess was returned, pool tokens were minted to Alice.
-        assertEq(alice.balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
+        assertEq(alice.balance, defaultAccountBalance() - ethAmountIn, "Wrong ETH balance");
         assertEq(wethPool.balanceOf(alice), bptAmountOut, "Wrong WETH pool balance");
     }
 
@@ -361,9 +361,9 @@ contract RouterTest is BaseVaultTest {
         router.removeLiquidityCustom(address(wethPool), exactBptAmount, wethDaiAmountsIn, wethIsEth, bytes(""));
 
         // Liquidity position was removed, Alice gets weth back.
-        assertEq(weth.balanceOf(alice), defaultBalance + ethAmountIn, "Wrong WETH balance");
+        assertEq(weth.balanceOf(alice), defaultAccountBalance() + ethAmountIn, "Wrong WETH balance");
         assertEq(wethPool.balanceOf(alice), 0, "WETH pool balance is > 0");
-        assertEq(alice.balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
+        assertEq(alice.balance, defaultAccountBalance() - ethAmountIn, "Wrong ETH balance");
     }
 
     function testRemoveLiquidityNative() public {
@@ -391,7 +391,7 @@ contract RouterTest is BaseVaultTest {
         );
 
         // Liquidity position was removed, Alice gets ETH back.
-        assertEq(weth.balanceOf(alice), defaultBalance, "Wrong WETH balance");
+        assertEq(weth.balanceOf(alice), defaultAccountBalance(), "Wrong WETH balance");
         assertEq(wethPool.balanceOf(alice), 0, "WETH pool balance is > 0");
         assertEq(alice.balance, aliceNativeBalanceBefore + ethAmountIn, "Wrong ETH balance");
     }
@@ -438,8 +438,8 @@ contract RouterTest is BaseVaultTest {
     }
 
     function testRemoveLiquidityRecovery__Fuzz(uint256 amountIn1, uint256 amountIn2, uint256 exitPercentage) public {
-        amountIn1 = bound(amountIn1, 1e18, defaultBalance); // 1 to max user balance
-        amountIn2 = bound(amountIn2, 1e18, defaultBalance); // 1 to max user balance
+        amountIn1 = bound(amountIn1, 1e18, defaultAccountBalance()); // 1 to max user balance
+        amountIn2 = bound(amountIn2, 1e18, defaultAccountBalance()); // 1 to max user balance
         exitPercentage = bound(exitPercentage, 0, FixedPoint.ONE); // 0 to 100%
 
         // Add initial liquidity.
@@ -551,7 +551,7 @@ contract RouterTest is BaseVaultTest {
     }
 
     function testSwapExactInWETH() public {
-        require(weth.balanceOf(alice) == defaultBalance, "Precondition: wrong WETH balance");
+        require(weth.balanceOf(alice) == defaultAccountBalance(), "Precondition: wrong WETH balance");
 
         bool wethIsEth = false;
 
@@ -567,12 +567,12 @@ contract RouterTest is BaseVaultTest {
             bytes("")
         );
 
-        assertEq(weth.balanceOf(alice), defaultBalance - ethAmountIn, "Wrong WETH balance");
-        assertEq(dai.balanceOf(alice), defaultBalance + outputTokenAmount, "Wrong DAI balance");
+        assertEq(weth.balanceOf(alice), defaultAccountBalance() - ethAmountIn, "Wrong WETH balance");
+        assertEq(dai.balanceOf(alice), defaultAccountBalance() + outputTokenAmount, "Wrong DAI balance");
     }
 
     function testSwapExactOutWETH() public {
-        require(weth.balanceOf(alice) == defaultBalance, "Precondition: wrong WETH balance");
+        require(weth.balanceOf(alice) == defaultAccountBalance(), "Precondition: wrong WETH balance");
         bool wethIsEth = false;
 
         vm.prank(alice);
@@ -587,13 +587,13 @@ contract RouterTest is BaseVaultTest {
             bytes("")
         );
 
-        assertEq(weth.balanceOf(alice), defaultBalance - outputTokenAmount, "Wrong WETH balance");
-        assertEq(dai.balanceOf(alice), defaultBalance + daiAmountOut, "Wrong DAI balance");
+        assertEq(weth.balanceOf(alice), defaultAccountBalance() - outputTokenAmount, "Wrong WETH balance");
+        assertEq(dai.balanceOf(alice), defaultAccountBalance() + daiAmountOut, "Wrong DAI balance");
     }
 
     function testSwapExactInNative() public {
-        require(weth.balanceOf(alice) == defaultBalance, "Precondition: wrong WETH balance");
-        require(alice.balance == defaultBalance, "Precondition: wrong ETH balance");
+        require(weth.balanceOf(alice) == defaultAccountBalance(), "Precondition: wrong WETH balance");
+        require(alice.balance == defaultAccountBalance(), "Precondition: wrong ETH balance");
 
         bool wethIsEth = true;
 
@@ -609,14 +609,14 @@ contract RouterTest is BaseVaultTest {
             bytes("")
         );
 
-        assertEq(weth.balanceOf(alice), defaultBalance, "Wrong WETH balance");
-        assertEq(dai.balanceOf(alice), defaultBalance + ethAmountIn, "Wrong DAI balance");
-        assertEq(alice.balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
+        assertEq(weth.balanceOf(alice), defaultAccountBalance(), "Wrong WETH balance");
+        assertEq(dai.balanceOf(alice), defaultAccountBalance() + ethAmountIn, "Wrong DAI balance");
+        assertEq(alice.balance, defaultAccountBalance() - ethAmountIn, "Wrong ETH balance");
     }
 
     function testSwapExactOutNative() public {
-        require(weth.balanceOf(alice) == defaultBalance, "Precondition: wrong WETH balance");
-        require(alice.balance == defaultBalance, "Precondition: wrong ETH balance");
+        require(weth.balanceOf(alice) == defaultAccountBalance(), "Precondition: wrong WETH balance");
+        require(alice.balance == defaultAccountBalance(), "Precondition: wrong ETH balance");
 
         bool wethIsEth = true;
 
@@ -632,19 +632,19 @@ contract RouterTest is BaseVaultTest {
             bytes("")
         );
 
-        assertEq(weth.balanceOf(alice), defaultBalance, "Wrong WETH balance");
-        assertEq(dai.balanceOf(alice), defaultBalance + daiAmountOut, "Wrong DAI balance");
-        assertEq(alice.balance, defaultBalance - daiAmountOut, "Wrong ETH balance");
+        assertEq(weth.balanceOf(alice), defaultAccountBalance(), "Wrong WETH balance");
+        assertEq(dai.balanceOf(alice), defaultAccountBalance() + daiAmountOut, "Wrong DAI balance");
+        assertEq(alice.balance, defaultAccountBalance() - daiAmountOut, "Wrong ETH balance");
     }
 
     function testSwapNativeExcessEth() public {
-        require(weth.balanceOf(alice) == defaultBalance, "Precondition: wrong WETH balance");
-        require(alice.balance == defaultBalance, "Precondition: wrong ETH balance");
+        require(weth.balanceOf(alice) == defaultAccountBalance(), "Precondition: wrong WETH balance");
+        require(alice.balance == defaultAccountBalance(), "Precondition: wrong ETH balance");
 
         bool wethIsEth = true;
 
         vm.startPrank(alice);
-        router.swapSingleTokenExactIn{ value: defaultBalance }(
+        router.swapSingleTokenExactIn{ value: defaultAccountBalance() }(
             address(wethPool),
             weth,
             dai,
@@ -656,9 +656,9 @@ contract RouterTest is BaseVaultTest {
         );
 
         // Only ethAmountIn is sent to the Router.
-        assertEq(weth.balanceOf(alice), defaultBalance, "Wrong WETH balance");
-        assertEq(dai.balanceOf(alice), defaultBalance + ethAmountIn, "Wrong DAI balance");
-        assertEq(alice.balance, defaultBalance - ethAmountIn, "Wrong ETH balance");
+        assertEq(weth.balanceOf(alice), defaultAccountBalance(), "Wrong WETH balance");
+        assertEq(dai.balanceOf(alice), defaultAccountBalance() + ethAmountIn, "Wrong DAI balance");
+        assertEq(alice.balance, defaultAccountBalance() - ethAmountIn, "Wrong ETH balance");
     }
 
     function testGetSingleInputArray() public {
@@ -683,13 +683,13 @@ contract RouterTest is BaseVaultTest {
     }
 
     function checkRemoveLiquidityPreConditions() internal view {
-        require(weth.balanceOf(alice) == defaultBalance, "Precondition: Wrong WETH balance");
+        require(weth.balanceOf(alice) == defaultAccountBalance(), "Precondition: Wrong WETH balance");
         require(wethPool.balanceOf(alice) == bptAmountOut, "Precondition: Wrong weth pool balance");
     }
 
     function checkAddLiquidityPreConditions() internal view {
-        require(weth.balanceOf(alice) == defaultBalance, "Precondition: Wrong WETH balance");
-        require(alice.balance == defaultBalance, "Precondition: Wrong ETH balance");
+        require(weth.balanceOf(alice) == defaultAccountBalance(), "Precondition: Wrong WETH balance");
+        require(alice.balance == defaultAccountBalance(), "Precondition: Wrong ETH balance");
         require(wethPool.balanceOf(alice) == 0, "Precondition: Wrong weth pool balance");
     }
 }

--- a/pkg/vault/test/foundry/UnbalancedLiquidityBounds.t.sol
+++ b/pkg/vault/test/foundry/UnbalancedLiquidityBounds.t.sol
@@ -51,7 +51,7 @@ contract UnbalancedLiquidityBounds is BaseVaultTest {
         // This will unbalance the pool; adding liquidity will result in different proportions being added on each run.
         vault.manualSetPoolBalances(pool, initialBalances, initialBalances);
 
-        uint256[] memory maxAmountsIn = [defaultBalance, defaultBalance].toMemoryArray();
+        uint256[] memory maxAmountsIn = [defaultAccountBalance(), defaultAccountBalance()].toMemoryArray();
 
         // Strict invariant ratio
         PoolMockFlexibleInvariantRatio(pool).setMinimumInvariantRatio(FixedPoint.ONE);
@@ -91,7 +91,7 @@ contract UnbalancedLiquidityBounds is BaseVaultTest {
         // `12 * defaultAmount`, so the invariant ratio (new / old) will be FP(6).
         uint256 bptAmountOut = defaultAmount * 10;
         uint256 maxInvariantRatio = FixedPoint.ONE * 2;
-        uint256 maxAmountIn = defaultBalance;
+        uint256 maxAmountIn = defaultAccountBalance();
 
         // Reasonable invariant ratio
         PoolMockFlexibleInvariantRatio(pool).setMaximumInvariantRatio(maxInvariantRatio);

--- a/pkg/vault/test/foundry/VaultSwap.t.sol
+++ b/pkg/vault/test/foundry/VaultSwap.t.sol
@@ -487,7 +487,11 @@ contract VaultSwapTest is BaseVaultTest {
         assertEq(0, feeAmounts[daiIdx], "Protocol fees are not zero");
 
         // Admin received protocol fees.
-        assertEq(usdc.balanceOf(admin) - defaultBalance, protocolSwapFeeExactIn, "Protocol fees not collected");
+        assertEq(
+            usdc.balanceOf(admin) - defaultAccountBalance(),
+            protocolSwapFeeExactIn,
+            "Protocol fees not collected"
+        );
     }
 
     function reentrancyHook() public {

--- a/pkg/vault/test/foundry/utils/BasePoolTest.sol
+++ b/pkg/vault/test/foundry/utils/BasePoolTest.sol
@@ -72,7 +72,7 @@ abstract contract BasePoolTest is BaseVaultTest {
         for (uint256 i = 0; i < poolTokens.length; ++i) {
             // Tokens are transferred from lp.
             assertEq(
-                defaultBalance - poolTokens[i].balanceOf(lp),
+                defaultAccountBalance() - poolTokens[i].balanceOf(lp),
                 tokenAmounts[i],
                 string.concat("LP: Wrong balance for ", Strings.toString(i))
             );
@@ -106,7 +106,7 @@ abstract contract BasePoolTest is BaseVaultTest {
         for (uint256 i = 0; i < poolTokens.length; ++i) {
             // Tokens are transferred from Bob.
             assertEq(
-                defaultBalance - poolTokens[i].balanceOf(bob),
+                defaultAccountBalance() - poolTokens[i].balanceOf(bob),
                 tokenAmounts[i],
                 string.concat("LP: Wrong token balance for ", Strings.toString(i))
             );
@@ -160,7 +160,7 @@ abstract contract BasePoolTest is BaseVaultTest {
             // Tokens are transferred to Bob.
             assertApproxEqAbs(
                 poolTokens[i].balanceOf(bob),
-                defaultBalance,
+                defaultAccountBalance(),
                 DELTA,
                 string.concat("LP: Wrong token balance for ", Strings.toString(i))
             );
@@ -216,8 +216,8 @@ abstract contract BasePoolTest is BaseVaultTest {
         );
 
         // Tokens are transferred from Bob.
-        assertEq(tokenOut.balanceOf(bob), defaultBalance + amountCalculated, "LP: Wrong tokenOut balance");
-        assertEq(tokenIn.balanceOf(bob), defaultBalance - tokenAmountIn, "LP: Wrong tokenIn balance");
+        assertEq(tokenOut.balanceOf(bob), defaultAccountBalance() + amountCalculated, "LP: Wrong tokenOut balance");
+        assertEq(tokenIn.balanceOf(bob), defaultAccountBalance() - tokenAmountIn, "LP: Wrong tokenIn balance");
 
         // Tokens are stored in the Vault.
         assertEq(


### PR DESCRIPTION

# Description

A variable that we initialize before setUp, defaultAccountBalance has been encapsulated in a separate method to be able to get a readable error and prevent uncontrolled changes to this variable.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
