### PR TITLE
MEV tax hook: Add configurable max mev swap fee percentage

### DIFF
--- a/pkg/interfaces/contracts/pool-hooks/IMevHook.sol
+++ b/pkg/interfaces/contracts/pool-hooks/IMevHook.sol
@@ -70,9 +70,8 @@ interface IMevHook {
     function enableMevTax() external;
 
     /**
-     * @notice Returns maximum MEV swap fee percentage returned by `onComputeDynamicSwapFeePercentage`.
-     * @dev The absolute minimum is still the static swap fee percentage of the pool. If the maximum MEV swap fee
-     * percentage of the pool is below the static fee percentage, the static fee percentage is used anyways.
+     * @notice Returns the maximum MEV swap fee percentage returned by `onComputeDynamicSwapFeePercentage`.
+     * @dev The absolute minimum is still the static swap fee percentage of the pool.
      * In other words:
      * - if `maxMevSwapFeePercentage > staticSwapFeePercentage`, then
      * `staticSwapFeePercentage <= computedFeePercentage <= maxMevSwapFeePercentage`

--- a/pkg/interfaces/contracts/pool-hooks/IMevHook.sol
+++ b/pkg/interfaces/contracts/pool-hooks/IMevHook.sol
@@ -109,7 +109,8 @@ interface IMevHook {
      * specific chain. However, the resulting swap fee percentage, given by `priorityGasPrice * multiplier`, is capped
      * at the lower end by the static swap fee, and at the upper end by the maximum swap fee percentage of the vault.
      * Therefore, a multiplier with value 0 will effectively disable the MEV tax, since the static swap fee will be
-     * charged. Also, a very high multiplier may disable pool swaps, since the MEV tax will be 99.9999%.
+     * charged. Also, a very high multiplier will make the trader pay the maximum configured swap fee which can be
+     * close to 100%, effectively disabling swaps.
      *
      * @param newDefaultMevTaxMultiplier 18-decimal used to calculate the MEV swap fee percentage
      */
@@ -134,8 +135,8 @@ interface IMevHook {
      * MevHookNotRegisteredForPool(pool). However, the resulting swap fee percentage, given by
      * `priorityGasPrice * multiplier`, is capped in the lower end by the static swap fee, and at the upper end by
      * the maximum swap fee percentage of the vault. Therefore, a multiplier with value 0 will effectively disable the
-     * MEV tax, since the static swap fee will be charged. Also, a very high multiplier may disable pool swaps, since
-     * the MEV tax will be 99.9999%.
+     * MEV tax, since the static swap fee will be charged. Also, a very high multiplier will make the trader pay the
+     * maximum configured swap fee which can be close to 100%, effectively disabling swaps.
      *
      * @param pool Address of the pool with the multiplier
      * @param newPoolMevTaxMultiplier New multiplier to be set in a pool

--- a/pkg/interfaces/contracts/pool-hooks/IMevHook.sol
+++ b/pkg/interfaces/contracts/pool-hooks/IMevHook.sol
@@ -10,6 +10,13 @@ interface IMevHook {
     error MevHookNotRegisteredInPool(address pool);
 
     /**
+     * @notice The new max MEV swap fee percentage is above the allowed absolute maximum.
+     * @param feePercentage New fee percentage being set
+     * @param maxFeePercentage Absolute maximum allowed
+     */
+    error MevSwapFeePercentageAboveMax(uint256 feePercentage, uint256 maxFeePercentage);
+
+    /**
      * @notice The MEV tax was globally enabled or disabled in the hook.
      * @param enabled The new value for mevTaxEnabled. If true, MEV tax will be charged
      */
@@ -28,6 +35,12 @@ interface IMevHook {
      * @param newDefaultMevTaxThreshold The new value for defaultMevTaxThreshold
      */
     event DefaultMevTaxThresholdSet(uint256 newDefaultMevTaxThreshold);
+
+    /**
+     * @notice The maximum MEV swap fee percentage was set.
+     * @param maxMevSwapFeePercentage The new value for maxMevSwapFeePercentage.
+     */
+    event MaxMevSwapFeePercentageSet(uint256 maxMevSwapFeePercentage);
 
     /**
      * @notice A pool's MEV tax multiplier was set.
@@ -55,6 +68,26 @@ interface IMevHook {
 
     /// @notice Permissioned function to enable charging the MEV Tax in registered pools.
     function enableMevTax() external;
+
+    /**
+     * @notice Returns maximum MEV swap fee percentage returned by `onComputeDynamicSwapFeePercentage`.
+     * @dev The absolute minimum is still the static swap fee percentage of the pool. If the maximum MEV swap fee
+     * percentage of the pool is below the static fee percentage, the static fee percentage is used anyways.
+     * In other words:
+     * - if `maxMevSwapFeePercentage > staticSwapFeePercentage`, then
+     * `staticSwapFeePercentage <= computedFeePercentage <= maxMevSwapFeePercentage`
+     * - if `maxMevSwapFeePercentage <= staticSwapFeePercentage, then `computedFeePercentage = maxMevSwapFeePercentage`
+     */
+    function getMaxMevSwapFeePercentage() external view returns (uint256);
+
+    /**
+     * @notice Permissioned function to set the maximum MEV swap fee percentage returned by
+     * `onComputeDynamicSwapFeePercentage`.
+     * @dev See `getMaxMevSwapFeePercentage` for reference; this maximum applies only when
+     * `maxMevSwapFeePercentage > staticSwapFeePercentage`.
+     * Capped by MAX_FEE_PERCENTAGE defined by the Vault.
+     */
+    function setMaxMevSwapFeePercentage(uint256 maxMevSwapFeePercentage) external;
 
     /**
      * @notice Fetch the default multiplier for the priority gas price.

--- a/pkg/pool-hooks/contracts/MevHook.sol
+++ b/pkg/pool-hooks/contracts/MevHook.sol
@@ -53,6 +53,7 @@ contract MevHook is BaseHooks, SingletonAuthentication, VaultGuard, IMevHook {
         _setMevTaxEnabled(false);
         _setDefaultMevTaxMultiplier(0);
         _setDefaultMevTaxThreshold(0);
+        // Default to the maximum value allowed by the Vault.
         _setMaxMevSwapFeePercentage(_MEV_MAX_FEE_PERCENTAGE);
     }
 

--- a/pkg/pool-hooks/contracts/MevHook.sol
+++ b/pkg/pool-hooks/contracts/MevHook.sol
@@ -32,6 +32,9 @@ contract MevHook is BaseHooks, SingletonAuthentication, VaultGuard, IMevHook {
     uint256 internal _defaultMevTaxThreshold;
     uint256 internal _defaultMevTaxMultiplier;
 
+    // Global max dynamic swap fee percentage returned by this hook.
+    uint256 internal _maxMevSwapFeePercentage;
+
     // Pool-specific parameters.
     mapping(address => uint256) internal _poolMevTaxThresholds;
     mapping(address => uint256) internal _poolMevTaxMultipliers;
@@ -50,6 +53,7 @@ contract MevHook is BaseHooks, SingletonAuthentication, VaultGuard, IMevHook {
         _setMevTaxEnabled(false);
         _setDefaultMevTaxMultiplier(0);
         _setDefaultMevTaxThreshold(0);
+        _setMaxMevSwapFeePercentage(_MEV_MAX_FEE_PERCENTAGE);
     }
 
     /// @inheritdoc IHooks
@@ -98,9 +102,11 @@ contract MevHook is BaseHooks, SingletonAuthentication, VaultGuard, IMevHook {
 
         uint256 mevSwapFeePercentage = priorityGasPrice.mulDown(_poolMevTaxMultipliers[pool]);
 
-        // Cap the maximum fee at `MAX_FEE_PERCENTAGE`.
-        if (mevSwapFeePercentage > _MEV_MAX_FEE_PERCENTAGE) {
-            return (true, _MEV_MAX_FEE_PERCENTAGE);
+        // Cap the maximum fee at `_maxMevSwapFeePercentage`.
+        uint256 maxMevSwapFeePercentage = _maxMevSwapFeePercentage;
+        if (mevSwapFeePercentage > maxMevSwapFeePercentage) {
+            // Don't return early. If the cap is below the static fee, we'll still use the static fee.
+            mevSwapFeePercentage = maxMevSwapFeePercentage;
         }
 
         // Use the greater of the static and MEV fee percentages.
@@ -126,6 +132,26 @@ contract MevHook is BaseHooks, SingletonAuthentication, VaultGuard, IMevHook {
         _mevTaxEnabled = value;
 
         emit MevTaxEnabledSet(value);
+    }
+
+    /// @inheritdoc IMevHook
+    function getMaxMevSwapFeePercentage() external view returns (uint256) {
+        return _maxMevSwapFeePercentage;
+    }
+
+    /// @inheritdoc IMevHook
+    function setMaxMevSwapFeePercentage(uint256 maxMevSwapFeePercentage) external authenticate {
+        _setMaxMevSwapFeePercentage(maxMevSwapFeePercentage);
+    }
+
+    function _setMaxMevSwapFeePercentage(uint256 maxMevSwapFeePercentage) internal {
+        if (maxMevSwapFeePercentage > _MEV_MAX_FEE_PERCENTAGE) {
+            revert MevSwapFeePercentageAboveMax(maxMevSwapFeePercentage, _MEV_MAX_FEE_PERCENTAGE);
+        }
+
+        _maxMevSwapFeePercentage = maxMevSwapFeePercentage;
+
+        emit MaxMevSwapFeePercentageSet(maxMevSwapFeePercentage);
     }
 
     /// @inheritdoc IMevHook

--- a/pkg/pool-hooks/test/foundry/MevHook.t.sol
+++ b/pkg/pool-hooks/test/foundry/MevHook.t.sol
@@ -119,7 +119,7 @@ contract MevHookTest is BaseVaultTest {
     }
 
     /********************************************************
-                         enableMevTax()
+                   setMaxMevSwapFeePercentage()
     ********************************************************/
     function testSetMaxMevSwapFeePercentageIsPermissioned() public {
         vm.expectRevert(IAuthentication.SenderNotAllowed.selector);

--- a/pkg/pool-hooks/test/foundry/MevHook.t.sol
+++ b/pkg/pool-hooks/test/foundry/MevHook.t.sol
@@ -5,7 +5,9 @@ pragma solidity ^0.8.24;
 import "forge-std/Test.sol";
 
 import { IMevHook } from "@balancer-labs/v3-interfaces/contracts/pool-hooks/IMevHook.sol";
+import { IHooks } from "@balancer-labs/v3-interfaces/contracts/vault/IHooks.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import { PoolSwapParams, MAX_FEE_PERCENTAGE } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
 
 import { CastingHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/CastingHelpers.sol";
@@ -25,6 +27,10 @@ contract MevHookTest is BaseVaultTest {
 
         authorizer.grantRole(IAuthentication(address(_mevHook)).getActionId(IMevHook.disableMevTax.selector), admin);
         authorizer.grantRole(IAuthentication(address(_mevHook)).getActionId(IMevHook.enableMevTax.selector), admin);
+        authorizer.grantRole(
+            IAuthentication(address(_mevHook)).getActionId(IMevHook.setMaxMevSwapFeePercentage.selector),
+            admin
+        );
         authorizer.grantRole(
             IAuthentication(address(_mevHook)).getActionId(IMevHook.setDefaultMevTaxMultiplier.selector),
             admin
@@ -103,6 +109,47 @@ contract MevHookTest is BaseVaultTest {
         vm.prank(admin);
         _mevHook.enableMevTax();
         assertTrue(_mevHook.isMevTaxEnabled(), "MEV Tax is not enabled");
+    }
+
+    /********************************************************
+                    getMaxMevSwapFeePercentage()
+    ********************************************************/
+    function getMaxMevSwapFeePercentage() public view {
+        assertEq(_mevHook.getMaxMevSwapFeePercentage(), MAX_FEE_PERCENTAGE, "Incorrect initial max mev fee percentage");
+    }
+
+    /********************************************************
+                         enableMevTax()
+    ********************************************************/
+    function testSetMaxMevSwapFeePercentageIsPermissioned() public {
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        _mevHook.setMaxMevSwapFeePercentage(50e16);
+    }
+
+    function testSetMaxMevSwapFeePercentageAboveMax() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IMevHook.MevSwapFeePercentageAboveMax.selector,
+                MAX_FEE_PERCENTAGE + 1,
+                MAX_FEE_PERCENTAGE
+            )
+        );
+        vm.prank(admin);
+        _mevHook.setMaxMevSwapFeePercentage(MAX_FEE_PERCENTAGE + 1);
+    }
+
+    function testSetMaxMevSwapFeePercentage() public {
+        uint256 newMaxMevSwapFeePercentage = 50e16;
+        assertEq(_mevHook.getMaxMevSwapFeePercentage(), MAX_FEE_PERCENTAGE, "Incorrect initial max mev fee percentage");
+        vm.prank(admin);
+        vm.expectEmit();
+        emit IMevHook.MaxMevSwapFeePercentageSet(newMaxMevSwapFeePercentage);
+        _mevHook.setMaxMevSwapFeePercentage(newMaxMevSwapFeePercentage);
+        assertEq(
+            _mevHook.getMaxMevSwapFeePercentage(),
+            newMaxMevSwapFeePercentage,
+            "Incorrect new max mev fee percentage"
+        );
     }
 
     /********************************************************
@@ -343,5 +390,61 @@ contract MevHookTest is BaseVaultTest {
         assertEq(_mevHook.getPoolMevTaxThreshold(pool), newPoolMevTaxThreshold, "poolMevTaxThreshold is not correct");
 
         assertEq(_mevHook.getDefaultMevTaxThreshold(), firstDefaultMevTaxThreshold, "Default threshold changed");
+    }
+
+    /**
+     * @dev No matter what the parameters are,
+     * - `staticFeePercentage <= computedFeePercentage <= maxFeePercentage` if `maxFeePercentage > staticFeePercentage`
+     * - `computedFeePercentage = staticFeePercentage` if `maxFeePercentage <= staticFeePercentage`
+     */
+    function testCallbackBoundaries__Fuzz(
+        uint256 txGasPrice,
+        uint256 txBaseFee,
+        uint256 threshold,
+        uint256 multiplier,
+        uint256 maxMevSwapFeePercentage,
+        uint256 staticSwapFeePercentage
+    ) public {
+        txGasPrice = bound(txGasPrice, 1, 100e9);
+        txBaseFee = bound(txBaseFee, 1, txGasPrice);
+        threshold = bound(threshold, 1, 100e9);
+        multiplier = bound(multiplier, 1, 1_000_000e18);
+        maxMevSwapFeePercentage = bound(maxMevSwapFeePercentage, 1, MAX_FEE_PERCENTAGE);
+        staticSwapFeePercentage = bound(staticSwapFeePercentage, 1e12, 10e16);
+
+        vm.txGasPrice(txGasPrice);
+        vm.fee(txBaseFee);
+        vm.startPrank(admin);
+        _mevHook.setPoolMevTaxThreshold(pool, threshold);
+        _mevHook.setPoolMevTaxMultiplier(pool, multiplier);
+        _mevHook.setMaxMevSwapFeePercentage(maxMevSwapFeePercentage);
+        vm.stopPrank();
+
+        PoolSwapParams memory poolSwapParams;
+
+        (bool success, uint256 computedSwapFeePercentage) = IHooks(address(_mevHook)).onComputeDynamicSwapFeePercentage(
+            poolSwapParams,
+            pool,
+            staticSwapFeePercentage
+        );
+        assertGe(
+            computedSwapFeePercentage,
+            staticSwapFeePercentage,
+            "Computed swap fee percentage below static fee percentage"
+        );
+        if (maxMevSwapFeePercentage >= staticSwapFeePercentage) {
+            assertLe(
+                computedSwapFeePercentage,
+                maxMevSwapFeePercentage,
+                "Computed swap fee percentage above max fee percentage"
+            );
+        } else {
+            assertEq(
+                computedSwapFeePercentage,
+                staticSwapFeePercentage,
+                "Computed swap fee percentage is not the static fee percentage"
+            );
+        }
+        assertTrue(success, "Hook failed");
     }
 }


### PR DESCRIPTION
# Description

Add configurable (soft) max mev swap fee percentage. The hard lower bound is always the static swap fee percentage, and the upper bound is the new max mev swap fee percentage only if it's larger than the static swap fee.

In principle we might not needed, but it's good to have one more extra lever to configure the behavior if needed. By default works exactly the same as before.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #1227