### PR TITLE
Add cow router type

### DIFF
--- a/pkg/interfaces/contracts/vault/IBalancerContractRegistry.sol
+++ b/pkg/interfaces/contracts/vault/IBalancerContractRegistry.sol
@@ -6,7 +6,8 @@ pragma solidity ^0.8.24;
 enum ContractType {
     OTHER, // a blank entry will have a 0-value type, and it's safest to return this in that case
     POOL_FACTORY,
-    ROUTER,
+    BALANCER_ROUTER,
+    COW_ROUTER,
     HOOK,
     ERC4626
 }

--- a/pkg/vault/contracts/BalancerContractRegistry.sol
+++ b/pkg/vault/contracts/BalancerContractRegistry.sol
@@ -299,7 +299,7 @@ contract BalancerContractRegistry is IBalancerContractRegistry, SingletonAuthent
 
     /// @inheritdoc IBalancerContractRegistry
     function isTrustedRouter(address router) external view returns (bool) {
-        return _isActiveBalancerContract(ContractType.ROUTER, router);
+        return _isActiveBalancerContract(ContractType.BALANCER_ROUTER, router);
     }
 
     function _getContractId(string memory contractName) internal pure returns (bytes32) {

--- a/pkg/vault/test/foundry/BalancerContractRegistry.t.sol
+++ b/pkg/vault/test/foundry/BalancerContractRegistry.t.sol
@@ -130,7 +130,7 @@ contract BalancerContractRegistryTest is BaseVaultTest {
         );
         // Only active with the correct type.
         assertFalse(
-            registry.isActiveBalancerContract(ContractType.ROUTER, ANY_ADDRESS),
+            registry.isActiveBalancerContract(ContractType.BALANCER_ROUTER, ANY_ADDRESS),
             "Address is active as a Router"
         );
     }
@@ -159,7 +159,7 @@ contract BalancerContractRegistryTest is BaseVaultTest {
     function testStaleAliasGetter() public {
         vm.startPrank(admin);
         // Register a contract and add an alias.
-        registry.registerBalancerContract(ContractType.ROUTER, DEFAULT_NAME, ANY_ADDRESS);
+        registry.registerBalancerContract(ContractType.BALANCER_ROUTER, DEFAULT_NAME, ANY_ADDRESS);
         registry.addOrUpdateBalancerContractAlias(DEFAULT_ALIAS, ANY_ADDRESS);
 
         // Deregister the contract - but the alias will still be there.
@@ -167,12 +167,15 @@ contract BalancerContractRegistryTest is BaseVaultTest {
         vm.stopPrank();
 
         // Getting it using the primary name should return 0.
-        (address contractAddress, bool active) = registry.getBalancerContract(ContractType.ROUTER, DEFAULT_NAME);
+        (address contractAddress, bool active) = registry.getBalancerContract(
+            ContractType.BALANCER_ROUTER,
+            DEFAULT_NAME
+        );
         assertEq(contractAddress, ZERO_ADDRESS, "Wrong primary contract address");
         assertFalse(active, "Contract is active using primary name");
 
         // Getting it using the alias should also return 0, even though there's a record there.
-        (contractAddress, active) = registry.getBalancerContract(ContractType.ROUTER, DEFAULT_ALIAS);
+        (contractAddress, active) = registry.getBalancerContract(ContractType.BALANCER_ROUTER, DEFAULT_ALIAS);
         assertEq(contractAddress, ZERO_ADDRESS, "Wrong alias contract address");
         assertFalse(active, "Contract is active using alias");
     }
@@ -184,14 +187,17 @@ contract BalancerContractRegistryTest is BaseVaultTest {
         registry.addOrUpdateBalancerContractAlias(DEFAULT_ALIAS, ANY_ADDRESS);
 
         // Getting a valid entry with the wrong type should return 0.
-        (address contractAddress, bool active) = registry.getBalancerContract(ContractType.ROUTER, DEFAULT_NAME);
+        (address contractAddress, bool active) = registry.getBalancerContract(
+            ContractType.BALANCER_ROUTER,
+            DEFAULT_NAME
+        );
         assertEq(contractAddress, ZERO_ADDRESS, "Wrong primary contract address");
         assertFalse(active, "Contract is active using primary name");
 
-        assertFalse(registry.isActiveBalancerContract(ContractType.ROUTER, ANY_ADDRESS));
+        assertFalse(registry.isActiveBalancerContract(ContractType.BALANCER_ROUTER, ANY_ADDRESS));
 
         // Getting a valid entry through the alias, with the wrong type, should return 0.
-        (contractAddress, active) = registry.getBalancerContract(ContractType.ROUTER, DEFAULT_ALIAS);
+        (contractAddress, active) = registry.getBalancerContract(ContractType.BALANCER_ROUTER, DEFAULT_ALIAS);
         assertEq(contractAddress, ZERO_ADDRESS, "Wrong alias contract address");
         assertFalse(active, "Contract is active using alias");
     }
@@ -202,7 +208,10 @@ contract BalancerContractRegistryTest is BaseVaultTest {
 
         // Should return the registered contract as active.
         assertTrue(registry.isActiveBalancerContract(ContractType.ERC4626, ANY_ADDRESS), "ANY_ADDRESS is not a Buffer");
-        assertFalse(registry.isActiveBalancerContract(ContractType.ROUTER, ANY_ADDRESS), "ANY_ADDRESS is a Router");
+        assertFalse(
+            registry.isActiveBalancerContract(ContractType.BALANCER_ROUTER, ANY_ADDRESS),
+            "ANY_ADDRESS is a Router"
+        );
     }
 
     function testValidRegistrationEmitsEvent() public {
@@ -215,9 +224,12 @@ contract BalancerContractRegistryTest is BaseVaultTest {
 
     function testIsTrustedRouter() public {
         vm.prank(admin);
-        registry.registerBalancerContract(ContractType.ROUTER, DEFAULT_NAME, ANY_ADDRESS);
+        registry.registerBalancerContract(ContractType.BALANCER_ROUTER, DEFAULT_NAME, ANY_ADDRESS);
 
-        assertTrue(registry.isActiveBalancerContract(ContractType.ROUTER, ANY_ADDRESS), "ANY_ADDRESS is not a Router");
+        assertTrue(
+            registry.isActiveBalancerContract(ContractType.BALANCER_ROUTER, ANY_ADDRESS),
+            "ANY_ADDRESS is not a Router"
+        );
         assertTrue(registry.isTrustedRouter(ANY_ADDRESS), "ANY_ADDRESS is not a Trusted router");
     }
 
@@ -239,13 +251,19 @@ contract BalancerContractRegistryTest is BaseVaultTest {
 
     function testValidDeregistration() public {
         vm.startPrank(admin);
-        registry.registerBalancerContract(ContractType.ROUTER, DEFAULT_NAME, ANY_ADDRESS);
-        assertTrue(registry.isActiveBalancerContract(ContractType.ROUTER, ANY_ADDRESS), "ANY_ADDRESS is not active");
+        registry.registerBalancerContract(ContractType.BALANCER_ROUTER, DEFAULT_NAME, ANY_ADDRESS);
+        assertTrue(
+            registry.isActiveBalancerContract(ContractType.BALANCER_ROUTER, ANY_ADDRESS),
+            "ANY_ADDRESS is not active"
+        );
 
         registry.deregisterBalancerContract(DEFAULT_NAME);
         vm.stopPrank();
 
-        assertFalse(registry.isActiveBalancerContract(ContractType.ROUTER, ANY_ADDRESS), "ANY_ADDRESS is still active");
+        assertFalse(
+            registry.isActiveBalancerContract(ContractType.BALANCER_ROUTER, ANY_ADDRESS),
+            "ANY_ADDRESS is still active"
+        );
 
         IBalancerContractRegistry.ContractInfo memory info = registry.getBalancerContractInfo(ANY_ADDRESS);
         assertFalse(info.isRegistered, "Contract is still registered");
@@ -253,11 +271,18 @@ contract BalancerContractRegistryTest is BaseVaultTest {
 
     function testDeregistrationEmitsEvent() public {
         vm.startPrank(admin);
-        registry.registerBalancerContract(ContractType.ROUTER, DEFAULT_NAME, ANY_ADDRESS);
-        assertTrue(registry.isActiveBalancerContract(ContractType.ROUTER, ANY_ADDRESS), "ANY_ADDRESS is not active");
+        registry.registerBalancerContract(ContractType.BALANCER_ROUTER, DEFAULT_NAME, ANY_ADDRESS);
+        assertTrue(
+            registry.isActiveBalancerContract(ContractType.BALANCER_ROUTER, ANY_ADDRESS),
+            "ANY_ADDRESS is not active"
+        );
 
         vm.expectEmit();
-        emit IBalancerContractRegistry.BalancerContractDeregistered(ContractType.ROUTER, DEFAULT_NAME, ANY_ADDRESS);
+        emit IBalancerContractRegistry.BalancerContractDeregistered(
+            ContractType.BALANCER_ROUTER,
+            DEFAULT_NAME,
+            ANY_ADDRESS
+        );
 
         registry.deregisterBalancerContract(DEFAULT_NAME);
         vm.stopPrank();


### PR DESCRIPTION
# Description

According to the CoW design doc, we will need a registry of CoW routers, requiring a new COW_ROUTER type. This is potentially ambiguous with the ROUTER type, so the simplest change would be to rename ROUTER to BALANCER_ROUTER, and add the new type.

`isTrustedRouter` is unchanged for now, assuming it won't be ambiguous in the context of regular hooks and pools, and we don't also need a shortcut for CoW. If we did, or think the name is now ambiguous, we could have `isTrustedBalancerRouter` and `isTrustedCowRouter`. Or just rename `isTrustedRouter` to `isTrustedBalancerRouter`.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
