### PR TITLE
Add project/reserve token information to LBPools

### DIFF
--- a/pkg/interfaces/contracts/pool-weighted/ILBPool.sol
+++ b/pkg/interfaces/contracts/pool-weighted/ILBPool.sol
@@ -95,14 +95,6 @@ struct LBPoolDynamicData {
  */
 interface ILBPool is IBasePool {
     /**
-     * @notice Emitted on deployment so that offchain processes know which token is which from the beginning.
-     * @dev This information is also available onchain through immutable data and explicit getters.
-     * @param projectToken The address of the project token (being distributed in the sale)
-     * @param reserveToken The address of the reserve token (used to purchase the project token)
-     */
-    event LBPoolCreated(IERC20 indexed projectToken, IERC20 indexed reserveToken);
-
-    /**
      * @notice Get dynamic pool data relevant to swap/add/remove calculations.
      * @return data A struct containing all dynamic LBP parameters
      */

--- a/pkg/interfaces/contracts/pool-weighted/ILBPool.sol
+++ b/pkg/interfaces/contracts/pool-weighted/ILBPool.sol
@@ -95,6 +95,14 @@ struct LBPoolDynamicData {
  */
 interface ILBPool is IBasePool {
     /**
+     * @notice Emitted on deployment so that offchain processes know which token is which from the beginning.
+     * @dev This information is also available onchain through immutable data and explicit getters.
+     * @param projectToken The address of the project token (being distributed in the sale)
+     * @param reserveToken The address of the reserve token (used to purchase the project token)
+     */
+    event LBPoolCreated(IERC20 indexed projectToken, IERC20 indexed reserveToken);
+
+    /**
      * @notice Get dynamic pool data relevant to swap/add/remove calculations.
      * @return data A struct containing all dynamic LBP parameters
      */

--- a/pkg/interfaces/contracts/pool-weighted/ILBPool.sol
+++ b/pkg/interfaces/contracts/pool-weighted/ILBPool.sol
@@ -45,6 +45,8 @@ struct LBPParams {
  * @param endWeights Ending weights for the LBP, sorted in token registration order
  * @param startTime Timestamp of the start of the sale, when all liquidity is present and swaps are enabled
  * @param endTime Timestamp of the end of the sale, when swaps are disabled, and liquidity can be removed
+ * @param projectTokenIndex The index of token (in `tokens`) being distributed through the sale
+ * @param reserveTokenIndex The index of the token (in `tokens`) used to purchase project tokens
  * @param isProjectTokenSwapInBlocked If true, it is impossible to sell the project token back into the pool
  */
 struct LBPoolImmutableData {
@@ -54,6 +56,8 @@ struct LBPoolImmutableData {
     uint256[] endWeights;
     uint256 startTime;
     uint256 endTime;
+    uint256 projectTokenIndex;
+    uint256 reserveTokenIndex;
     bool isProjectTokenSwapInBlocked;
 }
 
@@ -83,7 +87,12 @@ struct LBPoolDynamicData {
     bool isSwapEnabled;
 }
 
-/// @notice Full LBP interface - base pool plus immutable/dynamic field getters.
+/**
+ * @notice Full LBP interface - base pool plus immutable/dynamic field getters.
+ * @dev There is some redundancy here to cover all use cases. Project and reserve tokens can be read directly, if that
+ * is all that's needed. Those who already need the more complete data in `LBPoolImmutableData` can recover these
+ * values without further calls by indexing into the `tokens` array with `projectTokenIndex` and `reserveTokenIndex`.
+ */
 interface ILBPool is IBasePool {
     /**
      * @notice Get dynamic pool data relevant to swap/add/remove calculations.
@@ -96,4 +105,23 @@ interface ILBPool is IBasePool {
      * @return data A struct containing all immutable LBP parameters
      */
     function getLBPoolImmutableData() external view returns (LBPoolImmutableData memory data);
+
+    /**
+     * @notice Get the project token for this LBP.
+     * @dev This is the token being distributed through the sale. It is also available in the immutable data, but this
+     * getter is provided as a convenience for those who only need the project token address.
+     *
+     * @return projectToken The address of the project token
+     */
+    function getProjectToken() external view returns (IERC20);
+
+    /**
+     * @notice Get the reserve token for this LBP.
+     * @dev This is the token exchanged for the project token (usually a stablecoin or WETH). It is also available in
+     * the immutable data, but this getter is provided as a convenience for those who only need the reserve token
+     * address.
+     *
+     * @return reserveToken The address of the reserve token
+     */
+    function getReserveToken() external view returns (IERC20);
 }

--- a/pkg/pool-weighted/contracts/lbp/LBPool.sol
+++ b/pkg/pool-weighted/contracts/lbp/LBPool.sol
@@ -140,6 +140,8 @@ contract LBPool is ILBPool, WeightedPool, Ownable2Step, BaseHooks {
 
         (_projectTokenIndex, _reserveTokenIndex) = lbpParams.projectToken < lbpParams.reserveToken ? (0, 1) : (1, 0);
 
+        emit LBPoolCreated(lbpParams.projectToken, lbpParams.reserveToken);
+
         // Preserve event compatibility with previous LBP versions.
         uint256[] memory startWeights = new uint256[](_TWO_TOKENS);
         uint256[] memory endWeights = new uint256[](_TWO_TOKENS);

--- a/pkg/pool-weighted/contracts/lbp/LBPool.sol
+++ b/pkg/pool-weighted/contracts/lbp/LBPool.sol
@@ -140,8 +140,6 @@ contract LBPool is ILBPool, WeightedPool, Ownable2Step, BaseHooks {
 
         (_projectTokenIndex, _reserveTokenIndex) = lbpParams.projectToken < lbpParams.reserveToken ? (0, 1) : (1, 0);
 
-        emit LBPoolCreated(lbpParams.projectToken, lbpParams.reserveToken);
-
         // Preserve event compatibility with previous LBP versions.
         uint256[] memory startWeights = new uint256[](_TWO_TOKENS);
         uint256[] memory endWeights = new uint256[](_TWO_TOKENS);

--- a/pkg/pool-weighted/contracts/lbp/LBPool.sol
+++ b/pkg/pool-weighted/contracts/lbp/LBPool.sol
@@ -273,12 +273,12 @@ contract LBPool is ILBPool, WeightedPool, Ownable2Step, BaseHooks {
         data.endTime = _endTime;
 
         data.startWeights = new uint256[](_TWO_TOKENS);
-        data.startWeights[data.projectTokenIndex] = _projectTokenStartWeight;
-        data.startWeights[data.reserveTokenIndex] = _reserveTokenStartWeight;
+        data.startWeights[_projectTokenIndex] = _projectTokenStartWeight;
+        data.startWeights[_reserveTokenIndex] = _reserveTokenStartWeight;
 
         data.endWeights = new uint256[](_TWO_TOKENS);
-        data.endWeights[data.projectTokenIndex] = _projectTokenEndWeight;
-        data.endWeights[data.reserveTokenIndex] = _reserveTokenEndWeight;
+        data.endWeights[_projectTokenIndex] = _projectTokenEndWeight;
+        data.endWeights[_reserveTokenIndex] = _reserveTokenEndWeight;
     }
 
     /*******************************************************************************

--- a/pkg/pool-weighted/contracts/lbp/LBPool.sol
+++ b/pkg/pool-weighted/contracts/lbp/LBPool.sol
@@ -163,6 +163,16 @@ contract LBPool is ILBPool, WeightedPool, Ownable2Step, BaseHooks {
         return _trustedRouter;
     }
 
+    /// @inheritdoc ILBPool
+    function getProjectToken() external view returns (IERC20) {
+        return _projectToken;
+    }
+
+    /// @inheritdoc ILBPool
+    function getReserveToken() external view returns (IERC20) {
+        return _reserveToken;
+    }
+
     /**
      * @notice Return start time, end time, and endWeights as an array.
      * @dev Current weights should be retrieved via `getNormalizedWeights()`.
@@ -254,18 +264,21 @@ contract LBPool is ILBPool, WeightedPool, Ownable2Step, BaseHooks {
     /// @inheritdoc ILBPool
     function getLBPoolImmutableData() external view override returns (LBPoolImmutableData memory data) {
         data.tokens = _vault.getPoolTokens(address(this));
+        data.projectTokenIndex = _projectTokenIndex;
+        data.reserveTokenIndex = _reserveTokenIndex;
+
         (data.decimalScalingFactors, ) = _vault.getPoolTokenRates(address(this));
         data.isProjectTokenSwapInBlocked = _blockProjectTokenSwapsIn;
         data.startTime = _startTime;
         data.endTime = _endTime;
 
         data.startWeights = new uint256[](_TWO_TOKENS);
-        data.startWeights[_projectTokenIndex] = _projectTokenStartWeight;
-        data.startWeights[_reserveTokenIndex] = _reserveTokenStartWeight;
+        data.startWeights[data.projectTokenIndex] = _projectTokenStartWeight;
+        data.startWeights[data.reserveTokenIndex] = _reserveTokenStartWeight;
 
         data.endWeights = new uint256[](_TWO_TOKENS);
-        data.endWeights[_projectTokenIndex] = _projectTokenEndWeight;
-        data.endWeights[_reserveTokenIndex] = _reserveTokenEndWeight;
+        data.endWeights[data.projectTokenIndex] = _projectTokenEndWeight;
+        data.endWeights[data.reserveTokenIndex] = _reserveTokenEndWeight;
     }
 
     /*******************************************************************************

--- a/pkg/pool-weighted/contracts/lbp/LBPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/lbp/LBPoolFactory.sol
@@ -31,6 +31,15 @@ contract LBPoolFactory is IPoolVersion, ReentrancyGuardTransient, BasePoolFactor
 
     address internal immutable _trustedRouter;
 
+    /**
+     * @notice Emitted on deployment so that offchain processes know which token is which from the beginning.
+     * @dev This information is also available onchain through immutable data and explicit getters on the pool.
+     * @param pool The address of the new pool
+     * @param projectToken The address of the project token (being distributed in the sale)
+     * @param reserveToken The address of the reserve token (used to purchase the project token)
+     */
+    event LBPoolCreated(address indexed pool, IERC20 indexed projectToken, IERC20 indexed reserveToken);
+
     /// @notice The zero address was given for the trusted router.
     error InvalidTrustedRouter();
 
@@ -103,6 +112,8 @@ contract LBPoolFactory is IPoolVersion, ReentrancyGuardTransient, BasePoolFactor
         );
 
         pool = _create(abi.encode(name, symbol, lbpParams, getVault(), _trustedRouter, _poolVersion), salt);
+
+        emit LBPoolCreated(pool, lbpParams.projectToken, lbpParams.reserveToken);
 
         _registerPoolWithVault(
             pool,

--- a/pkg/pool-weighted/test/foundry/LBPool.t.sol
+++ b/pkg/pool-weighted/test/foundry/LBPool.t.sol
@@ -149,11 +149,27 @@ contract LBPoolTest is BaseLBPTest {
         uint32 startTime = uint32(block.timestamp + DEFAULT_START_OFFSET);
         uint32 endTime = uint32(block.timestamp + DEFAULT_END_OFFSET);
 
-        vm.expectEmit();
-        emit ILBPool.LBPoolCreated(projectToken, reserveToken);
+        uint256 preCreateSnapshotId = vm.snapshot();
 
         vm.expectEmit();
         emit LBPool.GradualWeightUpdateScheduled(startTime, endTime, startWeights, endWeights);
+
+        (address newPool, ) = _createLBPoolWithCustomWeights(
+            startWeights[projectIdx],
+            startWeights[reserveIdx],
+            endWeights[projectIdx],
+            endWeights[reserveIdx],
+            startTime,
+            endTime,
+            DEFAULT_PROJECT_TOKENS_SWAP_IN
+        );
+
+        vm.revertTo(preCreateSnapshotId);
+
+        vm.expectEmit();
+        emit LBPoolFactory.LBPoolCreated(newPool, projectToken, reserveToken);
+
+        // Should create the same pool address again.
         _createLBPoolWithCustomWeights(
             startWeights[projectIdx],
             startWeights[reserveIdx],

--- a/pkg/pool-weighted/test/foundry/LBPool.t.sol
+++ b/pkg/pool-weighted/test/foundry/LBPool.t.sol
@@ -13,7 +13,8 @@ import { IRouterCommon } from "@balancer-labs/v3-interfaces/contracts/vault/IRou
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 import {
     LBPoolImmutableData,
-    LBPoolDynamicData
+    LBPoolDynamicData,
+    ILBPool
 } from "@balancer-labs/v3-interfaces/contracts/pool-weighted/ILBPool.sol";
 import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
@@ -167,6 +168,18 @@ contract LBPoolTest is BaseLBPTest {
 
     function testGetTrustedRouter() public view {
         assertEq(LBPool(pool).getTrustedRouter(), address(router), "Wrong trusted router");
+    }
+
+    function testGetProjectToken() public view {
+        IERC20[] memory poolTokens = vault.getPoolTokens(pool);
+
+        assertEq(address(ILBPool(pool).getProjectToken()), address(poolTokens[projectIdx]), "Wrong project token");
+    }
+
+    function testGetReserveToken() public view {
+        IERC20[] memory poolTokens = vault.getPoolTokens(pool);
+
+        assertEq(address(ILBPool(pool).getReserveToken()), address(poolTokens[reserveIdx]), "Wrong reserve token");
     }
 
     function testGradualWeightUpdateParams() public {
@@ -334,6 +347,8 @@ contract LBPoolTest is BaseLBPTest {
         assertEq(data.tokens.length, poolTokens.length, "tokens length mismatch");
         assertEq(address(data.tokens[projectIdx]), address(poolTokens[projectIdx]), "Project token mismatch");
         assertEq(address(data.tokens[reserveIdx]), address(poolTokens[reserveIdx]), "Reserve token mismatch");
+        assertEq(data.projectTokenIndex, projectIdx, "Project token index mismatch");
+        assertEq(data.reserveTokenIndex, reserveIdx, "Reserve token index mismatch");
 
         // Check decimal scaling factors
         (uint256[] memory decimalScalingFactors, ) = vault.getPoolTokenRates(pool);

--- a/pkg/pool-weighted/test/foundry/LBPool.t.sol
+++ b/pkg/pool-weighted/test/foundry/LBPool.t.sol
@@ -145,9 +145,12 @@ contract LBPoolTest is BaseLBPTest {
         );
     }
 
-    function testCreatePoolEvent() public {
+    function testCreatePoolEvents() public {
         uint32 startTime = uint32(block.timestamp + DEFAULT_START_OFFSET);
         uint32 endTime = uint32(block.timestamp + DEFAULT_END_OFFSET);
+
+        vm.expectEmit();
+        emit ILBPool.LBPoolCreated(projectToken, reserveToken);
 
         vm.expectEmit();
         emit LBPool.GradualWeightUpdateScheduled(startTime, endTime, startWeights, endWeights);
@@ -171,15 +174,11 @@ contract LBPoolTest is BaseLBPTest {
     }
 
     function testGetProjectToken() public view {
-        IERC20[] memory poolTokens = vault.getPoolTokens(pool);
-
-        assertEq(address(ILBPool(pool).getProjectToken()), address(poolTokens[projectIdx]), "Wrong project token");
+        assertEq(address(ILBPool(pool).getProjectToken()), address(projectToken), "Wrong project token");
     }
 
     function testGetReserveToken() public view {
-        IERC20[] memory poolTokens = vault.getPoolTokens(pool);
-
-        assertEq(address(ILBPool(pool).getReserveToken()), address(poolTokens[reserveIdx]), "Wrong reserve token");
+        assertEq(address(ILBPool(pool).getReserveToken()), address(reserveToken), "Wrong reserve token");
     }
 
     function testGradualWeightUpdateParams() public {


### PR DESCRIPTION
# Description

We explicitly store the project and reserve tokens, but don't have getters for them. It's fairly obvious to a human which is which, but automated systems might also need to know this; for instance, aggregators who must know which direction to block if `blockProjectTokenSwapsIn` is true.

Both on- and off-chain processes might conceivably need this, so this PR:
1) Adds an LBP-specific event with the project and reserve tokens named
2) Adds explicit getters for the project and reserve tokens, in case somebody just wants that, and doesn't need the full immutable data (including token decimals, etc.)
3) Adds project/reserve information to the immutable data getter, so that processes already calling that can either use the existing tokens array (e.g., if they don't care which is which and just need the tokens), or use the added indexes to pull the token(s) they need out of the array, without needing to make any more calls

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Resolves #1278 
