### PR TITLE
Update link to WeightedMath

### DIFF
--- a/pkg/solidity-utils/contracts/math/WeightedMath.sol
+++ b/pkg/solidity-utils/contracts/math/WeightedMath.sol
@@ -9,7 +9,7 @@ import { FixedPoint } from "./FixedPoint.sol";
  * @dev It is a generalization of the x * y = k constant product formula, accounting for cases with more than two
  * tokens, and weights that are not 50/50.
  *
- * See https://docs.balancer.fi/concepts/explore-available-balancer-pools/weighted-pool/weighted-math.
+ * See https://docs.balancer.fi/concepts/explore-available-balancer-pools/weighted-pool/weighted-math.html
  *
  * For security reasons, to help ensure that for all possible "round trip" paths the caller always receives the same
  * or fewer tokens than supplied, we have chosen the rounding direction to favor the protocol in all cases.

--- a/pkg/solidity-utils/contracts/math/WeightedMath.sol
+++ b/pkg/solidity-utils/contracts/math/WeightedMath.sol
@@ -7,7 +7,9 @@ import { FixedPoint } from "./FixedPoint.sol";
 /**
  * @notice Implementation of Balancer Weighted Math, essentially unchanged since v1.
  * @dev It is a generalization of the x * y = k constant product formula, accounting for cases with more than two
- * tokens, and weights that are not 50/50. See https://docs.qr68.com/tech-implementations/weighted-math.
+ * tokens, and weights that are not 50/50.
+ *
+ * See https://docs.balancer.fi/concepts/explore-available-balancer-pools/weighted-pool/weighted-math.
  *
  * For security reasons, to help ensure that for all possible "round trip" paths the caller always receives the same
  * or fewer tokens than supplied, we have chosen the rounding direction to favor the protocol in all cases.


### PR DESCRIPTION
# Description

Update the link to WeightedMath. The old docs.qr68.com link was a very simple page (see https://web.archive.org/web/20240529211301/https://docs.qr68.com/tech-implementations/weighted-math). Linking to our current docs is safer (and should be better maintained).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [X] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Resolves #1265 
