### PR TITLE
Add trusted router functionality to balancer registry

### DIFF
--- a/pkg/interfaces/contracts/vault/IBalancerContractRegistry.sol
+++ b/pkg/interfaces/contracts/vault/IBalancerContractRegistry.sol
@@ -68,12 +68,6 @@ interface IBalancerContractRegistry {
      */
     event ContractAliasUpdated(string indexed contractAlias, address indexed contractAddress);
 
-    /// @notice Trusted router successfully added to the registry.
-    event TrustedRouterAdded(address trustedRouter);
-
-    /// @notice Trusted router successfully removed from the registry.
-    event TrustedRouterRemoved(address trustedRouter);
-
     /**
      * @notice A contract has already been registered under the given address.
      * @dev Both names and addresses must be unique in the primary registration mapping. Though there are two mappings
@@ -140,12 +134,6 @@ interface IBalancerContractRegistry {
 
     /// @notice Cannot add an empty string as an alias.
     error InvalidContractAlias();
-
-    /// @notice Trying to add a trusted router that had already been added.
-    error TrustedRouterAlreadyAdded(address trustedRouter);
-
-    /// @notice Trying to remove a trusted router that had not been added before.
-    error TrustedRouterNotAdded(address trustedRouter);
 
     /**
      * @notice Register an official Balancer contract (e.g., a trusted router, standard pool factory, or hook).
@@ -234,29 +222,6 @@ interface IBalancerContractRegistry {
      */
     function getBalancerContractInfo(address contractAddress) external view returns (ContractInfo memory info);
 
-    /// @notice Returns `true` if the given address is a registered trusted router; false otherwise.
+    /// @notice Returns `true` if the given address is an active contract under the ROUTER type.
     function isTrustedRouter(address router) external view returns (bool);
-
-    /// @notice Returns how many trusted routers are registered.
-    function getTrustedRoutersNumber() external view returns (uint256);
-
-    /**
-     * @notice Returns the address of a given trusted router by index.
-     * @dev Reverts if the index is greater than or equal to the number of trusted routers.
-     */
-    function getTrustedRouterAt(uint256 index) external view returns (address);
-
-    /**
-     * @notice Adds an array of addresses to the registered trusted routers. This is a permissioned function.
-     * @dev Reverts if any of the addresses was already registered; emits one `TrustedRouterAdded` event for each
-     * router successfully added to the registry.
-     */
-    function addTrustedRouters(address[] memory trustedRouters) external;
-
-    /**
-     * @notice Removes an array of addresses from the registered trusted routers. This is a permissioned function.
-     * @dev Reverts if any of the addresses was not registered; emits one `TrustedRouterRemoved` event for each
-     * router successfully removed from the registry.
-     */
-    function removeTrustedRouters(address[] memory trustedRouters) external;
 }

--- a/pkg/interfaces/contracts/vault/IBalancerContractRegistry.sol
+++ b/pkg/interfaces/contracts/vault/IBalancerContractRegistry.sol
@@ -68,6 +68,12 @@ interface IBalancerContractRegistry {
      */
     event ContractAliasUpdated(string indexed contractAlias, address indexed contractAddress);
 
+    /// @notice Trusted router successfully added to the registry.
+    event TrustedRouterAdded(address trustedRouter);
+
+    /// @notice Trusted router successfully removed from the registry.
+    event TrustedRouterRemoved(address trustedRouter);
+
     /**
      * @notice A contract has already been registered under the given address.
      * @dev Both names and addresses must be unique in the primary registration mapping. Though there are two mappings
@@ -134,6 +140,12 @@ interface IBalancerContractRegistry {
 
     /// @notice Cannot add an empty string as an alias.
     error InvalidContractAlias();
+
+    /// @notice Trying to add a trusted router that had already been added.
+    error TrustedRouterAlreadyAdded(address trustedRouter);
+
+    /// @notice Trying to remove a trusted router that had not been added before.
+    error TrustedRouterNotAdded(address trustedRouter);
 
     /**
      * @notice Register an official Balancer contract (e.g., a trusted router, standard pool factory, or hook).
@@ -221,4 +233,30 @@ interface IBalancerContractRegistry {
      * @return info ContractInfo struct corresponding to the address
      */
     function getBalancerContractInfo(address contractAddress) external view returns (ContractInfo memory info);
+
+    /// @notice Returns `true` if the given address is a registered trusted router; false otherwise.
+    function isTrustedRouter(address router) external view returns (bool);
+
+    /// @notice Returns how many trusted routers are registered.
+    function getTrustedRoutersNumber() external view returns (uint256);
+
+    /**
+     * @notice Returns the address of a given trusted router by index.
+     * @dev Reverts if the index is greater than or equal to the number of trusted routers.
+     */
+    function getTrustedRouterAt(uint256 index) external view returns (address);
+
+    /**
+     * @notice Adds an array of addresses to the registered trusted routers. This is a permissioned function.
+     * @dev Reverts if any of the addresses was already registered; emits one `TrustedRouterAdded` event for each
+     * router successfully added to the registry.
+     */
+    function addTrustedRouters(address[] memory trustedRouters) external;
+
+    /**
+     * @notice Removes an array of addresses from the registered trusted routers. This is a permissioned function.
+     * @dev Reverts if any of the addresses was not registered; emits one `TrustedRouterRemoved` event for each
+     * router successfully removed from the registry.
+     */
+    function removeTrustedRouters(address[] memory trustedRouters) external;
 }

--- a/pkg/vault/contracts/BalancerContractRegistry.sol
+++ b/pkg/vault/contracts/BalancerContractRegistry.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.24;
 
+import { EnumerableSet } from "@balancer-labs/v3-solidity-utils/contracts/openzeppelin/EnumerableSet.sol";
+
 import {
     IBalancerContractRegistry,
     ContractType
@@ -39,6 +41,8 @@ import { SingletonAuthentication } from "./SingletonAuthentication.sol";
  * contract for the Vault address, so it doesn't need to be a type.
  */
 contract BalancerContractRegistry is IBalancerContractRegistry, SingletonAuthentication {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
     // ContractId is the hash of contract name. Names must be unique (cannot have the same name with different types).
     mapping(bytes32 contractId => address addr) private _contractRegistry;
 
@@ -58,6 +62,8 @@ contract BalancerContractRegistry is IBalancerContractRegistry, SingletonAuthent
     // This is separate from the main contract registry to enforce different rules (e.g., prevent corrupting the
     // contract state by overwriting a registry entry with an "alias" that matches a different contract).
     mapping(bytes32 contractAliasId => address addr) private _contractAliases;
+
+    EnumerableSet.AddressSet internal _trustedRouters;
 
     /**
      * @notice A `_contractRegistry` entry has no corresponding `_contractInfo`.
@@ -292,5 +298,54 @@ contract BalancerContractRegistry is IBalancerContractRegistry, SingletonAuthent
 
     function _getContractId(string memory contractName) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(contractName));
+    }
+
+    /// @inheritdoc IBalancerContractRegistry
+    function isTrustedRouter(address router) external view returns (bool) {
+        return _trustedRouters.contains(router);
+    }
+
+    /// @inheritdoc IBalancerContractRegistry
+    function getTrustedRoutersNumber() external view returns (uint256) {
+        return _trustedRouters.length();
+    }
+
+    /// @inheritdoc IBalancerContractRegistry
+    function getTrustedRouterAt(uint256 index) external view returns (address) {
+        return _trustedRouters.at(index);
+    }
+
+    /// @inheritdoc IBalancerContractRegistry
+    function addTrustedRouters(address[] memory trustedRouters) external authenticate {
+        uint256 numRouters = trustedRouters.length;
+        for (uint256 i = 0; i < numRouters; ++i) {
+            _addTrustedRouter(trustedRouters[i]);
+        }
+    }
+
+    function _addTrustedRouter(address trustedRouter) internal {
+        bool routerAdded = _trustedRouters.add(trustedRouter);
+        if (routerAdded == false) {
+            revert TrustedRouterAlreadyAdded(trustedRouter);
+        }
+
+        emit TrustedRouterAdded(trustedRouter);
+    }
+
+    /// @inheritdoc IBalancerContractRegistry
+    function removeTrustedRouters(address[] memory trustedRouters) external authenticate {
+        uint256 numRouters = trustedRouters.length;
+        for (uint256 i = 0; i < numRouters; ++i) {
+            _removeTrustedRouter(trustedRouters[i]);
+        }
+    }
+
+    function _removeTrustedRouter(address trustedRouter) internal {
+        bool routerRemoved = _trustedRouters.remove(trustedRouter);
+        if (routerRemoved == false) {
+            revert TrustedRouterNotAdded(trustedRouter);
+        }
+
+        emit TrustedRouterRemoved(trustedRouter);
     }
 }

--- a/pkg/vault/contracts/BalancerContractRegistry.sol
+++ b/pkg/vault/contracts/BalancerContractRegistry.sol
@@ -255,7 +255,7 @@ contract BalancerContractRegistry is IBalancerContractRegistry, SingletonAuthent
     }
 
     /// @inheritdoc IBalancerContractRegistry
-    function isActiveBalancerContract(ContractType contractType, address contractAddress) public view returns (bool) {
+    function isActiveBalancerContract(ContractType contractType, address contractAddress) external view returns (bool) {
         return _isActiveBalancerContract(contractType, contractAddress);
     }
 
@@ -297,12 +297,12 @@ contract BalancerContractRegistry is IBalancerContractRegistry, SingletonAuthent
         return _contractInfo[contractAddress];
     }
 
-    function _getContractId(string memory contractName) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked(contractName));
-    }
-
     /// @inheritdoc IBalancerContractRegistry
     function isTrustedRouter(address router) external view returns (bool) {
         return _isActiveBalancerContract(ContractType.ROUTER, router);
+    }
+
+    function _getContractId(string memory contractName) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(contractName));
     }
 }

--- a/pkg/vault/contracts/BalancerContractRegistry.sol
+++ b/pkg/vault/contracts/BalancerContractRegistry.sol
@@ -256,6 +256,13 @@ contract BalancerContractRegistry is IBalancerContractRegistry, SingletonAuthent
 
     /// @inheritdoc IBalancerContractRegistry
     function isActiveBalancerContract(ContractType contractType, address contractAddress) public view returns (bool) {
+        return _isActiveBalancerContract(contractType, contractAddress);
+    }
+
+    function _isActiveBalancerContract(
+        ContractType contractType,
+        address contractAddress
+    ) internal view returns (bool) {
         ContractInfo memory info = _contractInfo[contractAddress];
 
         // Ensure the address was registered as the given type - and that it's still active.
@@ -296,6 +303,6 @@ contract BalancerContractRegistry is IBalancerContractRegistry, SingletonAuthent
 
     /// @inheritdoc IBalancerContractRegistry
     function isTrustedRouter(address router) external view returns (bool) {
-        return isActiveBalancerContract(ContractType.ROUTER, router);
+        return _isActiveBalancerContract(ContractType.ROUTER, router);
     }
 }

--- a/pkg/vault/test/foundry/BalancerContractRegistry.t.sol
+++ b/pkg/vault/test/foundry/BalancerContractRegistry.t.sol
@@ -213,6 +213,14 @@ contract BalancerContractRegistryTest is BaseVaultTest {
         registry.registerBalancerContract(ContractType.POOL_FACTORY, DEFAULT_NAME, ANY_ADDRESS);
     }
 
+    function testIsTrustedRouter() public {
+        vm.prank(admin);
+        registry.registerBalancerContract(ContractType.ROUTER, DEFAULT_NAME, ANY_ADDRESS);
+
+        assertTrue(registry.isActiveBalancerContract(ContractType.ROUTER, ANY_ADDRESS), "ANY_ADDRESS is not a Router");
+        assertTrue(registry.isTrustedRouter(ANY_ADDRESS), "ANY_ADDRESS is not a Trusted router");
+    }
+
     function testDeregisterNonExistentContract() public {
         vm.prank(admin);
 


### PR DESCRIPTION
# Description

For contracts that might need more than one trusted router, it's better to just ask the registry 'is this a trusted router?'.

We can achieve that by storing those in a mapping, but perhaps a set is a bit more user friendly (e.g. it allows retrieving trusted router addresses from etherscan, etc).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A