### PR TITLE
Fix rounding of 2CLP pools

### DIFF
--- a/pkg/pool-gyro/contracts/Gyro2CLPPool.sol
+++ b/pkg/pool-gyro/contracts/Gyro2CLPPool.sol
@@ -166,14 +166,7 @@ contract Gyro2CLPPool is IGyro2CLPPool, BalancerPoolToken {
 
         (uint256 sqrtAlpha, uint256 sqrtBeta) = _getSqrtAlphaAndBeta();
 
-        // If EXACT_IN, round invariant down to give less tokens to the user. If EXACT_OUT, round invariant up to
-        // charge more tokens from the user.
-        uint256 currentInvariant = Gyro2CLPMath.calculateInvariant(
-            balances,
-            sqrtAlpha,
-            sqrtBeta,
-            kind == SwapKind.EXACT_IN ? Rounding.ROUND_DOWN : Rounding.ROUND_UP
-        );
+        uint256 currentInvariant = Gyro2CLPMath.calculateInvariant(balances, sqrtAlpha, sqrtBeta, Rounding.ROUND_DOWN);
 
         // virtualBalanceIn is always rounded up, because:
         // * If swap is EXACT_IN: a bigger virtualBalanceIn leads to a lower amount out;

--- a/pkg/pool-gyro/contracts/Gyro2CLPPool.sol
+++ b/pkg/pool-gyro/contracts/Gyro2CLPPool.sol
@@ -167,7 +167,7 @@ contract Gyro2CLPPool is IGyro2CLPPool, BalancerPoolToken {
 
         uint256 currentInvariant = Gyro2CLPMath.calculateInvariant(balances, sqrtAlpha, sqrtBeta, rounding);
 
-        uint256[2] memory virtualOffsets = _calculateVirtualOffsets(currentInvariant, sqrtAlpha, sqrtBeta);
+        uint256[2] memory virtualOffsets = _calculateVirtualOffsets(currentInvariant, sqrtAlpha, sqrtBeta, rounding);
 
         virtualBalanceIn = tokenInIsToken0 ? virtualOffsets[0] : virtualOffsets[1];
         virtualBalanceOut = tokenInIsToken0 ? virtualOffsets[1] : virtualOffsets[0];
@@ -177,10 +177,11 @@ contract Gyro2CLPPool is IGyro2CLPPool, BalancerPoolToken {
     function _calculateVirtualOffsets(
         uint256 invariant,
         uint256 sqrtAlpha,
-        uint256 sqrtBeta
+        uint256 sqrtBeta,
+        Rounding rounding
     ) internal view virtual returns (uint256[2] memory virtualOffsets) {
-        virtualOffsets[0] = Gyro2CLPMath.calculateVirtualParameter0(invariant, sqrtBeta);
-        virtualOffsets[1] = Gyro2CLPMath.calculateVirtualParameter1(invariant, sqrtAlpha);
+        virtualOffsets[0] = Gyro2CLPMath.calculateVirtualParameter0(invariant, sqrtBeta, rounding);
+        virtualOffsets[1] = Gyro2CLPMath.calculateVirtualParameter1(invariant, sqrtAlpha, rounding);
         return virtualOffsets;
     }
 

--- a/pkg/pool-gyro/contracts/Gyro2CLPPool.sol
+++ b/pkg/pool-gyro/contracts/Gyro2CLPPool.sol
@@ -116,7 +116,7 @@ contract Gyro2CLPPool is IGyro2CLPPool, BalancerPoolToken {
             balanceTokenInScaled18,
             balanceTokenOutScaled18,
             tokenInIsToken0,
-            request.kind == SwapKind.EXACT_IN ? Rounding.ROUND_DOWN : Rounding.ROUND_UP
+            request.kind
         );
 
         if (request.kind == SwapKind.EXACT_IN) {
@@ -158,7 +158,7 @@ contract Gyro2CLPPool is IGyro2CLPPool, BalancerPoolToken {
         uint256 balanceTokenInScaled18,
         uint256 balanceTokenOutScaled18,
         bool tokenInIsToken0,
-        Rounding rounding
+        SwapKind kind
     ) internal view virtual returns (uint256 virtualBalanceIn, uint256 virtualBalanceOut) {
         uint256[] memory balances = new uint256[](2);
         balances[0] = tokenInIsToken0 ? balanceTokenInScaled18 : balanceTokenOutScaled18;
@@ -166,24 +166,36 @@ contract Gyro2CLPPool is IGyro2CLPPool, BalancerPoolToken {
 
         (uint256 sqrtAlpha, uint256 sqrtBeta) = _getSqrtAlphaAndBeta();
 
-        uint256 currentInvariant = Gyro2CLPMath.calculateInvariant(balances, sqrtAlpha, sqrtBeta, rounding);
+        // If EXACT_IN, round invariant down to give less tokens to the user. If EXACT_OUT, round invariant up to
+        // charge more tokens from the user.
+        uint256 currentInvariant = Gyro2CLPMath.calculateInvariant(
+            balances,
+            sqrtAlpha,
+            sqrtBeta,
+            kind == SwapKind.EXACT_IN ? Rounding.ROUND_DOWN : Rounding.ROUND_UP
+        );
 
-        uint256[2] memory virtualOffsets = _calculateVirtualOffsets(currentInvariant, sqrtAlpha, sqrtBeta, rounding);
-
-        virtualBalanceIn = tokenInIsToken0 ? virtualOffsets[0] : virtualOffsets[1];
-        virtualBalanceOut = tokenInIsToken0 ? virtualOffsets[1] : virtualOffsets[0];
-    }
-
-    /// @notice Returns an array with virtual offsets of both tokens of the pool, in registration order.
-    function _calculateVirtualOffsets(
-        uint256 invariant,
-        uint256 sqrtAlpha,
-        uint256 sqrtBeta,
-        Rounding rounding
-    ) internal view virtual returns (uint256[2] memory virtualOffsets) {
-        virtualOffsets[0] = Gyro2CLPMath.calculateVirtualParameter0(invariant, sqrtBeta, rounding);
-        virtualOffsets[1] = Gyro2CLPMath.calculateVirtualParameter1(invariant, sqrtAlpha, rounding);
-        return virtualOffsets;
+        // virtualBalanceIn is always rounded up, because:
+        // * If swap is EXACT_IN: a bigger virtualBalanceIn leads to a lower amount out;
+        // * If swap is EXACT_OUT: a bigger virtualBalanceIn leads to a bigger amount in;
+        // virtualBalanceOut is always rounded down, because:
+        // * If swap is EXACT_IN: a lower virtualBalanceOut leads to a lower amount out;
+        // * If swap is EXACT_OUT: a lower virtualBalanceOut leads to a bigger amount in;
+        if (tokenInIsToken0) {
+            virtualBalanceIn = Gyro2CLPMath.calculateVirtualParameter0(currentInvariant, sqrtBeta, Rounding.ROUND_UP);
+            virtualBalanceOut = Gyro2CLPMath.calculateVirtualParameter1(
+                currentInvariant,
+                sqrtAlpha,
+                Rounding.ROUND_DOWN
+            );
+        } else {
+            virtualBalanceIn = Gyro2CLPMath.calculateVirtualParameter1(currentInvariant, sqrtAlpha, Rounding.ROUND_UP);
+            virtualBalanceOut = Gyro2CLPMath.calculateVirtualParameter0(
+                currentInvariant,
+                sqrtBeta,
+                Rounding.ROUND_DOWN
+            );
+        }
     }
 
     /// @inheritdoc ISwapFeePercentageBounds

--- a/pkg/pool-gyro/contracts/Gyro2CLPPool.sol
+++ b/pkg/pool-gyro/contracts/Gyro2CLPPool.sol
@@ -90,16 +90,24 @@ contract Gyro2CLPPool is IGyro2CLPPool, BalancerPoolToken {
         // New invariant
         invariant = invariant.mulUp(invariantRatio);
         uint256 squareNewInv = invariant * invariant;
-        // L / sqrt(beta)
-        uint256 a = invariant.divDown(sqrtBeta);
-        // L * sqrt(alpha)
-        uint256 b = invariant.mulDown(sqrtAlpha);
 
         if (tokenInIndex == 0) {
             // if newBalance = newX
+
+            // L / sqrt(beta), rounded down to minimize newBalance.
+            uint256 a = invariant.divDown(sqrtBeta);
+            // L * sqrt(alpha), rounded up to minimize newBalance (b is in the denominator).
+            uint256 b = invariant.mulUp(sqrtAlpha);
+
             newBalance = squareNewInv.divUpRaw(b + balancesLiveScaled18[1]) - a;
         } else {
             // if newBalance = newY
+
+            // L / sqrt(beta), rounded up to minimize newBalance (a is in the denominator).
+            uint256 a = invariant.divUp(sqrtBeta);
+            // L * sqrt(alpha), rounded down to minimize newBalance.
+            uint256 b = invariant.mulDown(sqrtAlpha);
+
             newBalance = squareNewInv.divUpRaw(a + balancesLiveScaled18[0]) - b;
         }
     }

--- a/pkg/pool-gyro/contracts/Gyro2CLPPool.sol
+++ b/pkg/pool-gyro/contracts/Gyro2CLPPool.sol
@@ -91,23 +91,16 @@ contract Gyro2CLPPool is IGyro2CLPPool, BalancerPoolToken {
         invariant = invariant.mulUp(invariantRatio);
         uint256 squareNewInv = invariant * invariant;
 
+        // L / sqrt(beta), rounded down to maximize newBalance.
+        uint256 a = invariant.divDown(sqrtBeta);
+        // L * sqrt(alpha), rounded down to maximize newBalance (b is in the denominator).
+        uint256 b = invariant.mulDown(sqrtAlpha);
+
         if (tokenInIndex == 0) {
             // if newBalance = newX
-
-            // L / sqrt(beta), rounded down to minimize newBalance.
-            uint256 a = invariant.divDown(sqrtBeta);
-            // L * sqrt(alpha), rounded up to minimize newBalance (b is in the denominator).
-            uint256 b = invariant.mulUp(sqrtAlpha);
-
             newBalance = squareNewInv.divUpRaw(b + balancesLiveScaled18[1]) - a;
         } else {
             // if newBalance = newY
-
-            // L / sqrt(beta), rounded up to minimize newBalance (a is in the denominator).
-            uint256 a = invariant.divUp(sqrtBeta);
-            // L * sqrt(alpha), rounded down to minimize newBalance.
-            uint256 b = invariant.mulDown(sqrtAlpha);
-
             newBalance = squareNewInv.divUpRaw(a + balancesLiveScaled18[0]) - b;
         }
     }

--- a/pkg/pool-gyro/contracts/lib/Gyro2CLPMath.sol
+++ b/pkg/pool-gyro/contracts/lib/Gyro2CLPMath.sol
@@ -174,14 +174,11 @@ library Gyro2CLPMath {
       // Note that -dy > 0 is what the trader receives.                                            //
       // We exploit the fact that this formula is symmetric up to virtualOffset{X,Y}.               //
       // We do not use L^2, but rather x' * y', to prevent a potential accumulation of errors.      //
-      // We add a very small safety margin to compensate for potential errors in the invariant.     //
       **********************************************************************************************/
 
         {
-            // The factors in total lead to a multiplicative "safety margin" between the employed virtual offsets
-            // that is very slightly larger than 3e-18.
-            uint256 virtInOver = balanceIn + virtualOffsetIn.mulUp(FixedPoint.ONE + 2);
-            uint256 virtOutUnder = balanceOut + (virtualOffsetOut).mulDown(FixedPoint.ONE - 1);
+            uint256 virtInOver = balanceIn + virtualOffsetIn;
+            uint256 virtOutUnder = balanceOut + virtualOffsetOut;
 
             amountOut = virtOutUnder.mulDown(amountIn).divDown(virtInOver + amountIn);
         }
@@ -216,17 +213,14 @@ library Gyro2CLPMath {
       // Note that dy < 0 < dx.                                                                      //
       // We exploit the fact that this formula is symmetric up to virtualOffset{X,Y}.                //
       // We do not use L^2, but rather x' * y', to prevent a potential accumulation of errors.       //
-      // We add a very small safety margin to compensate for potential errors in the invariant.      //
       **********************************************************************************************/
         if (!(amountOut <= balanceOut)) {
             revert AssetBoundsExceeded();
         }
 
         {
-            // The factors in total lead to a multiplicative "safety margin" between the employed virtual offsets
-            // that is very slightly larger than 3e-18.
-            uint256 virtInOver = balanceIn + virtualOffsetIn.mulUp(FixedPoint.ONE + 2);
-            uint256 virtOutUnder = balanceOut + virtualOffsetOut.mulDown(FixedPoint.ONE - 1);
+            uint256 virtInOver = balanceIn + virtualOffsetIn;
+            uint256 virtOutUnder = balanceOut + virtualOffsetOut;
 
             amountIn = virtInOver.mulUp(amountOut).divUp(virtOutUnder - amountOut);
         }

--- a/pkg/pool-gyro/contracts/lib/Gyro2CLPMath.sol
+++ b/pkg/pool-gyro/contracts/lib/Gyro2CLPMath.sol
@@ -233,13 +233,21 @@ library Gyro2CLPMath {
     }
 
     /// @dev Calculate the virtual offset `a` for reserves `x`, as in (x+a)*(y+b)=L^2.
-    function calculateVirtualParameter0(uint256 invariant, uint256 _sqrtBeta) internal pure returns (uint256) {
-        return invariant.divDown(_sqrtBeta);
+    function calculateVirtualParameter0(
+        uint256 invariant,
+        uint256 _sqrtBeta,
+        Rounding rounding
+    ) internal pure returns (uint256) {
+        return rounding == Rounding.ROUND_DOWN ? invariant.divDown(_sqrtBeta) : invariant.divUp(_sqrtBeta);
     }
 
     /// @dev Calculate the virtual offset `b` for reserves `y`, as in (x+a)*(y+b)=L^2.
-    function calculateVirtualParameter1(uint256 invariant, uint256 _sqrtAlpha) internal pure returns (uint256) {
-        return invariant.mulDown(_sqrtAlpha);
+    function calculateVirtualParameter1(
+        uint256 invariant,
+        uint256 _sqrtAlpha,
+        Rounding rounding
+    ) internal pure returns (uint256) {
+        return rounding == Rounding.ROUND_DOWN ? invariant.mulDown(_sqrtAlpha) : invariant.mulUp(_sqrtAlpha);
     }
 
     /**

--- a/pkg/pool-gyro/test/foundry/Gyro2CLPMathRounding.sol
+++ b/pkg/pool-gyro/test/foundry/Gyro2CLPMathRounding.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { Rounding } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+
+import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/test/ArrayHelpers.sol";
+
+import "../../contracts/lib/Gyro2CLPMath.sol";
+
+struct QuadraticTerms {
+    uint256 a;
+    uint256 mb;
+    uint256 bSquare;
+    uint256 mc;
+}
+
+contract Gyro2CLPMathRoundingTest is Test {
+    using ArrayHelpers for *;
+
+    uint256 internal constant MIN_DIFF_ALPHA_BETA = 100;
+
+    uint256 internal constant MIN_SQRT_ALPHA = 0.01e18;
+    uint256 internal constant MAX_SQRT_ALPHA = 10e18 - MIN_DIFF_ALPHA_BETA;
+    // Make sqrtBeta 0.5% higher than sqrtAlpha
+    uint256 internal constant MIN_SQRT_BETA = MIN_SQRT_ALPHA;
+    uint256 internal constant MAX_SQRT_BETA = MAX_SQRT_ALPHA + MIN_DIFF_ALPHA_BETA;
+
+    function testCalculateQuadraticTermsRounding__Fuzz(
+        uint256[2] memory balances,
+        uint256 sqrtAlpha,
+        uint256 sqrtBeta
+    ) public pure {
+        balances[0] = bound(balances[0], 1e16, 1e8 * 1e18);
+        balances[1] = bound(balances[1], 1e16, 1e8 * 1e18);
+        sqrtAlpha = bound(sqrtAlpha, MIN_SQRT_ALPHA, MAX_SQRT_ALPHA);
+        sqrtBeta = bound(sqrtBeta, sqrtAlpha + MIN_DIFF_ALPHA_BETA, MAX_SQRT_BETA);
+
+        QuadraticTerms memory qTermsDown;
+        QuadraticTerms memory qTermsUp;
+
+        (qTermsDown.a, qTermsDown.mb, qTermsDown.bSquare, qTermsDown.mc) = Gyro2CLPMath.calculateQuadraticTerms(
+            balances.toMemoryArray(),
+            sqrtAlpha,
+            sqrtBeta,
+            Rounding.ROUND_DOWN
+        );
+        (qTermsUp.a, qTermsUp.mb, qTermsUp.bSquare, qTermsUp.mc) = Gyro2CLPMath.calculateQuadraticTerms(
+            balances.toMemoryArray(),
+            sqrtAlpha,
+            sqrtBeta,
+            Rounding.ROUND_UP
+        );
+
+        assertLe(qTermsUp.a, qTermsDown.a, "Wrong rounding result (a)");
+        assertGe(qTermsUp.mb, qTermsDown.mb, "Wrong rounding result (mb)");
+        assertGe(qTermsUp.bSquare, qTermsDown.bSquare, "Wrong rounding result (bSquare)");
+        assertGe(qTermsUp.mc, qTermsDown.mc, "Wrong rounding result (mc)");
+    }
+
+    function testCalculateQuadraticRounding__Fuzz(uint256 a, uint256 mb, uint256 mc) public pure {
+        a = bound(a, 1, 1e18); // 0 < a < FP(1)
+        mb = bound(mb, 1, 1e8 * 1e18);
+        uint256 bSquare = mb * mb; // This is an approximation just to unit fuzz calculate quadratic.
+        mc = bound(mc, 1, 1e8 * 1e18);
+
+        uint256 quadraticRoundDown = Gyro2CLPMath.calculateQuadratic(a, mb, bSquare, mc, Rounding.ROUND_DOWN);
+        uint256 quadraticRoundUp = Gyro2CLPMath.calculateQuadratic(a, mb, bSquare, mc, Rounding.ROUND_UP);
+
+        assertGe(quadraticRoundUp, quadraticRoundDown, "Wrong rounding result");
+    }
+
+    function testComputeInvariantRounding__Fuzz(
+        uint256[2] memory balances,
+        uint256 sqrtAlpha,
+        uint256 sqrtBeta
+    ) public pure {
+        balances[0] = bound(balances[0], 1e16, 1e8 * 1e18);
+        balances[1] = bound(balances[1], 1e16, 1e8 * 1e18);
+        sqrtAlpha = bound(sqrtAlpha, MIN_SQRT_ALPHA, MAX_SQRT_ALPHA);
+        sqrtBeta = bound(sqrtBeta, sqrtAlpha + MIN_DIFF_ALPHA_BETA, MAX_SQRT_BETA);
+
+        uint256 invariantDown = Gyro2CLPMath.calculateInvariant(
+            balances.toMemoryArray(),
+            sqrtAlpha,
+            sqrtBeta,
+            Rounding.ROUND_DOWN
+        );
+        uint256 invariantUp = Gyro2CLPMath.calculateInvariant(
+            balances.toMemoryArray(),
+            sqrtAlpha,
+            sqrtBeta,
+            Rounding.ROUND_UP
+        );
+
+        assertGe(invariantUp, invariantDown, "Wrong rounding result");
+    }
+}


### PR DESCRIPTION
# Description

Certora found some rounding issues related to some functions of 2-CLP pool:
1. Function `calculateQuadratic()`, from `Gyro2CLPMath.sol`, was not rounded properly.
2. When calculating virtual offsets, rounding was not applied.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge
