### PR TITLE
Change MEV Capture Hook defaults

### DIFF
--- a/pkg/pool-hooks/contracts/MevCaptureHook.sol
+++ b/pkg/pool-hooks/contracts/MevCaptureHook.sol
@@ -58,7 +58,12 @@ contract MevCaptureHook is BaseHooks, SingletonAuthentication, VaultGuard, IMevC
         _;
     }
 
-    constructor(IVault vault, IBalancerContractRegistry registry) SingletonAuthentication(vault) VaultGuard(vault) {
+    constructor(
+        IVault vault,
+        IBalancerContractRegistry registry,
+        uint256 defaultMevTaxMultiplier,
+        uint256 defaultMevTaxThreshold
+    ) SingletonAuthentication(vault) VaultGuard(vault) {
         _registry = registry;
 
         // Smoke test to ensure the given registry is a contract and isn't hard-coded to trust everything.
@@ -67,9 +72,12 @@ contract MevCaptureHook is BaseHooks, SingletonAuthentication, VaultGuard, IMevC
             revert InvalidBalancerContractRegistry();
         }
 
-        _setMevTaxEnabled(false);
-        _setDefaultMevTaxMultiplier(0);
-        _setDefaultMevTaxThreshold(0);
+        // Default to enabled and externally provided default numerical values to avoid requiring further
+        // governance actions.
+        _setMevTaxEnabled(true);
+        _setDefaultMevTaxMultiplier(defaultMevTaxMultiplier);
+        _setDefaultMevTaxThreshold(defaultMevTaxThreshold);
+
         // Default to the maximum value allowed by the Vault.
         _setMaxMevSwapFeePercentage(_MEV_MAX_FEE_PERCENTAGE);
     }

--- a/pkg/pool-hooks/contracts/MevCaptureHook.sol
+++ b/pkg/pool-hooks/contracts/MevCaptureHook.sol
@@ -72,7 +72,7 @@ contract MevCaptureHook is BaseHooks, SingletonAuthentication, VaultGuard, IMevC
             revert InvalidBalancerContractRegistry();
         }
 
-        // Default to enabled and externally provided default numerical values to avoid requiring further
+        // Default to enabled and externally-provided default numerical values to reduce the need for further
         // governance actions.
         _setMevTaxEnabled(true);
         _setDefaultMevTaxMultiplier(defaultMevTaxMultiplier);

--- a/pkg/pool-hooks/contracts/test/MevCaptureHookMock.sol
+++ b/pkg/pool-hooks/contracts/test/MevCaptureHookMock.sol
@@ -10,7 +10,7 @@ import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol"
 import { MevCaptureHook } from "../MevCaptureHook.sol";
 
 contract MevCaptureHookMock is MevCaptureHook {
-    constructor(IVault vault, IBalancerContractRegistry registry) MevCaptureHook(vault, registry) {
+    constructor(IVault vault, IBalancerContractRegistry registry) MevCaptureHook(vault, registry, 0, 0) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/pool-hooks/contracts/test/MevCaptureHookMock.sol
+++ b/pkg/pool-hooks/contracts/test/MevCaptureHookMock.sol
@@ -10,7 +10,12 @@ import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol"
 import { MevCaptureHook } from "../MevCaptureHook.sol";
 
 contract MevCaptureHookMock is MevCaptureHook {
-    constructor(IVault vault, IBalancerContractRegistry registry) MevCaptureHook(vault, registry, 0, 0) {
+    constructor(
+        IVault vault,
+        IBalancerContractRegistry registry,
+        uint256 defaultMevTaxMultiplier,
+        uint256 defaultMevTaxThreshold
+    ) MevCaptureHook(vault, registry, defaultMevTaxMultiplier, defaultMevTaxThreshold) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/pool-hooks/test/MevCaptureHook.test.ts
+++ b/pkg/pool-hooks/test/MevCaptureHook.test.ts
@@ -77,7 +77,12 @@ describe('MevCaptureHook', () => {
       args: [vaultAddress, 'Pool with MEV Hook', 'POOL-MEV'],
     });
 
-    hook = await deploy('MevCaptureHook', { args: [vaultAddress, registry] });
+    const defaultMevTaxMultiplier = 0;
+    const defaultMevTaxThreshold = 0;
+
+    hook = await deploy('MevCaptureHook', {
+      args: [vaultAddress, registry, defaultMevTaxMultiplier, defaultMevTaxThreshold],
+    });
 
     await factory.registerPoolWithHook(pool, buildTokenConfig(poolTokens), hook);
   });

--- a/pkg/pool-hooks/test/foundry/MevCaptureHook.t.sol
+++ b/pkg/pool-hooks/test/foundry/MevCaptureHook.t.sol
@@ -116,7 +116,7 @@ contract MevCaptureHookTest is BaseVaultTest {
                        isMevTaxEnabled()
     ********************************************************/
     function testIsMevTaxEnabledStartingState() public view {
-        assertFalse(_mevCaptureHook.isMevTaxEnabled(), "MEV Tax is enabled after hook creation.");
+        assertTrue(_mevCaptureHook.isMevTaxEnabled(), "MEV Tax is not enabled after hook creation.");
     }
 
     /********************************************************
@@ -128,22 +128,28 @@ contract MevCaptureHookTest is BaseVaultTest {
     }
 
     function testEnableMevTax() public {
-        assertFalse(_mevCaptureHook.isMevTaxEnabled(), "MEV Tax is enabled");
-        vm.prank(admin);
+        // Defaults to enabled initially
+        assertTrue(_mevCaptureHook.isMevTaxEnabled(), "MEV Tax is not enabled");
+        vm.startPrank(admin);
+        _mevCaptureHook.disableMevTax();
+        assertFalse(_mevCaptureHook.isMevTaxEnabled(), "MEV Tax is enabled after disabling");
+
         vm.expectEmit();
         emit IMevCaptureHook.MevTaxEnabledSet(true);
         _mevCaptureHook.enableMevTax();
+        vm.stopPrank();
+
         assertTrue(_mevCaptureHook.isMevTaxEnabled(), "MEV Tax is not enabled");
     }
 
     function testMultipleEnableMevTax() public {
-        assertFalse(_mevCaptureHook.isMevTaxEnabled(), "MEV Tax is enabled");
+        assertTrue(_mevCaptureHook.isMevTaxEnabled(), "MEV Tax is not initially enabled");
         vm.prank(admin);
         _mevCaptureHook.enableMevTax();
-        assertTrue(_mevCaptureHook.isMevTaxEnabled(), "MEV Tax is not enabled");
+        assertTrue(_mevCaptureHook.isMevTaxEnabled(), "MEV Tax is not enabled (first time set)");
         vm.prank(admin);
         _mevCaptureHook.enableMevTax();
-        assertTrue(_mevCaptureHook.isMevTaxEnabled(), "MEV Tax is not enabled");
+        assertTrue(_mevCaptureHook.isMevTaxEnabled(), "MEV Tax is not enabled (second time set)");
     }
 
     /********************************************************

--- a/pkg/pool-hooks/test/foundry/MevCaptureHook.t.sol
+++ b/pkg/pool-hooks/test/foundry/MevCaptureHook.t.sol
@@ -26,6 +26,9 @@ contract MevCaptureHookTest is BaseVaultTest {
 
     error MockRegistryRevert();
 
+    uint256 private DEFAULT_MEV_TAX_MULTIPLIER = 10e18;
+    uint256 private DEFAULT_MEV_TAX_THRESHOLD = 10e16;
+
     MevCaptureHookMock private _mevCaptureHook;
 
     BalancerContractRegistry private registry;
@@ -76,7 +79,12 @@ contract MevCaptureHookTest is BaseVaultTest {
 
     function createHook() internal override returns (address) {
         registry = new BalancerContractRegistry(vault);
-        _mevCaptureHook = new MevCaptureHookMock(IVault(address(vault)), registry);
+        _mevCaptureHook = new MevCaptureHookMock(
+            IVault(address(vault)),
+            registry,
+            DEFAULT_MEV_TAX_MULTIPLIER,
+            DEFAULT_MEV_TAX_THRESHOLD
+        );
         vm.label(address(_mevCaptureHook), "MEV Hook");
         return address(_mevCaptureHook);
     }
@@ -97,7 +105,12 @@ contract MevCaptureHookTest is BaseVaultTest {
             abi.encode(true)
         );
         vm.expectRevert(abi.encodeWithSelector(IMevCaptureHook.InvalidBalancerContractRegistry.selector));
-        new MevCaptureHookMock(IVault(address(vault)), mockRegistry);
+        new MevCaptureHookMock(
+            IVault(address(vault)),
+            mockRegistry,
+            DEFAULT_MEV_TAX_THRESHOLD,
+            DEFAULT_MEV_TAX_MULTIPLIER
+        );
     }
 
     function testRevertingRegistry() public {
@@ -109,7 +122,28 @@ contract MevCaptureHookTest is BaseVaultTest {
         );
 
         vm.expectRevert(MockRegistryRevert.selector);
-        new MevCaptureHookMock(IVault(address(vault)), mockRegistry);
+        new MevCaptureHookMock(
+            IVault(address(vault)),
+            mockRegistry,
+            DEFAULT_MEV_TAX_THRESHOLD,
+            DEFAULT_MEV_TAX_MULTIPLIER
+        );
+    }
+
+    function testDefaultMevTaxMultiplier() public view {
+        assertEq(
+            _mevCaptureHook.getDefaultMevTaxMultiplier(),
+            DEFAULT_MEV_TAX_MULTIPLIER,
+            "Wrong default MEV tax multiplier"
+        );
+    }
+
+    function testDefaultMevTaxThreshold() public view {
+        assertEq(
+            _mevCaptureHook.getDefaultMevTaxThreshold(),
+            DEFAULT_MEV_TAX_THRESHOLD,
+            "Wrong default MEV tax threshold"
+        );
     }
 
     /********************************************************
@@ -234,17 +268,6 @@ contract MevCaptureHookTest is BaseVaultTest {
     }
 
     /********************************************************
-                   getDefaultMevTaxMultiplier()
-    ********************************************************/
-    function testGetDefaultMevTaxMultiplierStartingState() public view {
-        assertEq(
-            _mevCaptureHook.getDefaultMevTaxMultiplier(),
-            0,
-            "Default MEV Tax Multiplier is not 0 after hook creation."
-        );
-    }
-
-    /********************************************************
                    setDefaultMevTaxMultiplier()
     ********************************************************/
     function testSetDefaultMevTaxMultiplierIsPermissioned() public {
@@ -285,17 +308,6 @@ contract MevCaptureHookTest is BaseVaultTest {
             _mevCaptureHook.getDefaultMevTaxMultiplier(),
             _mevCaptureHook.getPoolMevTaxMultiplier(pool),
             "setDefaultMevTaxMultiplier changed pool multiplier."
-        );
-    }
-
-    /********************************************************
-                   getDefaultMevTaxThreshold()
-    ********************************************************/
-    function testGetDefaultMevTaxThresholdStartingState() public view {
-        assertEq(
-            _mevCaptureHook.getDefaultMevTaxThreshold(),
-            0,
-            "Default MEV Tax Threshold is not 0 after hook creation."
         );
     }
 


### PR DESCRIPTION
# Description

The Maxis note that since the MEV Capture Hook defaults to "off" and 0 default values for the multiplier and threshold parameters, this requires further governance action to "active" the hook for each pool.

This might often be the case anyway (certainly per network), since the values do depend heavily on both the network (initially only Base) and pool parameters, but starting off "on" with non-zero values should reduce the work required.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #1289
