### PR TITLE
Fix foundry tests

### DIFF
--- a/pkg/pool-cow/foundry.toml
+++ b/pkg/pool-cow/foundry.toml
@@ -27,6 +27,7 @@ solc_version = '0.8.27'
 auto_detect_solc = false
 evm_version = 'cancun'
 ignored_error_codes = [2394, 5574, 3860] # Transient storage, code size
+allow_internal_expect_revert = true
 
 [fuzz]
 runs = 10000

--- a/pkg/pool-gyro/foundry.toml
+++ b/pkg/pool-gyro/foundry.toml
@@ -27,6 +27,7 @@ solc_version = '0.8.27'
 auto_detect_solc = false
 evm_version = 'cancun'
 ignored_error_codes = [2394, 5574, 3860] # Transient storage, code size
+allow_internal_expect_revert = true
 
 [fuzz]
 runs = 10000

--- a/pkg/pool-hooks/foundry.toml
+++ b/pkg/pool-hooks/foundry.toml
@@ -27,6 +27,7 @@ solc_version = '0.8.26'
 auto_detect_solc = false
 evm_version = 'cancun'
 ignored_error_codes = [2394, 5574, 3860] # Transient storage, code size
+allow_internal_expect_revert = true
 
 [fuzz]
 runs = 10000

--- a/pkg/pool-stable/foundry.toml
+++ b/pkg/pool-stable/foundry.toml
@@ -28,6 +28,7 @@ auto_detect_solc = false
 evm_version = 'cancun'
 ignored_error_codes = [2394, 5574, 3860] # Transient storage, code size
 allow_internal_expect_revert = true
+
 [fuzz]
 runs = 10000
 max_test_rejects = 60000

--- a/pkg/pool-stable/foundry.toml
+++ b/pkg/pool-stable/foundry.toml
@@ -27,7 +27,7 @@ solc_version = '0.8.26'
 auto_detect_solc = false
 evm_version = 'cancun'
 ignored_error_codes = [2394, 5574, 3860] # Transient storage, code size
-
+allow_internal_expect_revert = true
 [fuzz]
 runs = 10000
 max_test_rejects = 60000

--- a/pkg/pool-utils/foundry.toml
+++ b/pkg/pool-utils/foundry.toml
@@ -27,6 +27,7 @@ solc_version = '0.8.26'
 auto_detect_solc = false
 evm_version = 'cancun'
 ignored_error_codes = [2394, 5574, 3860] # Transient storage, code size
+allow_internal_expect_revert = true
 
 [fuzz]
 runs = 10000

--- a/pkg/pool-weighted/foundry.toml
+++ b/pkg/pool-weighted/foundry.toml
@@ -28,6 +28,7 @@ auto_detect_solc = false
 evm_version = 'cancun'
 ignored_error_codes = [2394, 5574, 3860] # Transient storage, code size
 allow_internal_expect_revert = true
+
 [fuzz]
 runs = 10000
 max_test_rejects = 60000

--- a/pkg/pool-weighted/foundry.toml
+++ b/pkg/pool-weighted/foundry.toml
@@ -27,7 +27,7 @@ solc_version = '0.8.26'
 auto_detect_solc = false
 evm_version = 'cancun'
 ignored_error_codes = [2394, 5574, 3860] # Transient storage, code size
-
+allow_internal_expect_revert = true
 [fuzz]
 runs = 10000
 max_test_rejects = 60000

--- a/pkg/pool-weighted/test/foundry/WeightedPool.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedPool.t.sol
@@ -120,7 +120,7 @@ contract WeightedPoolTest is WeightedPoolContractsDeployer, BasePoolTest {
         IRateProvider(pool).getRate();
     }
 
-    function test_RevertsWhen_SwapFeeTooLow() public {
+    function testRevertsWhenSwapFeeTooLow() public {
         TokenConfig[] memory tokenConfigs = new TokenConfig[](2);
         tokenConfigs[daiIdx].token = IERC20(dai);
         tokenConfigs[usdcIdx].token = IERC20(usdc);

--- a/pkg/pool-weighted/test/foundry/WeightedPool.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedPool.t.sol
@@ -120,28 +120,31 @@ contract WeightedPoolTest is WeightedPoolContractsDeployer, BasePoolTest {
         IRateProvider(pool).getRate();
     }
 
-    function testFailSwapFeeTooLow() public {
+    function test_RevertsWhen_SwapFeeTooLow() public {
         TokenConfig[] memory tokenConfigs = new TokenConfig[](2);
         tokenConfigs[daiIdx].token = IERC20(dai);
         tokenConfigs[usdcIdx].token = IERC20(usdc);
 
         PoolRoleAccounts memory roleAccounts;
 
+        uint256 minimumSwapFeePercentage = IBasePool(pool).getMinimumSwapFeePercentage();
+
+        vm.expectRevert(IVaultErrors.SwapFeePercentageTooLow.selector);
         address lowFeeWeightedPool = WeightedPoolFactory(poolFactory).create(
             "ERC20 Pool",
             "ERC20POOL",
             tokenConfigs,
             [uint256(50e16), uint256(50e16)].toMemoryArray(),
             roleAccounts,
-            IBasePool(pool).getMinimumSwapFeePercentage() - 1, // Swap fee too low
+            minimumSwapFeePercentage - 1, // Swap fee too low
             poolHooksContract,
             false, // Do not enable donations
             false, // Do not disable unbalanced add/remove liquidity
             "Low fee pool"
         );
 
-        vm.expectRevert(IVaultErrors.SwapFeePercentageTooLow.selector);
-        PoolFactoryMock(poolFactory).registerTestPool(lowFeeWeightedPool, tokenConfigs);
+        // The pool was not deployed, so the address is 0x0.
+        assertEq(address(lowFeeWeightedPool), address(0));
     }
 
     function testGetWeightedPoolImmutableData() public view {

--- a/pkg/solidity-utils/foundry.toml
+++ b/pkg/solidity-utils/foundry.toml
@@ -24,6 +24,7 @@ solc_version = '0.8.26'
 auto_detect_solc = false
 evm_version = 'cancun'
 ignored_error_codes = [2394, 5574, 3860] # Transient storage, code size
+allow_internal_expect_revert = true
 
 [fuzz]
 runs = 10000

--- a/pkg/standalone-utils/foundry.toml
+++ b/pkg/standalone-utils/foundry.toml
@@ -28,6 +28,7 @@ auto_detect_solc = false
 evm_version = 'cancun'
 ignored_error_codes = [2394, 5574, 3860] # Transient storage, code size
 allow_internal_expect_revert = true
+
 [fuzz]
 runs = 10000
 max_test_rejects = 60000

--- a/pkg/standalone-utils/foundry.toml
+++ b/pkg/standalone-utils/foundry.toml
@@ -27,7 +27,7 @@ solc_version = '0.8.26'
 auto_detect_solc = false
 evm_version = 'cancun'
 ignored_error_codes = [2394, 5574, 3860] # Transient storage, code size
-
+allow_internal_expect_revert = true
 [fuzz]
 runs = 10000
 max_test_rejects = 60000

--- a/pkg/vault/foundry.toml
+++ b/pkg/vault/foundry.toml
@@ -27,6 +27,7 @@ solc_version = '0.8.26'
 auto_detect_solc = false
 evm_version = 'cancun'
 ignored_error_codes = [2394, 5574, 3860] # Transient storage, code size
+allow_internal_expect_revert = true
 
 [fuzz]
 runs = 10000

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	22.390
-InitCode	24.208
+Bytecode	14.289
+InitCode	15.854

--- a/pkg/vault/test/foundry/BalancerPoolTokenTest.t.sol
+++ b/pkg/vault/test/foundry/BalancerPoolTokenTest.t.sol
@@ -389,7 +389,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     ) public {
         deadline = bound(deadline, block.timestamp, MAX_UINT256);
         // privKey cannot be greater than Secp256k1 curve order.
-        privKey = bound(privKey, 1, 115792089237316195423570985008687907852837564279074904382605163141518161494337);
+        privKey = bound(privKey, 1, 115792089237316195423570985008687907852837564279074904382605163141518161494336);
         vm.assume(to != address(0));
         vm.assume(nonce != 0);
 

--- a/pkg/vault/test/foundry/BalancerPoolTokenTest.t.sol
+++ b/pkg/vault/test/foundry/BalancerPoolTokenTest.t.sol
@@ -210,7 +210,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function testFailPermitBadNonce() public {
+    function test_RevertWhen_PermitBadNonce() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -254,7 +254,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
         poolToken.permit(user, address(0xCAFE), DEFAULT_AMOUNT, block.timestamp, v2, r2, s2);
     }
 
-    function testFailPermitRevokedNonceV1() public {
+    function test_RevertWhen_PermitRevokedNonceV1() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -272,7 +272,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
         poolToken.permit(user, address(0xCAFE), DEFAULT_AMOUNT, block.timestamp, v, r, s);
     }
 
-    function testFailPermitRevokedNonceV2() public {
+    function test_RevertWhen_PermitRevokedNonceV2() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -303,7 +303,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function testFailPermitBadDeadline() public {
+    function test_RevertWhen_PermitBadDeadline() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -318,7 +318,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function testFailPermitPastDeadline() public {
+    function test_RevertWhen_PermitPastDeadline() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -333,7 +333,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function testFailPermitReplay() public {
+    function test_RevertWhen_PermitReplay() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -375,7 +375,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function testFailPermitBadNonce__Fuzz(
+    function test_RevertWhen_PermitBadNonce__Fuzz(
         uint256 privKey,
         address to,
         uint256 amount,
@@ -403,7 +403,12 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function testFailPermitBadDeadline__Fuzz(uint248 privKey, address to, uint256 amount, uint256 deadline) public {
+    function test_RevertWhen_PermitBadDeadline__Fuzz(
+        uint248 privKey,
+        address to,
+        uint256 amount,
+        uint256 deadline
+    ) public {
         deadline = bound(deadline, 0, block.timestamp - 1);
         vm.assume(privKey != 0);
         vm.assume(to != address(0));
@@ -445,7 +450,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function testFailPermitReplay__Fuzz(uint248 privKey, address to, uint256 amount, uint256 deadline) public {
+    function test_RevertWhen_PermitReplay__Fuzz(uint248 privKey, address to, uint256 amount, uint256 deadline) public {
         vm.assume(privKey != 0);
         vm.assume(to != address(0));
         deadline = bound(deadline, block.timestamp, MAX_UINT256);

--- a/pkg/vault/test/foundry/BalancerPoolTokenTest.t.sol
+++ b/pkg/vault/test/foundry/BalancerPoolTokenTest.t.sol
@@ -210,7 +210,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function test_RevertsWhen_PermitBadNonce() public {
+    function testRevertsWhenPermitBadNonce() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -254,7 +254,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
         poolToken.permit(user, address(0xCAFE), DEFAULT_AMOUNT, block.timestamp, v2, r2, s2);
     }
 
-    function test_RevertsWhen_PermitRevokedNonceV1() public {
+    function testRevertsWhenPermitRevokedNonceV1() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -272,7 +272,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
         poolToken.permit(user, address(0xCAFE), DEFAULT_AMOUNT, block.timestamp, v, r, s);
     }
 
-    function test_RevertsWhen_PermitRevokedNonceV2() public {
+    function testRevertsWhenPermitRevokedNonceV2() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -305,7 +305,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function test_RevertsWhen_PermitBadDeadline() public {
+    function testRevertsWhenPermitBadDeadline() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -321,7 +321,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function test_RevertsWhen_PermitPastDeadline() public {
+    function testRevertsWhenPermitPastDeadline() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -337,7 +337,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function test_RevertsWhen_PermitReplay() public {
+    function testRevertsWhenPermitReplay() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -380,7 +380,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function test_RevertsWhen_PermitBadNonce__Fuzz(
+    function testRevertsWhenPermitBadNonce__Fuzz(
         uint256 privKey,
         address to,
         uint256 amount,
@@ -410,7 +410,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function test_RevertsWhen_PermitBadDeadline__Fuzz(
+    function testRevertsWhenPermitBadDeadline__Fuzz(
         uint248 privKey,
         address to,
         uint256 amount,
@@ -458,7 +458,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function test_RevertsWhen_PermitReplay__Fuzz(uint248 privKey, address to, uint256 amount, uint256 deadline) public {
+    function testRevertsWhenPermitReplay__Fuzz(uint248 privKey, address to, uint256 amount, uint256 deadline) public {
         vm.assume(privKey != 0);
         vm.assume(to != address(0));
         deadline = bound(deadline, block.timestamp, MAX_UINT256);

--- a/pkg/vault/test/foundry/BalancerPoolTokenTest.t.sol
+++ b/pkg/vault/test/foundry/BalancerPoolTokenTest.t.sol
@@ -210,7 +210,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function test_RevertWhen_PermitBadNonce() public {
+    function test_RevertsWhen_PermitBadNonce() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -221,7 +221,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
             privateKey
         );
 
-        vm.expectRevert(bytes(""));
+        vm.expectRevert();
         poolToken.permit(user, address(0xCAFE), DEFAULT_AMOUNT, block.timestamp, v, r, s);
     }
 
@@ -254,7 +254,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
         poolToken.permit(user, address(0xCAFE), DEFAULT_AMOUNT, block.timestamp, v2, r2, s2);
     }
 
-    function test_RevertWhen_PermitRevokedNonceV1() public {
+    function test_RevertsWhen_PermitRevokedNonceV1() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -268,11 +268,11 @@ contract BalancerPoolTokenTest is BaseVaultTest {
         vm.prank(user);
         poolToken.incrementNonce();
 
-        vm.expectRevert(bytes(""));
+        vm.expectRevert();
         poolToken.permit(user, address(0xCAFE), DEFAULT_AMOUNT, block.timestamp, v, r, s);
     }
 
-    function test_RevertWhen_PermitRevokedNonceV2() public {
+    function test_RevertsWhen_PermitRevokedNonceV2() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -295,15 +295,17 @@ contract BalancerPoolTokenTest is BaseVaultTest {
             block.timestamp,
             privateKey
         );
+
+        vm.expectRevert();
         // Works with nonce + 2.
         poolToken.permit(user, address(0xCAFE), DEFAULT_AMOUNT, block.timestamp, v2, r2, s2);
 
-        vm.expectRevert(bytes(""));
+        vm.expectRevert();
         poolToken.permit(user, address(0xCAFE), DEFAULT_AMOUNT, block.timestamp, v, r, s);
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function test_RevertWhen_PermitBadDeadline() public {
+    function test_RevertsWhen_PermitBadDeadline() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -314,11 +316,12 @@ contract BalancerPoolTokenTest is BaseVaultTest {
             privateKey
         );
 
+        vm.expectRevert();
         poolToken.permit(user, address(0xCAFE), DEFAULT_AMOUNT, block.timestamp + 1, v, r, s);
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function test_RevertWhen_PermitPastDeadline() public {
+    function test_RevertsWhen_PermitPastDeadline() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -329,11 +332,12 @@ contract BalancerPoolTokenTest is BaseVaultTest {
             privateKey
         );
 
+        vm.expectRevert();
         poolToken.permit(user, address(0xCAFE), DEFAULT_AMOUNT, block.timestamp - 1, v, r, s);
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function test_RevertWhen_PermitReplay() public {
+    function test_RevertsWhen_PermitReplay() public {
         (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
             IEIP712(address(poolToken)),
             user,
@@ -345,6 +349,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
         );
 
         poolToken.permit(user, address(0xCAFE), DEFAULT_AMOUNT, block.timestamp, v, r, s);
+        vm.expectRevert();
         poolToken.permit(user, address(0xCAFE), DEFAULT_AMOUNT, block.timestamp, v, r, s);
     }
 
@@ -375,7 +380,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function test_RevertWhen_PermitBadNonce__Fuzz(
+    function test_RevertsWhen_PermitBadNonce__Fuzz(
         uint256 privKey,
         address to,
         uint256 amount,
@@ -383,7 +388,8 @@ contract BalancerPoolTokenTest is BaseVaultTest {
         uint256 nonce
     ) public {
         deadline = bound(deadline, block.timestamp, MAX_UINT256);
-        vm.assume(privKey != 0);
+        // privKey cannot be greater than Secp256k1 curve order.
+        privKey = bound(privKey, 1, 115792089237316195423570985008687907852837564279074904382605163141518161494337);
         vm.assume(to != address(0));
         vm.assume(nonce != 0);
 
@@ -399,11 +405,12 @@ contract BalancerPoolTokenTest is BaseVaultTest {
             privKey
         );
 
+        vm.expectRevert();
         poolToken.permit(usr, to, amount, deadline, v, r, s);
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function test_RevertWhen_PermitBadDeadline__Fuzz(
+    function test_RevertsWhen_PermitBadDeadline__Fuzz(
         uint248 privKey,
         address to,
         uint256 amount,
@@ -425,6 +432,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
             privKey
         );
 
+        vm.expectRevert();
         poolToken.permit(usr, to, amount, deadline + 1, v, r, s);
     }
 
@@ -450,7 +458,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
     }
 
     /// @dev Just test for general fail as it is hard to compute error arguments.
-    function test_RevertWhen_PermitReplay__Fuzz(uint248 privKey, address to, uint256 amount, uint256 deadline) public {
+    function test_RevertsWhen_PermitReplay__Fuzz(uint248 privKey, address to, uint256 amount, uint256 deadline) public {
         vm.assume(privKey != 0);
         vm.assume(to != address(0));
         deadline = bound(deadline, block.timestamp, MAX_UINT256);
@@ -468,6 +476,7 @@ contract BalancerPoolTokenTest is BaseVaultTest {
         );
 
         poolToken.permit(usr, to, amount, deadline, v, r, s);
+        vm.expectRevert();
         poolToken.permit(usr, to, amount, deadline, v, r, s);
     }
 


### PR DESCRIPTION
# Description

Foundry updated the stable version to 1.0, which is a breaking change. It caused some existing tests to break, for 2 reasons:
* Forge fails when reverts do not come from the external call, but from other contracts that were called.
* testFail* was deprecated. We should use a syntax like test_RevertsWhen_[Condition], but it does not check the revert automatically. We also need to include vm.expectRevert() in the tests. 

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [x] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge
