### PR TITLE
Basic Protocol Fee Sweeper

### DIFF
--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol
@@ -6,9 +6,9 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IProtocolFeeBurner {
     function burn(
-        IERC20 tokenIn,
-        uint256 tokenInAmount,
-        IERC20 tokenOut,
+        IERC20 feeToken,
+        uint256 feeTokenAmount,
+        IERC20 targetToken,
         address recipient
-    ) external returns (uint256 tokenOutAmount);
+    ) external returns (uint256 targetTokenAmount);
 }

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol
@@ -5,7 +5,25 @@ pragma solidity ^0.8.24;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IProtocolFeeBurner {
+    event ProtocolFeeBurned(
+        address indexed pool,
+        IERC20 indexed feeToken,
+        uint256 feeTokenAmount,
+        IERC20 indexed targetToken,
+        uint256 targetTokenAmount,
+        address recipient
+    );
+
+    /**
+     * @notice Swap an exact amount of `feeToken` for the `targetToken`, and send proceeds to the `recipient`.
+     * @param pool The pool the fees came from (only used for documentation in the event)
+     * @param feeToken The feeToken collected from the pool
+     * @param feeTokenAmount The number of fee tokens collected
+     * @param targetToken The desired target token (token out of the swap)
+     * @param recipient The recipient of the swap proceeds
+     */
     function burn(
+        address pool,
         IERC20 feeToken,
         uint256 feeTokenAmount,
         IERC20 targetToken,

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol
@@ -16,6 +16,7 @@ interface IProtocolFeeBurner {
 
     /**
      * @notice Swap an exact amount of `feeToken` for the `targetToken`, and send proceeds to the `recipient`.
+     * @dev Assumes the sweeper has transferred the tokens to the burner prior to the call.
      * @param pool The pool the fees came from (only used for documentation in the event)
      * @param feeToken The feeToken collected from the pool
      * @param feeTokenAmount The number of fee tokens collected

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol
@@ -5,5 +5,10 @@ pragma solidity ^0.8.24;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IProtocolFeeBurner {
-    function burn(IERC20 tokenIn, uint256 tokenInAmount, IERC20 tokenOut, address recipient) external returns(uint256 tokenOutAmount);
+    function burn(
+        IERC20 tokenIn,
+        uint256 tokenInAmount,
+        IERC20 tokenOut,
+        address recipient
+    ) external returns (uint256 tokenOutAmount);
 }

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol
@@ -10,5 +10,5 @@ interface IProtocolFeeBurner {
         uint256 feeTokenAmount,
         IERC20 targetToken,
         address recipient
-    ) external returns (uint256 targetTokenAmount);
+    ) external;
 }

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IProtocolFeeBurner {
+    function burn(IERC20 tokenIn, uint256 tokenInAmount, IERC20 tokenOut, address recipient) external returns(uint256 tokenOutAmount);
+}

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
@@ -34,12 +34,7 @@ interface IProtocolFeeSweeper {
      * @param feeTokenAmount The number of feeTokens
      * @param recipient The recipient of the target tokens
      */
-    event ProtocolFeeSwept(
-        address indexed pool,
-        IERC20 indexed feeToken,
-        uint256 feeTokenAmount,
-        address recipient
-    );
+    event ProtocolFeeSwept(address indexed pool, IERC20 indexed feeToken, uint256 feeTokenAmount, address recipient);
 
     /**
      * @notice Withdraw, convert, and forward protocol fees for a given pool.
@@ -55,7 +50,7 @@ interface IProtocolFeeSweeper {
      * @dev It is not immutable in the Vault, so we need to get it every time.
      * @return protocolFeeController The address of the current `ProtocolFeeController`
      */
-    function getProtocolFeeController() public view returns (IProtocolFeeController);
+    function getProtocolFeeController() external view returns (IProtocolFeeController);
 
     /**
      * @notice Getter for the target token.
@@ -75,4 +70,34 @@ interface IProtocolFeeSweeper {
      * @return protocolFeeBurner The currently active protocol fee burner
      */
     function getProtocolFeeBurner() external view returns (IProtocolFeeBurner);
+
+    /**
+     * @notice Update the fee recipient address.
+     * @dev This is a permissioned function.
+     * @param feeRecipient The address of the new fee recipient
+     */
+    function setFeeRecipient(address feeRecipient) external;
+
+    /**
+     * @notice Set a protocol fee burner, used to convert protocol fees to a target token.
+     * @dev This is a permissioned function. If it is not set, the contract will fall back to forwarding the fee tokens
+     * directly to the fee recipient.
+     *
+     * @param protocolFeeBurner The address of the current protocol fee burner
+     */
+    function setProtocolFeeBurner(IProtocolFeeBurner protocolFeeBurner) external;
+
+    /**
+     * @notice Update the address of the target token.
+     * @dev This is the token the burner will attempt to swap all collected fee tokens to.
+     * @param targetToken The address of the target token
+     */
+    function setTargetToken(IERC20 targetToken) external;
+
+    /**
+     * @notice Retrieve any tokens "stuck" in this contract (e.g., dust, or failed conversions).
+     * @dev It will recover the full balance of all the tokens. This can only be called by the `feeRecipient`.
+     * @param feeTokens The tokens to recover
+     */
+    function recoverProtocolFees(IERC20[] memory feeTokens) external;
 }

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.24;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import { IProtocolFeeController } from "../vault/IProtocolFeeController.sol";
+import { IProtocolFeeBurner } from "./IProtocolFeeBurner.sol";
+
 interface IProtocolFeeSweeper {
     /**
      * @notice Emitted when the target token is updated.
@@ -24,35 +27,14 @@ interface IProtocolFeeSweeper {
     event ProtocolFeeBurnerSet(address indexed protocolFeeBurner);
 
     /**
-     * @notice Emitted when a fee token has been burned.
-     * @dev This means it was converted to the target and sent to the recipient.
-     * @param pool The pool the fee was collected on
-     * @param feeToken The token the fee was collected in
-     * @param feeTokenAmount The number of feeTokens to be swapped for the target token
-     * @param targetToken The target token to exchange the fee token for
-     * @param targetTokenAmount The number of target tokens the burner swapped for the fee tokens
-     * @param protocolFeeBurner The address of the burner contract that performed the swap
-     * @param recipient The recipient of the target tokens
-     */
-    event ProtocolFeeBurned(
-        address indexed pool,
-        IERC20 indexed feeToken,
-        uint256 feeTokenAmount,
-        IERC20 indexed targetToken,
-        uint256 targetTokenAmount,
-        address protocolFeeBurner,
-        address recipient
-    );
-
-    /**
      * @notice Emitted when a fee token is transferred directly.
-     * @dev This happens when the fee token is already the target token.
+     * @dev This can happen if no target token or burner contract was specified, or the fee token is the target token.
      * @param pool The pool the fee was collected on
      * @param feeToken The token the fee was collected in (also the target token in this case; no swap necessary)
      * @param feeTokenAmount The number of feeTokens
      * @param recipient The recipient of the target tokens
      */
-    event ProtocolFeeTransferred(
+    event ProtocolFeeSwept(
         address indexed pool,
         IERC20 indexed feeToken,
         uint256 feeTokenAmount,
@@ -67,4 +49,30 @@ interface IProtocolFeeSweeper {
      * @param pool The pool from which we're withdrawing fees
      */
     function sweepProtocolFees(address pool) external;
+
+    /**
+     * @notice Return the address of the current `ProtocolFeeController` from the Vault.
+     * @dev It is not immutable in the Vault, so we need to get it every time.
+     * @return protocolFeeController The address of the current `ProtocolFeeController`
+     */
+    function getProtocolFeeController() public view returns (IProtocolFeeController);
+
+    /**
+     * @notice Getter for the target token.
+     * @dev This is the token the burner will swap all fee tokens for.
+     * @return targetToken The current target token
+     */
+    function getTargetToken() external view returns (IERC20);
+
+    /**
+     * @notice Getter for the current fee recipient.
+     * @return feeRecipient The currently active fee recipient
+     */
+    function getFeeRecipient() external view returns (address);
+
+    /**
+     * @notice Getter for the current protocol fee burner.
+     * @return protocolFeeBurner The currently active protocol fee burner
+     */
+    function getProtocolFeeBurner() external view returns (IProtocolFeeBurner);
 }

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
@@ -36,12 +36,35 @@ interface IProtocolFeeSweeper {
      */
     event ProtocolFeeSwept(address indexed pool, IERC20 indexed feeToken, uint256 feeTokenAmount, address recipient);
 
+    /// @notice The fee recipient is invalid.
+    error InvalidFeeRecipient();
+
+    /// @notice The target token is invalid.
+    error InvalidTargetToken();
+
+    /**
+     * @notice Withdraw, convert, and forward protocol fees for a given pool and token.
+     * @dev This will withdraw the fee token from the controller to this contract, and attempt to convert and forward
+     * the proceeds to the fee recipient. Note that this requires governance to grant this contract permission to call
+     * `withdrawProtocolFeesForToken` on the `ProtocolFeeController`. Since the general idea is to sweep when the token
+     * value crosses a certain threshold, we expect that this might be the most commonly used sweeping function.
+     *
+     * This is a permissioned call, since it involves a swap and a permissionless sweep could be triggered at times
+     * disadvantageous to the protocol (e.g., flash crashes).
+     *
+     * @param pool The pool that incurred the fees we're withdrawing
+     * @param feeToken The fee token in the pool
+     */
+    function sweepProtocolFeesForToken(address pool, IERC20 feeToken) external;
+
     /**
      * @notice Withdraw, convert, and forward protocol fees for a given pool.
      * @dev This will withdraw all fee tokens from the controller to this contract, and attempt to convert and forward
-     * them to the fee recipient. There is also a single token pool withdrawal, but that is an edge case not in scope
-     * for the sweeper. Note that this requires governance to grant this contract permission to call
+     * the proceeds to the fee recipient. Note that this requires governance to grant this contract permission to call
      * `withdrawProtocolFees` on the `ProtocolFeeController`.
+     *
+     * This is a permissioned call, since it involves a swap and a permissionless sweep could be triggered at times
+     * disadvantageous to the protocol (e.g., flash crashes).
      *
      * @param pool The pool that incurred the fees we're withdrawing
      */

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
@@ -61,16 +61,10 @@ interface IProtocolFeeSweeper {
 
     /**
      * @notice Withdraw, convert, and forward protocol fees for a given pool.
-     * @dev This will withdraw all fee tokens to this contract, and attempt to convert and forward them.
+     * @dev This will withdraw all fee tokens to this contract, and attempt to convert and forward them. There is also
+     * a single token pool withdrawal, but that is an edge case not in scope for the sweeper.
+     *
      * @param pool The pool from which we're withdrawing fees
      */
     function sweepProtocolFees(address pool) external;
-
-    /**
-     * @notice Withdraw, convert, and forward protocol fees for a given pool and token.
-     * @dev This will withdraw any fees collected on that pool and token, and attempt to convert and forward them.
-     * @param pool The pool from which we're withdrawing fees
-     * @param token The fee token
-     */
-    function sweepProtocolFeesForToken(address pool, IERC20 token) external;
 }

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
@@ -108,7 +108,8 @@ interface IProtocolFeeSweeper {
     /**
      * @notice Update the address of the protocol fee burner, used to convert protocol fees to a target token.
      * @dev This is a permissioned function. If it is not set, the contract will fall back to forwarding all fee tokens
-     * directly to the fee recipient.
+     * directly to the fee recipient. Note that if this function is called, `setTargetToken` must be called as well,
+     * or any sweep operations using the burner will revert with `InvalidTargetToken`.
      *
      * @param protocolFeeBurner The address of the current protocol fee burner
      */

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IProtocolFeeSweeper {
+    /**
+     * @notice Withdraw, convert, and forward protocol fees for a given pool.
+     * @dev This will withdraw all fee tokens to this contract, and attempt to convert and forward them.
+     * @param pool The pool from which we're withdrawing fees
+     */
+    function sweepProtocolFees(address pool) external;
+
+    /**
+     * @notice Withdraw, convert, and forward protocol fees for a given pool and token.
+     * @dev This will withdraw any fees collected on that pool and token, and attempt to convert and forward them.
+     * @param pool The pool from which we're withdrawing fees
+     * @param token The fee token
+     */
+    function sweepProtocolFeesForToken(address pool, IERC20 token) external;
+}

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
@@ -6,6 +6,60 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IProtocolFeeSweeper {
     /**
+     * @notice Emitted when the target token is updated.
+     * @param token The preferred token for receiving protocol fees
+     */
+    event TargetTokenSet(IERC20 indexed token);
+
+    /**
+     * @notice Emitted when the fee recipient address is verified.
+     * @param feeRecipient The final destination of collected protocol fees
+     */
+    event FeeRecipientSet(address indexed feeRecipient);
+
+    /**
+     * @notice Emitted when governance has set the protocol fee burner contract.
+     * @param protocolFeeBurner The contract used to "burn" protocol fees (i.e., convert them to the target token)
+     */
+    event ProtocolFeeBurnerSet(address indexed protocolFeeBurner);
+
+    /**
+     * @notice Emitted when a fee token has been burned.
+     * @dev This means it was converted to the target and sent to the recipient.
+     * @param pool The pool the fee was collected on
+     * @param feeToken The token the fee was collected in
+     * @param feeTokenAmount The number of feeTokens to be swapped for the target token
+     * @param targetToken The target token to exchange the fee token for
+     * @param targetTokenAmount The number of target tokens the burner swapped for the fee tokens
+     * @param protocolFeeBurner The address of the burner contract that performed the swap
+     * @param recipient The recipient of the target tokens
+     */
+    event ProtocolFeeBurned(
+        address indexed pool,
+        IERC20 indexed feeToken,
+        uint256 feeTokenAmount,
+        IERC20 indexed targetToken,
+        uint256 targetTokenAmount,
+        address protocolFeeBurner,
+        address recipient
+    );
+
+    /**
+     * @notice Emitted when a fee token is transferred directly.
+     * @dev This happens when the fee token is already the target token.
+     * @param pool The pool the fee was collected on
+     * @param feeToken The token the fee was collected in (also the target token in this case; no swap necessary)
+     * @param feeTokenAmount The number of feeTokens
+     * @param recipient The recipient of the target tokens
+     */
+    event ProtocolFeeTransferred(
+        address indexed pool,
+        IERC20 indexed feeToken,
+        uint256 feeTokenAmount,
+        address recipient
+    );
+
+    /**
      * @notice Withdraw, convert, and forward protocol fees for a given pool.
      * @dev This will withdraw all fee tokens to this contract, and attempt to convert and forward them.
      * @param pool The pool from which we're withdrawing fees

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
@@ -9,64 +9,68 @@ import { IProtocolFeeBurner } from "./IProtocolFeeBurner.sol";
 
 interface IProtocolFeeSweeper {
     /**
-     * @notice Emitted when the target token is updated.
+     * @notice Emitted when the target token is set or updated.
      * @param token The preferred token for receiving protocol fees
      */
     event TargetTokenSet(IERC20 indexed token);
 
     /**
-     * @notice Emitted when the fee recipient address is verified.
+     * @notice Emitted when the fee recipient address is set or updated.
      * @param feeRecipient The final destination of collected protocol fees
      */
     event FeeRecipientSet(address indexed feeRecipient);
 
     /**
-     * @notice Emitted when governance has set the protocol fee burner contract.
+     * @notice Emitted when the protocol fee burner contract is set or updated.
      * @param protocolFeeBurner The contract used to "burn" protocol fees (i.e., convert them to the target token)
      */
     event ProtocolFeeBurnerSet(address indexed protocolFeeBurner);
 
     /**
-     * @notice Emitted when a fee token is transferred directly.
+     * @notice Emitted when a fee token is transferred directly, vs. calling the burner.
      * @dev This can happen if no target token or burner contract was specified, or the fee token is the target token.
-     * @param pool The pool the fee was collected on
+     * @param pool The pool on which the fee was collected
      * @param feeToken The token the fee was collected in (also the target token in this case; no swap necessary)
      * @param feeTokenAmount The number of feeTokens
-     * @param recipient The recipient of the target tokens
+     * @param recipient The recipient of the fee tokens
      */
     event ProtocolFeeSwept(address indexed pool, IERC20 indexed feeToken, uint256 feeTokenAmount, address recipient);
 
     /**
      * @notice Withdraw, convert, and forward protocol fees for a given pool.
-     * @dev This will withdraw all fee tokens to this contract, and attempt to convert and forward them. There is also
-     * a single token pool withdrawal, but that is an edge case not in scope for the sweeper.
+     * @dev This will withdraw all fee tokens from the controller to this contract, and attempt to convert and forward
+     * them to the fee recipient. There is also a single token pool withdrawal, but that is an edge case not in scope
+     * for the sweeper. Note that this requires governance to grant this contract permission to call
+     * `withdrawProtocolFees` on the `ProtocolFeeController`.
      *
-     * @param pool The pool from which we're withdrawing fees
+     * @param pool The pool that incurred the fees we're withdrawing
      */
     function sweepProtocolFees(address pool) external;
 
     /**
      * @notice Return the address of the current `ProtocolFeeController` from the Vault.
-     * @dev It is not immutable in the Vault, so we need to get it every time.
+     * @dev It is not immutable in the Vault, so we need to fetch it every time.
      * @return protocolFeeController The address of the current `ProtocolFeeController`
      */
     function getProtocolFeeController() external view returns (IProtocolFeeController);
 
     /**
      * @notice Getter for the target token.
-     * @dev This is the token the burner will swap all fee tokens for.
+     * @dev This is the token the burner will swap all fee tokens for. Can be changed by `setTargetToken`.
      * @return targetToken The current target token
      */
     function getTargetToken() external view returns (IERC20);
 
     /**
      * @notice Getter for the current fee recipient.
-     * @return feeRecipient The currently active fee recipient
+     * @dev Can be changed by `setFeeRecipient`.
+     * @return feeRecipient The current fee recipient
      */
     function getFeeRecipient() external view returns (address);
 
     /**
      * @notice Getter for the current protocol fee burner.
+     * @dev Can be changed by `setProtocolFeeBurner`.
      * @return protocolFeeBurner The currently active protocol fee burner
      */
     function getProtocolFeeBurner() external view returns (IProtocolFeeBurner);
@@ -79,8 +83,8 @@ interface IProtocolFeeSweeper {
     function setFeeRecipient(address feeRecipient) external;
 
     /**
-     * @notice Set a protocol fee burner, used to convert protocol fees to a target token.
-     * @dev This is a permissioned function. If it is not set, the contract will fall back to forwarding the fee tokens
+     * @notice Update the address of the protocol fee burner, used to convert protocol fees to a target token.
+     * @dev This is a permissioned function. If it is not set, the contract will fall back to forwarding all fee tokens
      * directly to the fee recipient.
      *
      * @param protocolFeeBurner The address of the current protocol fee burner
@@ -89,7 +93,7 @@ interface IProtocolFeeSweeper {
 
     /**
      * @notice Update the address of the target token.
-     * @dev This is the token the burner will attempt to swap all collected fee tokens to.
+     * @dev This is the token for which the burner will attempt to swap all collected fee tokens.
      * @param targetToken The address of the target token
      */
     function setTargetToken(IERC20 targetToken) external;

--- a/pkg/solidity-utils/test/foundry/utils/BaseTest.sol
+++ b/pkg/solidity-utils/test/foundry/utils/BaseTest.sol
@@ -31,6 +31,8 @@ abstract contract BaseTest is Test, GasSnapshot {
     bytes32 internal constant ZERO_BYTES32 = 0x0000000000000000000000000000000000000000000000000000000000000000;
     bytes32 internal constant ONE_BYTES32 = 0x0000000000000000000000000000000000000000000000000000000000000001;
 
+    address internal constant ZERO_ADDRESS = address(0);
+
     // Default admin.
     address payable internal admin;
     uint256 internal adminKey;

--- a/pkg/standalone-utils/contracts/ProtocolFeeSweeper.sol
+++ b/pkg/standalone-utils/contracts/ProtocolFeeSweeper.sol
@@ -109,6 +109,11 @@ contract ProtocolFeeSweeper is IProtocolFeeSweeper, SingletonAuthentication, Ree
         uint256 withdrawnTokenBalance,
         IProtocolFeeBurner feeBurner
     ) internal {
+        // Short-circuit if nothing to do.
+        if (withdrawnTokenBalance == 0) {
+            return;
+        }
+
         // If no burner has been set, fall back on direct transfer of the fee token.
         if (address(feeBurner) == address(0)) {
             _transferFeeToken(pool, feeToken, withdrawnTokenBalance);

--- a/pkg/standalone-utils/contracts/ProtocolFeeSweeper.sol
+++ b/pkg/standalone-utils/contracts/ProtocolFeeSweeper.sol
@@ -57,18 +57,6 @@ contract ProtocolFeeSweeper is IProtocolFeeSweeper, SingletonAuthentication {
         _processProtocolFees(pool, getVault().getPoolTokens(pool));
     }
 
-    /// @inheritdoc IProtocolFeeSweeper
-    function sweepProtocolFeesForToken(address pool, IERC20 token) external {
-        // Collect protocol fees - note that governance will need to grant this contract permission to call
-        // `withdrawProtocolFeesForToken` on the `ProtocolFeeController.
-        getProtocolFeeController().withdrawProtocolFeesForToken(pool, address(this), token);
-
-        IERC20[] memory tokens = new IERC20[](1);
-        tokens[0] = token;
-
-        _processProtocolFees(pool, tokens);
-    }
-
     // Convert the given tokens to the target token (if enabled), and forward to the fee recipient. This assumes we
     // have externally validated the fee recipient.
     function _processProtocolFees(address pool, IERC20[] memory tokens) internal {

--- a/pkg/standalone-utils/contracts/ProtocolFeeSweeper.sol
+++ b/pkg/standalone-utils/contracts/ProtocolFeeSweeper.sol
@@ -63,13 +63,13 @@ contract ProtocolFeeSweeper is IProtocolFeeSweeper, SingletonAuthentication {
         getProtocolFeeController().withdrawProtocolFees(pool, address(this));
 
         // Convert the given tokens to the target token (if enabled), and forward to the fee recipient.
-        IProtocolFeeBurner burner = _protocolFeeBurner;
+        IProtocolFeeBurner feeBurner = _protocolFeeBurner;
         IERC20 targetToken = _targetToken;
         address recipient = _feeRecipient;
 
         // There must be a burner contract and valid target token to enable converting fees to the preferred currency.
         // If these were not set, fall back on simply transferring all fee tokens directly to the recipient.
-        bool canBurn = targetToken != IERC20(address(0)) && burner != IProtocolFeeBurner(address(0));
+        bool canBurn = targetToken != IERC20(address(0)) && feeBurner != IProtocolFeeBurner(address(0));
 
         for (uint256 i = 0; i < numTokens; ++i) {
             IERC20 feeToken = poolTokens[i];
@@ -83,9 +83,9 @@ contract ProtocolFeeSweeper is IProtocolFeeSweeper, SingletonAuthentication {
             // If this is already the target token (or we haven't enabled burning), just forward directly.
             if (canBurn && feeToken != targetToken) {
                 // Allow the burner to withdraw tokens from this contract.
-                feeToken.forceApprove(address(burner), withdrawnTokenBalance);
+                feeToken.forceApprove(address(feeBurner), withdrawnTokenBalance);
                 // This is asynchronous; the burner will complete the action and emit an event.
-                _protocolFeeBurner.burn(pool, feeToken, withdrawnTokenBalance, targetToken, recipient);
+                feeBurner.burn(pool, feeToken, withdrawnTokenBalance, targetToken, recipient);
             } else {
                 feeToken.safeTransfer(recipient, withdrawnTokenBalance);
 

--- a/pkg/standalone-utils/contracts/ProtocolFeeSweeper.sol
+++ b/pkg/standalone-utils/contracts/ProtocolFeeSweeper.sol
@@ -82,8 +82,8 @@ contract ProtocolFeeSweeper is IProtocolFeeSweeper, SingletonAuthentication {
 
             // If this is already the target token (or we haven't enabled burning), just forward directly.
             if (canBurn && feeToken != targetToken) {
-                // Allow the burner to withdraw tokens from this contract.
-                feeToken.forceApprove(address(feeBurner), withdrawnTokenBalance);
+                // Transfer the tokens directly to avoid "hanging approvals," in case the burn is unsuccessful.
+                feeToken.safeTransfer(address(feeBurner), withdrawnTokenBalance);
                 // This is asynchronous; the burner will complete the action and emit an event.
                 feeBurner.burn(pool, feeToken, withdrawnTokenBalance, targetToken, recipient);
             } else {

--- a/pkg/standalone-utils/contracts/ProtocolFeeSweeper.sol
+++ b/pkg/standalone-utils/contracts/ProtocolFeeSweeper.sol
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IProtocolFeeBurner } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol";
+import { IProtocolFeeController } from "@balancer-labs/v3-interfaces/contracts/vault/IProtocolFeeController.sol";
+
+import { SingletonAuthentication } from "@balancer-labs/v3-vault/contracts/SingletonAuthentication.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+
+/**
+ * @notice Withdraw protocol fees, convert them to a target token, and forward to a recipient.
+ * @dev This withdraws all protocol fees previously collected and allocated to the protocol by the
+ * `ProtocolFeeController`, processes them with a configurable "burner" (e.g., from CowSwap) and forwards them to
+ * a recipient contract.
+ * 
+ * This is the basic version that uses only the "fallback" method, simply forwarding all tokens collected to a
+ * designated fee recipient (e.g., a multi-sig). It has some infrastructure that will be used for future versions.
+ */
+contract ProtocolFeeSweeper is SingletonAuthentication {
+    using SafeERC20 for IERC20;
+
+    /**
+     * @notice Emitted when the target token is updated.
+     * @param token The preferred token for receiving protocol fees
+     */
+    event TargetTokenSet(IERC20 indexed token);
+
+    /**
+     * @notice Emitted when a new fee recipient is proposed.
+     * @dev Fees will not be distributed until the fee recipient is finalized with `claimFeeRecipient`.
+     * @param feeRecipient The intended final destination of collected protocol fees
+     */
+    event PendingFeeRecipientSet(address indexed feeRecipient);
+
+    /**
+     * @notice Emitted when the fee recipient address is verified.
+     * @param feeRecipient The final destination of collected protocol fees
+     */
+    event FeeRecipientSet(address indexed feeRecipient);
+
+    /**
+     * @notice Emitted when governance has set the protocol fee burner contract.
+     * @param protocolFeeBurner The contract used to "burn" protocol fees (i.e., convert them to the target token)
+     */
+    event ProtocolFeeBurnerSet(address indexed protocolFeeBurner);
+
+    /// @notice Thrown if we attempt to sweep fees before setting a fee recipient.
+    error NoFeeRecipient();
+
+    /// @notice This contract should not receive ETH.
+    error CannotReceiveEth();
+
+    modifier withValidFeeRecipient() {
+        if (_feeRecipient == address(0)) {
+            revert NoFeeRecipient();
+        }
+        _;
+    }
+
+    // Preferred token for receiving protocol fees. This does not need to be validated, since setting it to an
+    // invalid or incorrect value would just mean fees could not be converted to it, in which case the contract
+    // would fall back on forwarding the tokens as collected.
+    IERC20 private _targetToken;
+
+    // Intended destination of the collected protocol fees. Since the protocol fee recipient is of critical importance,
+    // it must be claimed by that address to take effect.
+    address private _pendingFeeRecipient;
+
+    // Final destination of the collected protocol fees, after confirmation through the claims process.
+    address private _feeRecipient;
+
+    // Address of the current "burn" strategy (i.e., swapping fee tokens to the target).
+    IProtocolFeeBurner private _protocolFeeBurner;
+
+    constructor(IVault vault, address feeRecipient) SingletonAuthentication(vault) {
+        _setPendingFeeRecipient(feeRecipient);
+    }
+
+    /**
+     * @notice Getter for the pending fee recipient.
+     * @dev This will be initialized on deployment, and set to zero once claimed.
+     * @return pendingFeeRecipient The proposed fee recipient
+     */
+    function getPendingFeeRecipient() external view returns(address) {
+        return _pendingFeeRecipient;
+    }
+
+    /**
+     * @notice Getter for the current fee recipient.
+     * @dev This will be zero until claimed initially.
+     * @return feeRecipient The currently active fee recipient
+     */
+    function getFeeRecipient() external view returns(address) {
+        return _feeRecipient;
+    }
+
+    /**
+     * @notice Withdraw and distribute protocol fees for a given pool.
+     * @dev This will withdraw all fee tokens to this contract, and attempt to distribute them.
+     * @param pool The pool from which we're withdrawing fees
+     */
+    function sweepProtocolFees(address pool) external withValidFeeRecipient() {
+        // Collect protocol fees - note that governance will need to grant this contract permission to call
+        // `withdrawProtocolFees` on the `ProtocolFeeController. It is not immutable in the Vault, so we need
+        // to get it every time.
+        IProtocolFeeController feeController = getVault().getProtocolFeeController();
+        feeController.withdrawProtocolFees(pool, address(this));
+
+        _processProtocolFees(getVault().getPoolTokens(pool));
+    }
+
+    /**
+     * @notice Withdraw and distribute protocol fees for a given pool and token.
+     * @dev This will withdraw any fees collected on that pool and token, and attempt to distribute them.
+     * @param pool The pool from which we're withdrawing fees
+     * @param token The fee token
+     */
+    function sweepProtocolFeesForToken(address pool, IERC20 token) external withValidFeeRecipient() {
+        // Collect protocol fees - note that governance will need to grant this contract permission to call
+        // `withdrawProtocolFeesForToken` on the `ProtocolFeeController. It is not immutable in the Vault, so we need
+        // to get it every time.
+        IProtocolFeeController feeController = getVault().getProtocolFeeController();
+        feeController.withdrawProtocolFeesForToken(pool, address(this), token);
+
+        IERC20[] memory tokens = new IERC20[](1);
+        tokens[0] = token;
+
+        _processProtocolFees(tokens);
+    }
+
+    /**
+     * @notice Retrieve any tokens "stuck" in this contract (e.g., dust, or failed conversions).
+     * @dev It will recover the full balance of all the tokens. This can only be called by the `feeRecipient`.
+     * @param tokens The tokens to recover
+     */
+    function recoverProtocolFees(IERC20[] memory tokens) external {
+        if (msg.sender != _feeRecipient) {
+            revert SenderNotAllowed();
+        }
+
+        for (uint256 i = 0; i < tokens.length; ++i) {
+            IERC20 token = tokens[i];
+            uint256 tokenBalance = token.balanceOf(address(this));
+
+            if (tokenBalance > 0) {
+                token.safeTransfer(_feeRecipient, tokenBalance);
+            }
+        }
+    }
+
+    /**
+     * @notice Start the process of changing the protocol fee recipient.
+     * @dev The specified account must call `claimFeeRecipient` to complete the process, proving that the recipient
+     * address is a valid account. This is a permissioned function. If this address is set in error and can't be
+     * claimed, it can simply be overwritten.
+     *
+     * @param feeRecipient The address of the new proposed fee recipient
+     */
+    function setPendingFeeRecipient(address feeRecipient) external authenticate {
+        _setPendingFeeRecipient(feeRecipient);
+    }
+
+    /**
+     * @notice Complete the 2-step process to assign a fee recipient.
+     * @dev This must be called by the pending fee recipient.
+     */
+    function claimFeeRecipient() external {
+        if (msg.sender != _pendingFeeRecipient) {
+            revert SenderNotAllowed();
+        }
+
+        _feeRecipient = _pendingFeeRecipient;
+        _pendingFeeRecipient = address(0);
+
+        emit FeeRecipientSet(_feeRecipient);
+    }
+
+    /**
+     * @notice Set a protocol fee burner, used to convert protocol fees to a target token.
+     * @dev This is a permissioned function. If it is not set, the contract will fall back to forwarding the fee tokens
+     * directly to the fee recipient.
+     *
+     * @param protocolFeeBurner The address of the current protocol fee burner
+     */
+    function setProtocolFeeBurner(IProtocolFeeBurner protocolFeeBurner) external authenticate {
+        _protocolFeeBurner = protocolFeeBurner;
+
+        emit ProtocolFeeBurnerSet(address(protocolFeeBurner));
+    }
+
+    function _setTargetToken(IERC20 targetToken) internal {
+        _targetToken = targetToken;
+
+        emit TargetTokenSet(targetToken);
+    }
+
+    function _setPendingFeeRecipient(address feeRecipient) internal {
+        _pendingFeeRecipient = feeRecipient;
+
+        emit PendingFeeRecipientSet(feeRecipient);
+    }
+
+    // Convert the given tokens to the target token (if enabled), and forward to the fee recipient. This assumes we
+    // have externally validated the fee recipient.
+    function _processProtocolFees(IERC20[] memory tokens) internal {
+        IProtocolFeeBurner burner = _protocolFeeBurner;
+        IERC20 targetToken = _targetToken;
+        address recipient = _feeRecipient;
+
+        bool canBurn = targetToken != IERC20(address(0)) && burner != IProtocolFeeBurner(address(0));
+
+        for (uint256 i = 0; i < tokens.length; ++i) {
+            IERC20 token = tokens[i];
+            uint256 tokenBalance = token.balanceOf(address(this));
+
+            // If this is already the target token (or we haven't set a burner), just forward directly.
+            if (canBurn == false || token == targetToken) {
+                token.safeTransfer(recipient, tokenBalance);
+            } else {
+                token.forceApprove(address(burner), tokenBalance);
+                _protocolFeeBurner.burn(token, tokenBalance, targetToken, recipient);
+            }
+        }
+    }
+
+    /*******************************************************************************
+                                     Default handlers
+    *******************************************************************************/
+
+    // Maybe these aren't needed, but given the general sensitivity of this contract, preemptively disallow any
+    // ETH-related shenanigans. Tokens are always ERC20, so there should be no ETH involved in any operations.
+
+    receive() external payable {
+        revert CannotReceiveEth();
+    }
+
+    // solhint-disable no-complex-fallback
+
+    fallback() external payable {
+        if (msg.value > 0) {
+            revert CannotReceiveEth();
+        }
+
+        revert("Not implemented");
+    }
+}

--- a/pkg/standalone-utils/contracts/test/ProtocolFeeBurnerMock.sol
+++ b/pkg/standalone-utils/contracts/test/ProtocolFeeBurnerMock.sol
@@ -13,12 +13,6 @@ import { ERC20TestToken } from "@balancer-labs/v3-solidity-utils/contracts/test/
 contract ProtocolFeeBurnerMock is IProtocolFeeBurner {
     using SafeERC20 for IERC20;
 
-    IProtocolFeeSweeper private _feeSweeper;
-
-    constructor(IProtocolFeeSweeper feeSweeper) {
-        _feeSweeper = feeSweeper;
-    }
-
     /// @inheritdoc IProtocolFeeBurner
     function burn(
         address pool,
@@ -27,11 +21,10 @@ contract ProtocolFeeBurnerMock is IProtocolFeeBurner {
         IERC20 targetToken,
         address recipient
     ) external {
-        // Just emit the event, simulating the tokens being exchanged at 1-to-1.
-        feeToken.safeTransferFrom(address(_feeSweeper), address(this), feeTokenAmount);
         // Simulate the swap by minting the same amount of target to the recipient.
         ERC20TestToken(address(targetToken)).mint(recipient, feeTokenAmount);
 
+        // Just emit the event, simulating the tokens being exchanged at 1-to-1.
         emit ProtocolFeeBurned(pool, feeToken, feeTokenAmount, targetToken, feeTokenAmount, recipient);
     }
 }

--- a/pkg/standalone-utils/contracts/test/ProtocolFeeBurnerMock.sol
+++ b/pkg/standalone-utils/contracts/test/ProtocolFeeBurnerMock.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IProtocolFeeSweeper } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol";
+import { IProtocolFeeBurner } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol";
+
+import { ERC20TestToken } from "@balancer-labs/v3-solidity-utils/contracts/test/ERC20TestToken.sol";
+
+contract ProtocolFeeBurnerMock is IProtocolFeeBurner {
+    using SafeERC20 for IERC20;
+
+    IProtocolFeeSweeper private _feeSweeper;
+
+    constructor(IProtocolFeeSweeper feeSweeper) {
+        _feeSweeper = feeSweeper;
+    }
+
+    /// @inheritdoc IProtocolFeeBurner
+    function burn(
+        address pool,
+        IERC20 feeToken,
+        uint256 feeTokenAmount,
+        IERC20 targetToken,
+        address recipient
+    ) external {
+        // Just emit the event, simulating the tokens being exchanged at 1-to-1.
+        feeToken.safeTransferFrom(address(_feeSweeper), address(this), feeTokenAmount);
+        // Simulate the swap by minting the same amount of target to the recipient.
+        ERC20TestToken(address(targetToken)).mint(recipient, feeTokenAmount);
+
+        emit ProtocolFeeBurned(pool, feeToken, feeTokenAmount, targetToken, feeTokenAmount, recipient);
+    }
+}

--- a/pkg/standalone-utils/contracts/test/ProtocolFeeBurnerMock.sol
+++ b/pkg/standalone-utils/contracts/test/ProtocolFeeBurnerMock.sol
@@ -2,17 +2,13 @@
 
 pragma solidity ^0.8.24;
 
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import { IProtocolFeeSweeper } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol";
 import { IProtocolFeeBurner } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol";
 
 import { ERC20TestToken } from "@balancer-labs/v3-solidity-utils/contracts/test/ERC20TestToken.sol";
 
 contract ProtocolFeeBurnerMock is IProtocolFeeBurner {
-    using SafeERC20 for IERC20;
-
     /// @inheritdoc IProtocolFeeBurner
     function burn(
         address pool,

--- a/pkg/standalone-utils/test/foundry/ProtocolFeeSweeper.t.sol
+++ b/pkg/standalone-utils/test/foundry/ProtocolFeeSweeper.t.sol
@@ -348,4 +348,15 @@ contract ProtocolFeeSweeperTest is BaseVaultTest {
         assertEq(dai.balanceOf(address(feeRecipient)), 0, "DAI not burned");
         assertEq(usdc.balanceOf(address(feeRecipient)), DEFAULT_AMOUNT * 2, "USDC not forwarded");
     }
+
+    function testInvalidBurnerConfiguration() public {
+        vm.startPrank(admin);
+
+        // Set the burner, but not the token.
+        feeSweeper.setProtocolFeeBurner(feeBurner);
+
+        vm.expectRevert(IProtocolFeeSweeper.InvalidTargetToken.selector);
+        feeSweeper.sweepProtocolFees(pool);
+        vm.stopPrank();
+    }
 }

--- a/pkg/standalone-utils/test/foundry/ProtocolFeeSweeper.t.sol
+++ b/pkg/standalone-utils/test/foundry/ProtocolFeeSweeper.t.sol
@@ -77,6 +77,13 @@ contract ProtocolFeeSweeperTest is BaseVaultTest {
         feeSweeper.setFeeRecipient(admin);
     }
 
+    function testSetInvalidFeeRecipient() public {
+        vm.expectRevert(ProtocolFeeSweeper.InvalidFeeRecipient.selector);
+
+        vm.prank(admin);
+        feeSweeper.setFeeRecipient(ZERO_ADDRESS);
+    }
+
     function testSetFeeRecipient() public {
         vm.prank(admin);
         feeSweeper.setFeeRecipient(alice);

--- a/pkg/standalone-utils/test/foundry/ProtocolFeeSweeper.t.sol
+++ b/pkg/standalone-utils/test/foundry/ProtocolFeeSweeper.t.sol
@@ -34,7 +34,7 @@ contract ProtocolFeeSweeperTest is BaseVaultTest {
         (feeRecipient, ) = makeAddrAndKey("feeRecipient");
 
         feeSweeper = new ProtocolFeeSweeper(vault, feeRecipient);
-        feeBurner = new ProtocolFeeBurnerMock(feeSweeper);
+        feeBurner = new ProtocolFeeBurnerMock();
 
         authorizer.grantRole(
             IAuthentication(address(feeSweeper)).getActionId(IProtocolFeeSweeper.setFeeRecipient.selector),

--- a/pkg/standalone-utils/test/foundry/ProtocolFeeSweeper.t.sol
+++ b/pkg/standalone-utils/test/foundry/ProtocolFeeSweeper.t.sol
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+
+import { IProtocolFeeSweeper } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol";
+import { IProtocolFeeBurner } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol";
+import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
+import { IProtocolFeeController } from "@balancer-labs/v3-interfaces/contracts/vault/IProtocolFeeController.sol";
+
+import { CastingHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/CastingHelpers.sol";
+import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/test/ArrayHelpers.sol";
+import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVaultTest.sol";
+
+import { ProtocolFeeBurnerMock } from "../../contracts/test/ProtocolFeeBurnerMock.sol";
+import { ProtocolFeeSweeper } from "../../contracts/ProtocolFeeSweeper.sol";
+
+contract ProtocolFeeSweeperTest is BaseVaultTest {
+    using CastingHelpers for address[];
+    using Address for address payable;
+    using ArrayHelpers for *;
+
+    IProtocolFeeSweeper internal feeSweeper;
+
+    IProtocolFeeBurner internal feeBurner;
+
+    address internal feeRecipient;
+
+    function setUp() public override {
+        BaseVaultTest.setUp();
+
+        (feeRecipient, ) = makeAddrAndKey("feeRecipient");
+
+        feeSweeper = new ProtocolFeeSweeper(vault, feeRecipient);
+        feeBurner = new ProtocolFeeBurnerMock(feeSweeper);
+
+        authorizer.grantRole(
+            IAuthentication(address(feeSweeper)).getActionId(IProtocolFeeSweeper.setFeeRecipient.selector),
+            admin
+        );
+        authorizer.grantRole(
+            IAuthentication(address(feeSweeper)).getActionId(IProtocolFeeSweeper.setProtocolFeeBurner.selector),
+            admin
+        );
+        authorizer.grantRole(
+            IAuthentication(address(feeSweeper)).getActionId(IProtocolFeeSweeper.setTargetToken.selector),
+            admin
+        );
+
+        // Allow the fee sweeper to withdraw protocol fees.
+        authorizer.grantRole(
+            IAuthentication(address(feeController)).getActionId(IProtocolFeeController.withdrawProtocolFees.selector),
+            address(feeSweeper)
+        );
+    }
+
+    function testGetProtocolFeeController() public view {
+        assertEq(address(feeSweeper.getProtocolFeeController()), address(feeController), "Fee controller mismatch");
+    }
+
+    function testGetTargetToken() public view {
+        assertEq(address(feeSweeper.getTargetToken()), ZERO_ADDRESS, "Initial target token non-zero");
+    }
+
+    function testGetFeeRecipient() public view {
+        assertEq(feeSweeper.getFeeRecipient(), feeRecipient, "Wrong fee recipient");
+    }
+
+    function testGetProtocolFeeBurner() public view {
+        assertEq(address(feeSweeper.getProtocolFeeBurner()), ZERO_ADDRESS, "Initial fee burner non-zero");
+    }
+
+    function testSetFeeRecipientNoPermission() public {
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        feeSweeper.setFeeRecipient(admin);
+    }
+
+    function testSetFeeRecipient() public {
+        vm.prank(admin);
+        feeSweeper.setFeeRecipient(alice);
+
+        assertEq(feeSweeper.getFeeRecipient(), alice, "Wrong fee recipient");
+    }
+
+    function testSetFeeRecipientEmitsEvent() public {
+        vm.expectEmit();
+        emit IProtocolFeeSweeper.FeeRecipientSet(alice);
+
+        vm.prank(admin);
+        feeSweeper.setFeeRecipient(alice);
+    }
+
+    function testSetFeeBurnerNoPermission() public {
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        feeSweeper.setProtocolFeeBurner(feeBurner);
+    }
+
+    function testSetFeeBurner() public {
+        vm.prank(admin);
+        feeSweeper.setProtocolFeeBurner(feeBurner);
+
+        assertEq(address(feeSweeper.getProtocolFeeBurner()), address(feeBurner), "Wrong fee burner");
+    }
+
+    function testSetFeeBurnerEmitsEvent() public {
+        vm.expectEmit();
+        emit IProtocolFeeSweeper.ProtocolFeeBurnerSet(address(feeBurner));
+
+        vm.prank(admin);
+        feeSweeper.setProtocolFeeBurner(feeBurner);
+    }
+
+    function testSetTargetTokenNoPermission() public {
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        feeSweeper.setTargetToken(usdc);
+    }
+
+    function testSetTargetToken() public {
+        vm.prank(admin);
+        feeSweeper.setTargetToken(usdc);
+
+        assertEq(address(feeSweeper.getTargetToken()), address(usdc), "Wrong target token");
+    }
+
+    function testSetTargetTokenEmitsEvent() public {
+        vm.expectEmit();
+        emit IProtocolFeeSweeper.TargetTokenSet(usdc);
+
+        vm.prank(admin);
+        feeSweeper.setTargetToken(usdc);
+    }
+
+    function testNoEth() public {
+        vm.expectRevert(ProtocolFeeSweeper.CannotReceiveEth.selector);
+        vm.prank(alice);
+        payable(address(feeSweeper)).sendValue(1 ether);
+    }
+
+    function testFallbackNoEth() public {
+        vm.expectRevert(ProtocolFeeSweeper.CannotReceiveEth.selector);
+        (bool success, ) = address(feeSweeper).call{ value: 1 ether }(abi.encodeWithSignature("fish()"));
+        assertTrue(success);
+    }
+
+    function testNoFallback() public {
+        vm.expectRevert("Not implemented");
+        (bool success, ) = address(feeSweeper).call(abi.encodeWithSignature("fish()"));
+        assertTrue(success);
+    }
+
+    function testRecoverNoPermission() public {
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        feeSweeper.recoverProtocolFees(new IERC20[](0));
+    }
+
+    function testRecoverProtocolFees() public {
+        IERC20[] memory feeTokens = [address(dai), address(usdc)].toMemoryArray().asIERC20();
+
+        address feeSweeperAddress = address(feeSweeper);
+
+        // Send some to the fee Sweeper
+        vm.startPrank(alice);
+        dai.transfer(feeSweeperAddress, DEFAULT_AMOUNT);
+        usdc.transfer(feeSweeperAddress, DEFAULT_AMOUNT);
+        vm.stopPrank();
+
+        assertEq(dai.balanceOf(feeSweeperAddress), DEFAULT_AMOUNT, "DAI not transferred to sweeper");
+        assertEq(usdc.balanceOf(feeSweeperAddress), DEFAULT_AMOUNT, "USDC not transferred to sweeper");
+
+        vm.prank(feeRecipient);
+        feeSweeper.recoverProtocolFees(feeTokens);
+
+        assertEq(dai.balanceOf(feeRecipient), DEFAULT_AMOUNT, "DAI not recovered");
+        assertEq(usdc.balanceOf(feeRecipient), DEFAULT_AMOUNT, "USDC not recovered");
+
+        assertEq(dai.balanceOf(feeSweeperAddress), 0, "DAI not transferred from sweeper");
+        assertEq(usdc.balanceOf(feeSweeperAddress), 0, "USDC not transferred from sweeper");
+    }
+
+    function testSweepProtocolFeesFallback() public {
+        // Put some fees in the Vault.
+        vault.manualSetAggregateSwapFeeAmount(pool, dai, DEFAULT_AMOUNT);
+        vault.manualSetAggregateYieldFeeAmount(pool, usdc, DEFAULT_AMOUNT);
+
+        // Collect them (i.e., send from the Vault to the controller).
+        feeController.collectAggregateFees(pool);
+
+        // Initial state has balances in the fee controller and none in the sweeper.
+        assertEq(dai.balanceOf(address(feeController)), DEFAULT_AMOUNT, "DAI not collected");
+        assertEq(usdc.balanceOf(address(feeController)), DEFAULT_AMOUNT, "USDC not collected");
+        assertEq(dai.balanceOf(address(feeSweeper)), 0, "Initial sweeper DAI balance non-zero");
+        assertEq(usdc.balanceOf(address(feeSweeper)), 0, "Initial sweeper USDC balance non-zero");
+        assertEq(dai.balanceOf(address(feeRecipient)), 0, "Initial recipient DAI balance non-zero");
+        assertEq(usdc.balanceOf(address(feeRecipient)), 0, "Initial recipient USDC balance non-zero");
+
+        vm.expectEmit();
+        emit IProtocolFeeSweeper.ProtocolFeeSwept(pool, dai, DEFAULT_AMOUNT, feeRecipient);
+        vm.expectEmit();
+        emit IProtocolFeeSweeper.ProtocolFeeSwept(pool, usdc, DEFAULT_AMOUNT, feeRecipient);
+
+        feeSweeper.sweepProtocolFees(pool);
+
+        assertEq(dai.balanceOf(address(feeController)), 0, "DAI not withdrawn");
+        assertEq(usdc.balanceOf(address(feeController)), 0, "USDC not withdrawn");
+        assertEq(dai.balanceOf(address(feeSweeper)), 0, "Final sweeper DAI balance non-zero");
+        assertEq(usdc.balanceOf(address(feeSweeper)), 0, "Final sweeper USDC balance non-zero");
+        assertEq(dai.balanceOf(address(feeRecipient)), DEFAULT_AMOUNT, "DAI not forwarded");
+        assertEq(usdc.balanceOf(address(feeRecipient)), DEFAULT_AMOUNT, "USDC not forwarded");
+    }
+
+    function testSweepProtocolFeesBurner() public {
+        // Set up the sweeper to be able to burn.
+        vm.startPrank(admin);
+        feeSweeper.setProtocolFeeBurner(feeBurner);
+        feeSweeper.setTargetToken(usdc);
+        vm.stopPrank();
+
+        // Put some fees in the Vault.
+        vault.manualSetAggregateSwapFeeAmount(pool, dai, DEFAULT_AMOUNT);
+        vault.manualSetAggregateYieldFeeAmount(pool, usdc, DEFAULT_AMOUNT);
+
+        // Collect them (i.e., send from the Vault to the controller).
+        feeController.collectAggregateFees(pool);
+
+        // DAI is NOT the target token, so it should call burn.
+        vm.expectEmit();
+        emit IProtocolFeeBurner.ProtocolFeeBurned(pool, dai, DEFAULT_AMOUNT, usdc, DEFAULT_AMOUNT, feeRecipient);
+
+        // USDC is the target token, so it should be transferred directly.
+        vm.expectEmit();
+        emit IProtocolFeeSweeper.ProtocolFeeSwept(pool, usdc, DEFAULT_AMOUNT, feeRecipient);
+
+        feeSweeper.sweepProtocolFees(pool);
+
+        assertEq(dai.balanceOf(address(feeController)), 0, "DAI not withdrawn");
+        assertEq(usdc.balanceOf(address(feeController)), 0, "USDC not withdrawn");
+        assertEq(dai.balanceOf(address(feeSweeper)), 0, "Final sweeper DAI balance non-zero");
+        assertEq(usdc.balanceOf(address(feeSweeper)), 0, "Final sweeper USDC balance non-zero");
+        // DAI should have been converted to USDC, so we should have twice the DEFAULT_AMOUNT of it.
+        assertEq(dai.balanceOf(address(feeRecipient)), 0, "DAI not burned");
+        assertEq(usdc.balanceOf(address(feeRecipient)), DEFAULT_AMOUNT * 2, "USDC not forwarded");
+    }
+}

--- a/pkg/standalone-utils/test/foundry/ProtocolFeeSweeper.t.sol
+++ b/pkg/standalone-utils/test/foundry/ProtocolFeeSweeper.t.sol
@@ -176,6 +176,16 @@ contract ProtocolFeeSweeperTest is BaseVaultTest {
         feeSweeper.recoverProtocolFees(new IERC20[](0));
     }
 
+    function testSweepNoPermission() public {
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        feeSweeper.sweepProtocolFees(pool);
+    }
+
+    function testSweepForTokenNoPermission() public {
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        feeSweeper.sweepProtocolFeesForToken(pool, usdc);
+    }
+
     function testRecoverProtocolFees() public {
         IERC20[] memory feeTokens = [address(dai), address(usdc)].toMemoryArray().asIERC20();
 
@@ -321,13 +331,13 @@ contract ProtocolFeeSweeperTest is BaseVaultTest {
         emit IProtocolFeeBurner.ProtocolFeeBurned(pool, dai, DEFAULT_AMOUNT, usdc, DEFAULT_AMOUNT, feeRecipient);
 
         vm.startPrank(admin);
-        feeSweeper.sweepProtocolFeesForToken(pool, IERC20(address(dai)));
+        feeSweeper.sweepProtocolFeesForToken(pool, dai);
 
         // USDC is the target token, so it should be transferred directly.
         vm.expectEmit();
         emit IProtocolFeeSweeper.ProtocolFeeSwept(pool, usdc, DEFAULT_AMOUNT, feeRecipient);
 
-        feeSweeper.sweepProtocolFeesForToken(pool, IERC20(address(usdc)));
+        feeSweeper.sweepProtocolFeesForToken(pool, usdc);
         vm.stopPrank();
 
         assertEq(dai.balanceOf(address(feeController)), 0, "DAI not withdrawn");

--- a/pkg/vault/test/foundry/BalancerContractRegistry.t.sol
+++ b/pkg/vault/test/foundry/BalancerContractRegistry.t.sol
@@ -17,7 +17,6 @@ import { BalancerContractRegistry } from "../../contracts/BalancerContractRegist
 contract BalancerContractRegistryTest is BaseVaultTest {
     address private constant ANY_ADDRESS = 0x388C818CA8B9251b393131C08a736A67ccB19297;
     address private constant SECOND_ADDRESS = 0x26c212f06675a0149909030D15dc46DAEE9A1f8a;
-    address private constant ZERO_ADDRESS = address(0);
     string private constant DEFAULT_NAME = "Contract name";
     string private constant DEFAULT_ALIAS = "Alias name";
 

--- a/pkg/vault/test/foundry/mutation/vault/Vault.t.sol
+++ b/pkg/vault/test/foundry/mutation/vault/Vault.t.sol
@@ -44,8 +44,6 @@ contract VaultMutationTest is BaseVaultTest {
     uint256[] tokenRates = [uint256(1e18), 2e18];
     uint256 initTotalSupply = 1000e18;
 
-    address internal constant ZERO_ADDRESS = address(0x00);
-
     uint256[] internal amountsIn = [poolInitAmount, poolInitAmount].toMemoryArray();
 
     function setUp() public virtual override {

--- a/pkg/vault/test/foundry/unit/ERC20MultiTokenTest.t.sol
+++ b/pkg/vault/test/foundry/unit/ERC20MultiTokenTest.t.sol
@@ -14,6 +14,7 @@ import { BalancerPoolToken } from "../../../contracts/BalancerPoolToken.sol";
 import { VaultContractsDeployer } from "../utils/VaultContractsDeployer.sol";
 
 contract ERC20MultiTokenTest is Test, IERC20Errors, ERC20MultiToken, VaultContractsDeployer {
+    address internal constant ZERO_ADDRESS = address(0x00);
     address internal constant POOL = address(0x01);
     address internal constant OWNER = address(0x02);
     address internal constant OWNER2 = address(0x03);

--- a/pkg/vault/test/foundry/unit/ERC20MultiTokenTest.t.sol
+++ b/pkg/vault/test/foundry/unit/ERC20MultiTokenTest.t.sol
@@ -14,7 +14,6 @@ import { BalancerPoolToken } from "../../../contracts/BalancerPoolToken.sol";
 import { VaultContractsDeployer } from "../utils/VaultContractsDeployer.sol";
 
 contract ERC20MultiTokenTest is Test, IERC20Errors, ERC20MultiToken, VaultContractsDeployer {
-    address internal constant ZERO_ADDRESS = address(0x00);
     address internal constant POOL = address(0x01);
     address internal constant OWNER = address(0x02);
     address internal constant OWNER2 = address(0x03);

--- a/pkg/vault/test/foundry/unit/VaultUnitLiquidity.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultUnitLiquidity.t.sol
@@ -54,8 +54,6 @@ contract VaultUnitLiquidityTest is BaseTest, VaultContractsDeployer {
         uint256 expectedBPTAmountIn;
     }
 
-    address internal constant ZERO_ADDRESS = address(0x00);
-
     IVaultMock internal vault;
 
     uint256 initTotalSupply = 1000e18;


### PR DESCRIPTION
# Description

This is a helper contract used in conjunction with "Burners" (e.g., CoWBurner) to, after collection from the Vault, withdraw protocol fees from the ProtocolFeeController, convert them to a preferred token (e.g., USDC), and forward them to a recipient (e.g., a multi-sig tied to the treasury).

This is a "basic" version, without a real burner, that simply forwards all withdrawn fee tokens to the designated recipient (and emitting an event for the direct transfer).

I included some infrastructure and a mock burner as a basis for further iterations. If you set a target token and use the mock burner, it will simulate a burn by consuming the fee token and minting the target token to the recipient, emitting an event like the real burner would. Since the burners operate asynchronously, these events might come out in any order, and the sweeper contract could have temporary token balances while the burners are operating.

One thing we might want to add in future iterations is validation of the burners. Governance has to approve sweepers (by granting permission to withdraw protocol fees), and must also grant permission to set the burner contract address. If we wanted to decrease the trust level here, we could use the `BalancerContractRegistry` (perhaps with a new type) to register valid burners, and only allow adding vetted ones.

There is also a failsafe withdrawal in case tokens get "stuck" in the sweeper due to burner issues. (They could also get stuck in the burner contracts, which have a similar mechanism.) Since this is the basic version, it simply withdraws the full balance of the given set of tokens, which assumes the sweeper is no longer operating.

For instance, revoking a sweeper's permission to call `withdrawProtocolFees` would prevent it from accumulating any further tokens, and assuming there are no ongoing burner transactions, it would be safe to withdraw the full balances. If we need to support recovery *during* operations, withdrawing the full balances would not be correct, as some of the balance might reflect ongoing burns that would succeed, in addition to failed ones.

One strategy to deal with that would be to emit an event when the sweeper initiates a burn: e.g., BurnOrderEntered(burnNonce++, feeToken, feeTokenAmount), while also passing the nonce to the burner, which could include it in its "order completed" event. That way, an off-chain process could match up the nonces, identify any failed burns, and calculate exactly how many and which tokens were stuck in the sweeper. We could then pass in an array of amounts along with the array of tokens, and withdraw only the stuck ones without removing any tokens needed for ongoing burns. (Maybe 0 could mean "withdraw the whole balance," so `recoverProtocolFees(tokens, new uint256[](tokens.length))` would behave the same as the current version with no value inputs.

Whether this is needed or makes sense depends on requirements and how the burners actually work. Just something to keep in mind for future versions.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes (there's one extraneous change: adding ZERO_ADDRESS to BaseTest)
- [X] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #1215
