### PR TITLE
Fix MEV Hook: fee curve must be continuous when passing the threshold

### DIFF
--- a/pkg/pool-hooks/contracts/MevHook.sol
+++ b/pkg/pool-hooks/contracts/MevHook.sol
@@ -93,29 +93,14 @@ contract MevHook is BaseHooks, SingletonAuthentication, VaultGuard, IMevHook {
             return (true, staticSwapFeePercentage);
         }
 
-        // If gasprice is lower than basefee, the transaction is invalid and won't be processed. Gasprice is set
-        // by the transaction sender, is always bigger than basefee, and the difference between gasprice and basefee
-        // defines the priority gas price (the part of the gas cost that will be paid to the validator).
-        uint256 priorityGasPrice = _getPriorityGasPrice();
-
-        // If `priorityGasPrice` < threshold, this indicates the transaction is from a retail user, so we should not
-        // impose the MEV tax.
-        uint256 priorityGasThreshold = _poolMevTaxThresholds[pool];
-        if (priorityGasPrice < priorityGasThreshold) {
-            return (true, staticSwapFeePercentage);
-        }
-
-        uint256 mevSwapFeePercentage = staticSwapFeePercentage +
-            (priorityGasPrice - priorityGasThreshold).mulDown(_poolMevTaxMultipliers[pool]);
-
-        // Cap the maximum fee at `_maxMevSwapFeePercentage`.
-        uint256 maxMevSwapFeePercentage = _maxMevSwapFeePercentage;
-        if (mevSwapFeePercentage > maxMevSwapFeePercentage) {
-            // Don't return early. If the cap is below the static fee, we'll still use the static fee.
-            mevSwapFeePercentage = maxMevSwapFeePercentage;
-        }
-
-        return (true, mevSwapFeePercentage);
+        return (
+            true,
+            _calculateSwapFeePercentage(
+                staticSwapFeePercentage,
+                _poolMevTaxMultipliers[pool],
+                _poolMevTaxThresholds[pool]
+            )
+        );
     }
 
     /// @inheritdoc IHooks
@@ -261,6 +246,37 @@ contract MevHook is BaseHooks, SingletonAuthentication, VaultGuard, IMevHook {
         uint256 newPoolMevTaxThreshold
     ) external withMevTaxEnabledPool(pool) authenticate {
         _setPoolMevTaxThreshold(pool, newPoolMevTaxThreshold);
+    }
+
+    /*******************************************************
+                        Helper functions
+    *******************************************************/
+
+    function _calculateSwapFeePercentage(
+        uint256 staticSwapFeePercentage,
+        uint256 multiplier,
+        uint256 threshold
+    ) internal view returns (uint256) {
+        // If gasprice is lower than basefee, the transaction is invalid and won't be processed. Gasprice is set
+        // by the transaction sender, is always bigger than basefee, and the difference between gasprice and basefee
+        // defines the priority gas price (the part of the gas cost that will be paid to the validator).
+        uint256 priorityGasPrice = _getPriorityGasPrice();
+        uint256 maxMevSwapFeePercentage = _maxMevSwapFeePercentage;
+
+        // If `priorityGasPrice` < threshold, this indicates the transaction is from a retail user, so we should not
+        // impose the MEV tax. Also, if mev fee cap is lower than static fee percentage, returns the static.
+        if (priorityGasPrice < threshold || maxMevSwapFeePercentage < staticSwapFeePercentage) {
+            return staticSwapFeePercentage;
+        }
+
+        uint256 mevSwapFeePercentage = staticSwapFeePercentage + (priorityGasPrice - threshold).mulDown(multiplier);
+
+        // Cap the maximum fee at `_maxMevSwapFeePercentage`.
+        if (mevSwapFeePercentage > maxMevSwapFeePercentage) {
+            return maxMevSwapFeePercentage;
+        }
+
+        return mevSwapFeePercentage;
     }
 
     function _setPoolMevTaxThreshold(address pool, uint256 newPoolMevTaxThreshold) private {

--- a/pkg/pool-hooks/contracts/MevHook.sol
+++ b/pkg/pool-hooks/contracts/MevHook.sol
@@ -2,8 +2,6 @@
 
 pragma solidity ^0.8.24;
 
-import "forge-std/Test.sol";
-
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import { IMevHook } from "@balancer-labs/v3-interfaces/contracts/pool-hooks/IMevHook.sol";

--- a/pkg/pool-hooks/contracts/MevHook.sol
+++ b/pkg/pool-hooks/contracts/MevHook.sol
@@ -275,6 +275,7 @@ contract MevHook is BaseHooks, SingletonAuthentication, VaultGuard, IMevHook {
 
         (bool success, uint256 feeIncrement) = Math.tryMul(priorityGasPrice - threshold, multiplier);
 
+        // If success == false, an overflow occurred, so we should return the max fee.
         if (success == false) {
             return maxMevSwapFeePercentage;
         }
@@ -282,6 +283,7 @@ contract MevHook is BaseHooks, SingletonAuthentication, VaultGuard, IMevHook {
         // Math.tryMul is not an operation with 18-decimals number, so we need to fix the result dividing by 1e18.
         feeIncrement = feeIncrement / 1e18;
 
+        // At this point, `priorityGasPrice >= threshold` and `maxMevSwapFeePercentage >= staticSwapFeePercentage`.
         // `staticSwapFeePercentage` cannot be greater than 1e18, so there is no need to check if
         // `staticSwapFeePercentage + feeIncrement` overflows.
         uint256 mevSwapFeePercentage = staticSwapFeePercentage + feeIncrement;

--- a/pkg/pool-hooks/contracts/MevHook.sol
+++ b/pkg/pool-hooks/contracts/MevHook.sol
@@ -289,11 +289,7 @@ contract MevHook is BaseHooks, SingletonAuthentication, VaultGuard, IMevHook {
         uint256 mevSwapFeePercentage = staticSwapFeePercentage + feeIncrement;
 
         // Cap the maximum fee at `maxMevSwapFeePercentage`.
-        if (mevSwapFeePercentage > maxMevSwapFeePercentage) {
-            return maxMevSwapFeePercentage;
-        }
-
-        return mevSwapFeePercentage;
+        return Math.min(mevSwapFeePercentage, maxMevSwapFeePercentage);
     }
 
     function _setPoolMevTaxThreshold(address pool, uint256 newPoolMevTaxThreshold) private {

--- a/pkg/pool-hooks/contracts/test/MevHookMock.sol
+++ b/pkg/pool-hooks/contracts/test/MevHookMock.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+
+import { MevHook } from "../MevHook.sol";
+
+contract MevHookMock is MevHook {
+    constructor(IVault vault) MevHook(vault) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    function calculateSwapFeePercentageExternal(
+        uint256 staticSwapFeePercentage,
+        uint256 multiplier,
+        uint256 threshold
+    ) external view returns (uint256 feePercentage) {
+        return _calculateSwapFeePercentage(staticSwapFeePercentage, multiplier, threshold);
+    }
+}

--- a/pkg/pool-hooks/test/MevHook.test.ts
+++ b/pkg/pool-hooks/test/MevHook.test.ts
@@ -369,7 +369,6 @@ describe('MevHook', () => {
 
     let mevSwapFeePercentage =
       STATIC_SWAP_FEE_PERCENTAGE + fpMulDown(txGasPrice - PRIORITY_GAS_THRESHOLD - baseFee, mevMultiplier);
-    console.log(mevSwapFeePercentage);
     const maxMevSwapFeePercentage = await hook.getMaxMevSwapFeePercentage();
 
     if (mevSwapFeePercentage >= maxMevSwapFeePercentage) {

--- a/pkg/pool-hooks/test/MevHook.test.ts
+++ b/pkg/pool-hooks/test/MevHook.test.ts
@@ -367,8 +367,9 @@ describe('MevHook', () => {
 
     const baseFee = await getNextBlockBaseFee();
 
+    const priorityGasPrice = txGasPrice - baseFee;
     let mevSwapFeePercentage =
-      STATIC_SWAP_FEE_PERCENTAGE + fpMulDown(txGasPrice - PRIORITY_GAS_THRESHOLD - baseFee, mevMultiplier);
+      STATIC_SWAP_FEE_PERCENTAGE + fpMulDown(priorityGasPrice - PRIORITY_GAS_THRESHOLD, mevMultiplier);
     const maxMevSwapFeePercentage = await hook.getMaxMevSwapFeePercentage();
 
     if (mevSwapFeePercentage >= maxMevSwapFeePercentage) {


### PR DESCRIPTION
# Description

![image](https://github.com/user-attachments/assets/78676c62-be2f-46aa-ba89-6f03c3df48d4)
The fee percentage curve must be continuous when passing the Threshold of MEV Hook. To do so, the new fee percentage formula must be the one below after threshold is crossed:

`newFeePercentage = staticFeePercentage + (txGasPrice - baseFee - threshold) * multiplier`

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

Resolves #1237