### PR TITLE
Filter surge cases for unbalanced liquidity

### DIFF
--- a/pkg/pool-hooks/contracts/StableSurgeHook.sol
+++ b/pkg/pool-hooks/contracts/StableSurgeHook.sol
@@ -54,7 +54,7 @@ contract StableSurgeHook is BaseHooks, VaultGuard, SingletonAuthentication {
     uint256 private immutable _defaultSurgeThresholdPercentage;
 
     // Store the current threshold and max fee for each pool.
-    mapping(address pool => SurgeFeeData data) private _surgeFeePoolData;
+    mapping(address pool => SurgeFeeData data) internal _surgeFeePoolData;
 
     /**
      * @notice A new `StableSurgeHook` contract has been registered successfully.

--- a/pkg/pool-hooks/contracts/StableSurgeHook.sol
+++ b/pkg/pool-hooks/contracts/StableSurgeHook.sol
@@ -230,7 +230,7 @@ contract StableSurgeHook is BaseHooks, VaultGuard, SingletonAuthentication {
     ) public view override returns (bool success, uint256[] memory hookAdjustedAmountsInRaw) {
         // Proportional add is always fine.
         if (kind == AddLiquidityKind.PROPORTIONAL) {
-            return (true, hookAdjustedAmountsInRaw);
+            return (true, amountsInRaw);
         }
 
         // Rebuild old balances before adding liquidity.
@@ -261,7 +261,7 @@ contract StableSurgeHook is BaseHooks, VaultGuard, SingletonAuthentication {
     ) public view override returns (bool success, uint256[] memory hookAdjustedAmountsOutRaw) {
         // Proportional remove is always fine.
         if (kind == RemoveLiquidityKind.PROPORTIONAL) {
-            return (true, hookAdjustedAmountsOutRaw);
+            return (true, amountsOutRaw);
         }
 
         // Rebuild old balances before removing liquidity.

--- a/pkg/pool-hooks/contracts/StableSurgeHook.sol
+++ b/pkg/pool-hooks/contracts/StableSurgeHook.sol
@@ -199,11 +199,9 @@ contract StableSurgeHook is BaseHooks, VaultGuard, SingletonAuthentication {
         address pool,
         uint256 staticSwapFeePercentage
     ) public view returns (uint256) {
-        uint256 numTokens = params.balancesScaled18.length;
-
         uint256 amountCalculatedScaled18 = StablePool(pool).onSwap(params);
 
-        uint256[] memory newBalances = new uint256[](numTokens);
+        uint256[] memory newBalances = new uint256[](params.balancesScaled18.length);
         ScalingHelpers.copyToArray(params.balancesScaled18, newBalances);
 
         if (params.kind == SwapKind.EXACT_IN) {

--- a/pkg/pool-hooks/contracts/StableSurgePoolFactory.sol
+++ b/pkg/pool-hooks/contracts/StableSurgePoolFactory.sol
@@ -61,7 +61,6 @@ contract StableSurgePoolFactory is IPoolVersion, BasePoolFactory, Version {
      * @param roleAccounts Addresses the Vault will allow to change certain pool settings
      * @param swapFeePercentage Initial swap fee percentage
      * @param enableDonation If true, the pool will support the donation add liquidity mechanism
-     * @param disableUnbalancedLiquidity If true, only proportional add and remove liquidity are accepted
      * @param salt The salt value that will be passed to create3 deployment
      */
     function create(
@@ -72,7 +71,6 @@ contract StableSurgePoolFactory is IPoolVersion, BasePoolFactory, Version {
         PoolRoleAccounts memory roleAccounts,
         uint256 swapFeePercentage,
         bool enableDonation,
-        bool disableUnbalancedLiquidity,
         bytes32 salt
     ) external returns (address pool) {
         if (roleAccounts.poolCreator != address(0)) {
@@ -87,7 +85,6 @@ contract StableSurgePoolFactory is IPoolVersion, BasePoolFactory, Version {
 
         LiquidityManagement memory liquidityManagement = getDefaultLiquidityManagement();
         liquidityManagement.enableDonation = enableDonation;
-        liquidityManagement.disableUnbalancedLiquidity = disableUnbalancedLiquidity;
 
         pool = _create(
             abi.encode(

--- a/pkg/pool-hooks/contracts/test/StableSurgeHookMock.sol
+++ b/pkg/pool-hooks/contracts/test/StableSurgeHookMock.sol
@@ -2,7 +2,6 @@
 
 pragma solidity ^0.8.24;
 
-
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import { PoolSwapParams } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
@@ -13,8 +12,7 @@ contract StableSurgeHookMock is StableSurgeHook {
         IVault vault,
         uint256 defaultMaxSurgeFeePercentage,
         uint256 defaultSurgeThresholdPercentage
-    ) StableSurgeHook(vault, defaultMaxSurgeFeePercentage, defaultSurgeThresholdPercentage) {
-    }
+    ) StableSurgeHook(vault, defaultMaxSurgeFeePercentage, defaultSurgeThresholdPercentage) {}
 
     function getSurgeFeePercentage(
         PoolSwapParams calldata params,

--- a/pkg/pool-hooks/contracts/test/StableSurgeHookMock.sol
+++ b/pkg/pool-hooks/contracts/test/StableSurgeHookMock.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import { PoolSwapParams } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+
+import { StableSurgeHook } from "./../StableSurgeHook.sol";
+
+contract StableSurgeHookMock is StableSurgeHook {
+    constructor(
+        IVault vault,
+        uint256 defaultMaxSurgeFeePercentage,
+        uint256 defaultSurgeThresholdPercentage
+    ) StableSurgeHook(vault, defaultMaxSurgeFeePercentage, defaultSurgeThresholdPercentage) {
+    }
+
+    function getSurgeFeePercentage(
+        PoolSwapParams calldata params,
+        address pool,
+        uint256 staticFeePercentage,
+        uint256[] memory newBalances
+    ) external view returns (uint256) {
+        return _getSurgeFeePercentage(params, pool, staticFeePercentage, newBalances);
+    }
+
+    function isSurging(
+        SurgeFeeData memory surgeFeeData,
+        uint256[] memory currentBalances,
+        uint256 newTotalImbalance
+    ) external pure returns (bool) {
+        return _isSurging(surgeFeeData, currentBalances, newTotalImbalance);
+    }
+
+    function getSurgeFeeData(address pool) external view returns (SurgeFeeData memory) {
+        return _surgeFeePoolData[pool];
+    }
+}

--- a/pkg/pool-hooks/test/foundry/StableSurgeHook.t.sol
+++ b/pkg/pool-hooks/test/foundry/StableSurgeHook.t.sol
@@ -126,7 +126,10 @@ contract StableSurgeHookTest is BaseVaultTest {
 
         // Add USDC --> more unbalanced.
         uint256 newTotalImbalance = stableSurgeMedianMathMock.calculateImbalance(expectedBalancesAfterAdd);
-        assertTrue(stableSurgeHook.isSurging(surgeFeeData, initialBalances, newTotalImbalance), "Not surging after add");
+        assertTrue(
+            stableSurgeHook.isSurging(surgeFeeData, initialBalances, newTotalImbalance),
+            "Not surging after add"
+        );
 
         vm.expectRevert(IVaultErrors.AfterAddLiquidityHookFailed.selector);
         vm.prank(alice);
@@ -134,13 +137,7 @@ contract StableSurgeHookTest is BaseVaultTest {
 
         // Proportional is always fine
         vm.prank(alice);
-        router.addLiquidityProportional(
-            pool,
-            initialBalances,
-            1e18,
-            false,
-            bytes("")
-        );
+        router.addLiquidityProportional(pool, initialBalances, 1e18, false, bytes(""));
     }
 
     function testUnbalancedAddLiquidityWhenNotSurging() public {
@@ -188,20 +185,16 @@ contract StableSurgeHookTest is BaseVaultTest {
 
         // Remove DAI --> more unbalanced.
         uint256 newTotalImbalance = stableSurgeMedianMathMock.calculateImbalance(expectedBalancesAfterRemove);
-        assertTrue(stableSurgeHook.isSurging(surgeFeeData, initialBalances, newTotalImbalance), "Not surging after remove");
+        assertTrue(
+            stableSurgeHook.isSurging(surgeFeeData, initialBalances, newTotalImbalance),
+            "Not surging after remove"
+        );
 
         uint256 bptBalance = IERC20(pool).balanceOf(lp);
 
         vm.expectRevert(IVaultErrors.AfterRemoveLiquidityHookFailed.selector);
         vm.prank(lp);
-        router.removeLiquiditySingleTokenExactOut(
-            address(pool),
-            bptBalance,
-            dai,
-            amountsOut[daiIdx],
-            false,
-            bytes("")
-        );
+        router.removeLiquiditySingleTokenExactOut(address(pool), bptBalance, dai, amountsOut[daiIdx], false, bytes(""));
 
         uint256[] memory minAmountsOut = new uint256[](2);
         // Proportional is always fine
@@ -228,19 +221,15 @@ contract StableSurgeHookTest is BaseVaultTest {
 
         // Should not surge, close to balance
         uint256 newTotalImbalance = stableSurgeMedianMathMock.calculateImbalance(expectedBalancesAfterRemove);
-        assertFalse(stableSurgeHook.isSurging(surgeFeeData, initialBalances, newTotalImbalance), "Surging after remove");
+        assertFalse(
+            stableSurgeHook.isSurging(surgeFeeData, initialBalances, newTotalImbalance),
+            "Surging after remove"
+        );
 
         uint256 bptBalance = IERC20(pool).balanceOf(lp);
         // Does not revert
         vm.prank(lp);
-        router.removeLiquiditySingleTokenExactOut(
-            address(pool),
-            bptBalance,
-            dai,
-            amountsOut[daiIdx],
-            false,
-            bytes("")
-        );
+        router.removeLiquiditySingleTokenExactOut(address(pool), bptBalance, dai, amountsOut[daiIdx], false, bytes(""));
     }
 
     function testSwap__Fuzz(uint256 amountGivenScaled18, uint256 swapFeePercentageRaw, uint256 kindRaw) public {

--- a/pkg/pool-hooks/test/foundry/StableSurgeHookUnit.t.sol
+++ b/pkg/pool-hooks/test/foundry/StableSurgeHookUnit.t.sol
@@ -90,9 +90,9 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
             shouldCallBeforeSwap: false,
             shouldCallAfterSwap: false,
             shouldCallBeforeAddLiquidity: false,
-            shouldCallAfterAddLiquidity: false,
+            shouldCallAfterAddLiquidity: true,
             shouldCallBeforeRemoveLiquidity: false,
-            shouldCallAfterRemoveLiquidity: false
+            shouldCallAfterRemoveLiquidity: true
         });
         assertEq(abi.encode(stableSurgeHook.getHookFlags()), abi.encode(hookFlags), "Hook flags should be correct");
     }
@@ -182,7 +182,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
         stableSurgeHook.setSurgeThresholdPercentage(pool, 1e18);
     }
 
-    function testGetSurgeFeePercentage__Fuzz(
+    function testgetSurgeSwapFeePercentage__Fuzz(
         uint256 length,
         uint256 indexIn,
         uint256 indexOut,
@@ -204,7 +204,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
             rawBalances
         );
         PoolSwapParams memory swapParams = _buildSwapParams(indexIn, indexOut, amountGivenScaled18, kind, balances);
-        uint256 surgeFeePercentage = stableSurgeHook.getSurgeFeePercentage(swapParams, pool, STATIC_FEE_PERCENTAGE);
+        uint256 surgeFeePercentage = stableSurgeHook.getSurgeSwapFeePercentage(swapParams, pool, STATIC_FEE_PERCENTAGE);
         uint256[] memory newBalances = _computeNewBalances(swapParams);
         uint256 expectedFee = _calculateFee(
             stableSurgeMedianMathMock.calculateImbalance(newBalances),
@@ -253,7 +253,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
         assertEq(surgeFeePercentage, expectedFee, "Surge fee percentage should be expectedFee");
     }
 
-    function testGetSurgeFeePercentageWhenNewTotalImbalanceIsZero() public {
+    function testgetSurgeSwapFeePercentageWhenNewTotalImbalanceIsZero() public {
         _registerPool();
 
         uint256 numTokens = 8;
@@ -266,7 +266,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
         balances[indexIn] = 0;
         balances[indexOut] = 2e18;
 
-        uint256 surgeFeePercentage = stableSurgeHook.getSurgeFeePercentage(
+        uint256 surgeFeePercentage = stableSurgeHook.getSurgeSwapFeePercentage(
             _buildSwapParams(indexIn, indexOut, 1e18, SwapKind.EXACT_IN, balances),
             pool,
             STATIC_FEE_PERCENTAGE
@@ -275,7 +275,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
         assertEq(surgeFeePercentage, STATIC_FEE_PERCENTAGE, "Surge fee percentage should be staticFeePercentage");
     }
 
-    function testGetSurgeFeePercentageWhenNewTotalImbalanceLesOrEqOld() public {
+    function testgetSurgeSwapFeePercentageWhenNewTotalImbalanceLesOrEqOld() public {
         _registerPool();
 
         uint256 numTokens = 8;
@@ -285,7 +285,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
         }
         balances[3] = 10000e18;
 
-        uint256 surgeFeePercentage = stableSurgeHook.getSurgeFeePercentage(
+        uint256 surgeFeePercentage = stableSurgeHook.getSurgeSwapFeePercentage(
             _buildSwapParams(0, MAX_TOKENS - 1, 0, SwapKind.EXACT_IN, balances),
             pool,
             STATIC_FEE_PERCENTAGE
@@ -293,7 +293,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
         assertEq(surgeFeePercentage, STATIC_FEE_PERCENTAGE, "Surge fee percentage should be staticFeePercentage");
     }
 
-    function testGetSurgeFeePercentageWhenNewTotalImbalanceLessOrEqThreshold() public {
+    function testgetSurgeSwapFeePercentageWhenNewTotalImbalanceLessOrEqThreshold() public {
         _registerPool();
 
         uint256 numTokens = 8;
@@ -304,7 +304,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
         balances[4] = 2e18;
         balances[5] = 2e18;
 
-        uint256 surgeFeePercentage = stableSurgeHook.getSurgeFeePercentage(
+        uint256 surgeFeePercentage = stableSurgeHook.getSurgeSwapFeePercentage(
             _buildSwapParams(0, MAX_TOKENS - 1, 1, SwapKind.EXACT_IN, balances),
             pool,
             STATIC_FEE_PERCENTAGE

--- a/pkg/pool-hooks/test/foundry/StableSurgeHookUnit.t.sol
+++ b/pkg/pool-hooks/test/foundry/StableSurgeHookUnit.t.sol
@@ -182,7 +182,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
         stableSurgeHook.setSurgeThresholdPercentage(pool, 1e18);
     }
 
-    function testgetSurgeSwapFeePercentage__Fuzz(
+    function testGetSurgeFeePercentage__Fuzz(
         uint256 length,
         uint256 indexIn,
         uint256 indexOut,
@@ -204,7 +204,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
             rawBalances
         );
         PoolSwapParams memory swapParams = _buildSwapParams(indexIn, indexOut, amountGivenScaled18, kind, balances);
-        uint256 surgeFeePercentage = stableSurgeHook.getSurgeSwapFeePercentage(swapParams, pool, STATIC_FEE_PERCENTAGE);
+        uint256 surgeFeePercentage = stableSurgeHook.getSurgeFeePercentage(swapParams, pool, STATIC_FEE_PERCENTAGE);
         uint256[] memory newBalances = _computeNewBalances(swapParams);
         uint256 expectedFee = _calculateFee(
             stableSurgeMedianMathMock.calculateImbalance(newBalances),
@@ -253,7 +253,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
         assertEq(surgeFeePercentage, expectedFee, "Surge fee percentage should be expectedFee");
     }
 
-    function testgetSurgeSwapFeePercentageWhenNewTotalImbalanceIsZero() public {
+    function testGetSurgeFeePercentageWhenNewTotalImbalanceIsZero() public {
         _registerPool();
 
         uint256 numTokens = 8;
@@ -266,7 +266,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
         balances[indexIn] = 0;
         balances[indexOut] = 2e18;
 
-        uint256 surgeFeePercentage = stableSurgeHook.getSurgeSwapFeePercentage(
+        uint256 surgeFeePercentage = stableSurgeHook.getSurgeFeePercentage(
             _buildSwapParams(indexIn, indexOut, 1e18, SwapKind.EXACT_IN, balances),
             pool,
             STATIC_FEE_PERCENTAGE
@@ -275,7 +275,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
         assertEq(surgeFeePercentage, STATIC_FEE_PERCENTAGE, "Surge fee percentage should be staticFeePercentage");
     }
 
-    function testgetSurgeSwapFeePercentageWhenNewTotalImbalanceLesOrEqOld() public {
+    function testGetSurgeFeePercentageWhenNewTotalImbalanceLesOrEqOld() public {
         _registerPool();
 
         uint256 numTokens = 8;
@@ -285,7 +285,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
         }
         balances[3] = 10000e18;
 
-        uint256 surgeFeePercentage = stableSurgeHook.getSurgeSwapFeePercentage(
+        uint256 surgeFeePercentage = stableSurgeHook.getSurgeFeePercentage(
             _buildSwapParams(0, MAX_TOKENS - 1, 0, SwapKind.EXACT_IN, balances),
             pool,
             STATIC_FEE_PERCENTAGE
@@ -293,7 +293,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
         assertEq(surgeFeePercentage, STATIC_FEE_PERCENTAGE, "Surge fee percentage should be staticFeePercentage");
     }
 
-    function testgetSurgeSwapFeePercentageWhenNewTotalImbalanceLessOrEqThreshold() public {
+    function testGetSurgeFeePercentageWhenNewTotalImbalanceLessOrEqThreshold() public {
         _registerPool();
 
         uint256 numTokens = 8;
@@ -304,7 +304,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
         balances[4] = 2e18;
         balances[5] = 2e18;
 
-        uint256 surgeFeePercentage = stableSurgeHook.getSurgeSwapFeePercentage(
+        uint256 surgeFeePercentage = stableSurgeHook.getSurgeFeePercentage(
             _buildSwapParams(0, MAX_TOKENS - 1, 1, SwapKind.EXACT_IN, balances),
             pool,
             STATIC_FEE_PERCENTAGE

--- a/pkg/pool-hooks/test/foundry/StableSurgePoolFactory.t.sol
+++ b/pkg/pool-hooks/test/foundry/StableSurgePoolFactory.t.sol
@@ -129,7 +129,6 @@ contract StableSurgePoolFactoryTest is BaseVaultTest, StableSurgePoolFactoryDepl
             roleAccounts,
             MAX_SWAP_FEE_PERCENTAGE,
             false,
-            false,
             ZERO_BYTES32
         );
     }
@@ -146,7 +145,6 @@ contract StableSurgePoolFactoryTest is BaseVaultTest, StableSurgePoolFactoryDepl
             roleAccounts,
             MAX_SWAP_FEE_PERCENTAGE,
             supportsDonation,
-            false, // Do not disable unbalanced add/remove liquidity
             ZERO_BYTES32
         );
 


### PR DESCRIPTION
# Description

PoC: allow unbalanced liquidity for stable surge, blocking operations that would make the pool surge past the threshold (proportional excluded).

Using `after` hooks because it's easier to reconstruct original balances without caring about the operation kind. Also prevents reloading balances unnecessarily at the vault.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
