### PR TITLE
Aggregated fee sweeper

### DIFF
--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol
@@ -7,19 +7,17 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 interface IProtocolFeeBurner {
     /**
      * @notice A protocol fee token has been "burned" (i.e., swapped for the desired target token).
-     * @param pool The pool on which the fee was collected (used for event tracking)
      * @param feeToken The token in which the fee was originally collected
-     * @param feeTokenAmount The number of feeTokens collected
+     * @param exactFeeTokenAmountIn The number of feeTokens collected
      * @param targetToken The preferred token for fee collection (e.g., USDC)
-     * @param targetTokenAmount The number of target tokens actually received
+     * @param minTargetTokenAmountOut The number of target tokens actually received
      * @param recipient The address where the target tokens were sent
      */
     event ProtocolFeeBurned(
-        address indexed pool,
         IERC20 indexed feeToken,
-        uint256 feeTokenAmount,
+        uint256 exactFeeTokenAmountIn,
         IERC20 indexed targetToken,
-        uint256 targetTokenAmount,
+        uint256 minTargetTokenAmountOut,
         address recipient
     );
 
@@ -37,20 +35,18 @@ interface IProtocolFeeBurner {
     /**
      * @notice Swap an exact amount of `feeToken` for the `targetToken`, and send proceeds to the `recipient`.
      * @dev Assumes the sweeper has transferred the tokens to the burner prior to the call.
-     * @param pool The pool the fees came from (only used for documentation in the event)
      * @param feeToken The feeToken collected from the pool
-     * @param feeTokenAmount The number of fee tokens collected
+     * @param exactFeeTokenAmountIn The number of fee tokens collected
      * @param targetToken The desired target token (token out of the swap)
-     * @param minTargetTokenAmount The minimum amount out for the swap
+     * @param minTargetTokenAmountOut The minimum amount out for the swap
      * @param recipient The recipient of the swap proceeds
      * @param deadline Deadline for the burn operation (i.e., swap), after which it will revert
      */
     function burn(
-        address pool,
         IERC20 feeToken,
-        uint256 feeTokenAmount,
+        uint256 exactFeeTokenAmountIn,
         IERC20 targetToken,
-        uint256 minTargetTokenAmount,
+        uint256 minTargetTokenAmountOut,
         address recipient,
         uint256 deadline
     ) external;

--- a/pkg/standalone-utils/contracts/test/ProtocolFeeBurnerMock.sol
+++ b/pkg/standalone-utils/contracts/test/ProtocolFeeBurnerMock.sol
@@ -16,11 +16,10 @@ contract ProtocolFeeBurnerMock is IProtocolFeeBurner {
 
     /// @inheritdoc IProtocolFeeBurner
     function burn(
-        address pool,
         IERC20 feeToken,
-        uint256 feeTokenAmount,
+        uint256 exactFeeTokenAmountIn,
         IERC20 targetToken,
-        uint256 minTargetTokenAmount,
+        uint256 minTargetTokenAmountOut,
         address recipient,
         uint256 deadline
     ) external {
@@ -29,15 +28,15 @@ contract ProtocolFeeBurnerMock is IProtocolFeeBurner {
         }
 
         // Simulate the swap by minting the same amount of target to the recipient.
-        ERC20TestToken(address(targetToken)).mint(recipient, feeTokenAmount);
+        ERC20TestToken(address(targetToken)).mint(recipient, exactFeeTokenAmountIn);
 
-        uint256 targetTokenAmount = feeTokenAmount.mulDown(_tokenRatio);
-        if (targetTokenAmount < minTargetTokenAmount) {
-            revert AmountOutBelowMin(targetToken, targetTokenAmount, minTargetTokenAmount);
+        uint256 targetTokenAmount = exactFeeTokenAmountIn.mulDown(_tokenRatio);
+        if (targetTokenAmount < minTargetTokenAmountOut) {
+            revert AmountOutBelowMin(targetToken, targetTokenAmount, minTargetTokenAmountOut);
         }
 
         // Just emit the event, simulating the tokens being exchanged at 1-to-1.
-        emit ProtocolFeeBurned(pool, feeToken, feeTokenAmount, targetToken, targetTokenAmount, recipient);
+        emit ProtocolFeeBurned(feeToken, exactFeeTokenAmountIn, targetToken, targetTokenAmount, recipient);
     }
 
     function setTokenRatio(uint256 ratio) external {


### PR DESCRIPTION
# Description

Built on #1253 (support for multiple burners), this version "aggregates" collection from multiple pools. Instead of taking a pool argument and doing the withdrawal in the sweeper (requiring permission), it assumes the off-chain process has both collected and withdrawn the protocol fees to the sweeper (i.e, called withdrawal functions with the fee sweeper as the recipient), so that the token balances are in the sweeper.

It can then check these balances against a threshold, and sweep all (or optionally only some) of the token balance through a burner to a final recipient. This is more efficient if there are many pools with the same fee tokens (especially low liquidity pools), since the burns can be done less frequently, and with higher balances.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
