### PR TITLE
Fix StableSurgeHook underflow when maxSurgeFeePercentage < staticSwapFeePercentage

### DIFF
--- a/pkg/pool-hooks/contracts/StableSurgeHook.sol
+++ b/pkg/pool-hooks/contracts/StableSurgeHook.sol
@@ -328,6 +328,13 @@ contract StableSurgeHook is BaseHooks, VaultGuard, SingletonAuthentication {
         uint256[] memory newBalances
     ) internal view returns (uint256 surgeFeePercentage) {
         SurgeFeeData memory surgeFeeData = _surgeFeePoolData[pool];
+
+        // If the max surge fee percentage is less than the static fee percentage, return the static fee percentage.
+        // No matter where the imbalance is, the fee can never be smaller than the static fee.
+        if (surgeFeeData.maxSurgeFeePercentage < staticFeePercentage) {
+            return staticFeePercentage;
+        }
+
         uint256 newTotalImbalance = StableSurgeMedianMath.calculateImbalance(newBalances);
 
         bool isSurging = _isSurging(surgeFeeData, params.balancesScaled18, newTotalImbalance);

--- a/pkg/pool-hooks/test/foundry/StableSurgeHookUnit.t.sol
+++ b/pkg/pool-hooks/test/foundry/StableSurgeHookUnit.t.sol
@@ -45,6 +45,11 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
             DEFAULT_MAX_SURGE_FEE_PERCENTAGE,
             DEFAULT_SURGE_THRESHOLD_PERCENTAGE
         );
+
+        authorizer.grantRole(
+            IAuthentication(address(stableSurgeHook)).getActionId(StableSurgeHook.setMaxSurgeFeePercentage.selector),
+            admin
+        );
     }
 
     function testOnRegister() public {
@@ -180,6 +185,39 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
 
         vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         stableSurgeHook.setSurgeThresholdPercentage(pool, 1e18);
+    }
+
+    function testGetSurgeFeePercentage_MaxSurgeSmallerThanStatic() public {
+        // Set a small max surge fee percentage.
+        uint256 smallMaxSurgeFee = 1e16; // 1%
+        vm.prank(admin);
+        stableSurgeHook.setMaxSurgeFeePercentage(pool, smallMaxSurgeFee);
+
+        // Set a larger static fee.
+        uint256 largerStaticFee = 2e16; // 2%
+        vault.manuallySetSwapFee(pool, largerStaticFee);
+
+        // Create an unbalanced state to trigger surge pricing
+        uint256[] memory balances = new uint256[](2);
+        balances[0] = poolInitAmount / 10;
+        balances[1] = poolInitAmount;
+        vault.manualSetPoolBalances(pool, balances, balances);
+
+        // Create swap params that would normally trigger surge pricing.
+        PoolSwapParams memory params = PoolSwapParams({
+            kind: SwapKind.EXACT_IN,
+            indexIn: 0,
+            indexOut: 1,
+            amountGivenScaled18: poolInitAmount / 2,
+            balancesScaled18: balances,
+            router: address(0),
+            userData: bytes("")
+        });
+
+        // Even though we're in a surging state, we should get back the static fee since it's larger than the max
+        // surge fee.
+        uint256 surgeFeePercentage = stableSurgeHook.getSurgeFeePercentage(params, pool, largerStaticFee);
+        assertEq(surgeFeePercentage, largerStaticFee, "Should return static fee when max surge is smaller");
     }
 
     function testGetSurgeFeePercentage__Fuzz(

--- a/pkg/pool-hooks/test/foundry/StableSurgeHookUnit.t.sol
+++ b/pkg/pool-hooks/test/foundry/StableSurgeHookUnit.t.sol
@@ -193,9 +193,9 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
         vm.prank(admin);
         stableSurgeHook.setMaxSurgeFeePercentage(pool, smallMaxSurgeFee);
 
-        // Set a larger static fee.
-        uint256 largerStaticFee = 2e16; // 2%
-        vault.manuallySetSwapFee(pool, largerStaticFee);
+        // Set a larger static fee percentage.
+        uint256 staticFeePercentage = 2e16; // 2%
+        vault.manuallySetSwapFee(pool, staticFeePercentage);
 
         // Create an unbalanced state to trigger surge pricing
         uint256[] memory balances = new uint256[](2);
@@ -216,8 +216,8 @@ contract StableSurgeHookUnitTest is BaseVaultTest {
 
         // Even though we're in a surging state, we should get back the static fee since it's larger than the max
         // surge fee.
-        uint256 surgeFeePercentage = stableSurgeHook.getSurgeFeePercentage(params, pool, largerStaticFee);
-        assertEq(surgeFeePercentage, largerStaticFee, "Should return static fee when max surge is smaller");
+        uint256 surgeFeePercentage = stableSurgeHook.getSurgeFeePercentage(params, pool, staticFeePercentage);
+        assertEq(surgeFeePercentage, staticFeePercentage, "Should return static fee percentage");
     }
 
     function testGetSurgeFeePercentage__Fuzz(


### PR DESCRIPTION
# Description

Certora reported in the SbaleSurgeHook audit that when maxSurgeFeePercentage is smaller than staticSwapFeePercentage and the pool is imbalanced, a swap reverts due to a math underflow. This PR fixes this issue.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge
