### PR TITLE
NFT example add hook validation

### DIFF
--- a/pkg/pool-hooks/contracts/NftLiquidityPositionExample.sol
+++ b/pkg/pool-hooks/contracts/NftLiquidityPositionExample.sol
@@ -235,7 +235,7 @@ contract NftLiquidityPositionExample is MinimalRouter, ERC721, BaseHooks {
         uint256,
         uint256[] memory,
         bytes memory
-    ) public view override onlySelfRouter(router) returns (bool) {
+    ) public view override onlyVault onlySelfRouter(router) returns (bool) {
         // We only allow addLiquidity via the Router/Hook itself (as it must custody BPT).
         return true;
     }
@@ -250,7 +250,7 @@ contract NftLiquidityPositionExample is MinimalRouter, ERC721, BaseHooks {
         uint256[] memory amountsOutRaw,
         uint256[] memory,
         bytes memory userData
-    ) public override onlySelfRouter(router) returns (bool, uint256[] memory hookAdjustedAmountsOutRaw) {
+    ) public override onlyVault onlySelfRouter(router) returns (bool, uint256[] memory hookAdjustedAmountsOutRaw) {
         // We only allow removeLiquidity via the Router/Hook itself so that fee is applied correctly.
         uint256 tokenId = abi.decode(userData, (uint256));
         hookAdjustedAmountsOutRaw = amountsOutRaw;

--- a/pkg/pool-hooks/test/foundry/NftLiquidityPositionExample.t.sol
+++ b/pkg/pool-hooks/test/foundry/NftLiquidityPositionExample.t.sol
@@ -6,11 +6,17 @@ import "forge-std/Test.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import { LiquidityManagement, PoolRoleAccounts } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 import { IVaultExtension } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultExtension.sol";
+import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 import { IVaultAdmin } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultAdmin.sol";
 import { IVaultMock } from "@balancer-labs/v3-interfaces/contracts/test/IVaultMock.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import {
+    LiquidityManagement,
+    PoolRoleAccounts,
+    AddLiquidityKind,
+    RemoveLiquidityKind
+} from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
 import { CastingHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/CastingHelpers.sol";
 import { BasicAuthorizerMock } from "@balancer-labs/v3-vault/contracts/test/BasicAuthorizerMock.sol";
@@ -330,5 +336,36 @@ contract NftLiquidityPositionExampleTest is BaseVaultTest {
         vm.expectRevert(abi.encodeWithSelector(NftLiquidityPositionExample.CannotUseExternalRouter.selector, router));
         vm.prank(lp);
         router.removeLiquidityProportional(pool, 2 * amountOut, minAmountsOut, false, bytes(""));
+    }
+
+    function testBeforeAddOnlyVault() public {
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.SenderIsNotVault.selector, admin));
+
+        nftRouter.onBeforeAddLiquidity(
+            address(nftRouter),
+            address(0),
+            AddLiquidityKind.PROPORTIONAL,
+            new uint256[](0),
+            0,
+            new uint256[](0),
+            ""
+        );
+    }
+
+    function testAfterRemoveOnlyVault() public {
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.SenderIsNotVault.selector, admin));
+
+        nftRouter.onAfterRemoveLiquidity(
+            address(nftRouter),
+            address(0),
+            RemoveLiquidityKind.PROPORTIONAL,
+            0,
+            new uint256[](0),
+            new uint256[](0),
+            new uint256[](0),
+            ""
+        );
     }
 }


### PR DESCRIPTION
# Description

NftLiquidityPositionExample: Add onlyVault validation to onBeforeAddLiquidity and onAfterRemoveLiquidity hooks.
This was highlighted by Christian from QuantAMM.

## Type of change

- [X] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
