### PR TITLE
One stable math fuzz test 

### DIFF
--- a/pkg/solidity-utils/test/foundry/StableMath.t.sol
+++ b/pkg/solidity-utils/test/foundry/StableMath.t.sol
@@ -399,7 +399,7 @@ contract StableMathTest is Test {
         uint256[8] memory deltas,
         uint256[8] memory balancesRaw
     ) public view {
-        _testComputeInvariantLessThenInvariantWithDelta(
+        _testComputeInvariantLessThanInvariantWithDelta(
             amp,
             tokenCount,
             deltaCount,
@@ -410,7 +410,7 @@ contract StableMathTest is Test {
         );
     }
 
-    function _testComputeInvariantLessThenInvariantWithDelta(
+    function _testComputeInvariantLessThanInvariantWithDelta(
         uint256 amp,
         uint256 tokenCount,
         uint256 deltaCount,
@@ -447,8 +447,8 @@ contract StableMathTest is Test {
                 uint256 invariantWithDelta
             ) {
                 assertLe(
-                    currentInvariant - 5,
-                    invariantWithDelta,
+                    currentInvariant,
+                    invariantWithDelta + 5,
                     "Current invariant should be less than or equal to invariant with delta (5 wei tolerance)"
                 );
             } catch {}

--- a/pkg/solidity-utils/test/foundry/StableMath.t.sol
+++ b/pkg/solidity-utils/test/foundry/StableMath.t.sol
@@ -450,8 +450,8 @@ contract StableMathTest is Test {
                     assertApproxEqAbs(
                         currentInvariant,
                         invariantWithDelta,
-                        1,
-                        "Current invariant should be approximately equal to invariant with delta (within 1 wei)"
+                        5,
+                        "Current invariant should be approximately equal to invariant with delta (within 5 wei)"
                     );
                 } else {
                     assertLe(

--- a/pkg/solidity-utils/test/foundry/StableMath.t.sol
+++ b/pkg/solidity-utils/test/foundry/StableMath.t.sol
@@ -380,7 +380,7 @@ contract StableMathTest is Test {
         uint256[8] memory deltas,
         uint256[8] memory balancesRaw
     ) public view {
-        _testComputeInvariantLessThenInvariantWithDelta(
+        _testComputeInvariantLessThanInvariantWithDelta(
             amp,
             tokenCount,
             deltaCount,
@@ -420,7 +420,7 @@ contract StableMathTest is Test {
         uint256 maxDelta
     ) internal view {
         amp = boundAmp(amp);
-        tokenCount = bound(tokenCount, MIN_TOKENS, MAX_TOKENS);
+        tokenCount = bound(tokenCount, MIN_TOKENS, StableMath.MAX_STABLE_TOKENS);
         deltaCount = bound(deltaCount, 1, tokenCount);
 
         uint256[] memory balances = new uint256[](tokenCount);
@@ -446,20 +446,11 @@ contract StableMathTest is Test {
             try stableMathMock.computeInvariant(amp, newBalances, Rounding.ROUND_DOWN) returns (
                 uint256 invariantWithDelta
             ) {
-                if (invariantWithDelta < currentInvariant) {
-                    assertApproxEqAbs(
-                        currentInvariant,
-                        invariantWithDelta,
-                        5,
-                        "Current invariant should be approximately equal to invariant with delta (within 5 wei)"
-                    );
-                } else {
-                    assertLe(
-                        currentInvariant,
-                        invariantWithDelta,
-                        "Current invariant should be less than or equal to invariant with delta"
-                    );
-                }
+                assertLe(
+                    currentInvariant - 5,
+                    invariantWithDelta,
+                    "Current invariant should be less than or equal to invariant with delta (5 wei tolerance)"
+                );
             } catch {}
         } catch {}
     }

--- a/pkg/solidity-utils/test/foundry/StableMath.t.sol
+++ b/pkg/solidity-utils/test/foundry/StableMath.t.sol
@@ -10,6 +10,7 @@ import { StableMath } from "../../contracts/math/StableMath.sol";
 import { FixedPoint } from "../../contracts/math/FixedPoint.sol";
 import { ArrayHelpers } from "../../contracts/test/ArrayHelpers.sol";
 import { StableMathMock } from "../../contracts/test/StableMathMock.sol";
+import { ScalingHelpers } from "../../contracts/helpers/ScalingHelpers.sol";
 
 // In the `StableMath` functions, the protocol aims for computing a value either as small as possible or as large as possible
 // by means of rounding in its favor; in order to achieve this, it may use arbitrary rounding directions during the calculations.
@@ -20,6 +21,8 @@ contract StableMathTest is Test {
     using FixedPoint for uint256;
     using ArrayHelpers for *;
 
+    uint256 constant MIN_TOKENS = 2;
+    uint256 constant MAX_TOKENS = 8;
     uint256 constant NUM_TOKENS = 4;
 
     uint256 constant MIN_BALANCE_BASE = 1e18;
@@ -367,5 +370,44 @@ contract StableMathTest is Test {
             .divDown(currentInvariantUp);
 
         assertLe(invariantRatioDown, invariantRatioRegular, "Invariant ratio should have gone down");
+    }
+
+    function testComputeInvariantLessThenInvariantWithDelta__Fuzz(
+        uint256 amp,
+        uint256 tokenCount,
+        uint256 deltaCount,
+        uint256[8] memory indexes,
+        uint256[8] memory deltas,
+        uint256[8] memory balancesRaw
+    ) public view {
+        amp = boundAmp(amp);
+        tokenCount = bound(tokenCount, MIN_TOKENS, MAX_TOKENS);
+        deltaCount = bound(deltaCount, 1, tokenCount);
+
+        uint256[] memory balances = new uint256[](tokenCount);
+        for (uint256 i = 0; i < tokenCount; i++) {
+            balances[i] = bound(balancesRaw[i], 1, type(uint128).max);
+        }
+
+        uint256[] memory newBalances = new uint256[](tokenCount);
+        ScalingHelpers.copyToArray(balances, newBalances);
+
+        for (uint256 i = 0; i < deltaCount; i++) {
+            uint256 tokenIndex = bound(indexes[i], 0, tokenCount - 1);
+            uint256 delta = bound(deltas[i], 0, type(uint128).max - newBalances[tokenIndex]);
+            newBalances[tokenIndex] += delta;
+        }
+
+        try stableMathMock.computeInvariant(amp, balances, Rounding.ROUND_DOWN) returns (uint256 currentInvariant) {
+            try stableMathMock.computeInvariant(amp, newBalances, Rounding.ROUND_DOWN) returns (
+                uint256 invariantWithDelta
+            ) {
+                assertLe(
+                    currentInvariant,
+                    invariantWithDelta,
+                    "Current invariant should be less than invariant with delta"
+                );
+            } catch {}
+        } catch {}
     }
 }


### PR DESCRIPTION
# Description

Added a fuzz test for stable math to check that `computeInvariant(balances) <= computeInvariant(balances + deltas)`

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [X] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

