### PR TITLE
Allow swapFeeManager to also update the A factor

### DIFF
--- a/pkg/pool-stable/contracts/StablePool.sol
+++ b/pkg/pool-stable/contracts/StablePool.sol
@@ -126,7 +126,6 @@ contract StablePool is IStablePool, BalancerPoolToken, BasePoolAuthentication, P
             // Otherwise, defer to governance.
             _authenticateCaller();
         }
-
         _;
     }
 

--- a/pkg/pool-stable/contracts/StablePool.sol
+++ b/pkg/pool-stable/contracts/StablePool.sol
@@ -45,6 +45,22 @@ contract StablePool is IStablePool, BalancerPoolToken, BasePoolAuthentication, P
     using FixedPoint for uint256;
     using SafeCast for *;
 
+    /**
+     * @notice Parameters used to deploy a new Stable Pool.
+     * @param name ERC20 token name
+     * @param symbol ERC20 token symbol
+     * @param amplificationParameter Controls the "flatness" of the invariant curve. higher values = lower slippage,
+     * and assumes prices are near parity. lower values = closer to the constant product curve (e.g., more like a
+     * weighted pool). This has higher slippage, and accommodates greater price volatility
+     * @param version The stable pool version
+     */
+    struct NewPoolParams {
+        string name;
+        string symbol;
+        uint256 amplificationParameter;
+        string version;
+    }
+
     // This contract uses timestamps to slowly update its Amplification parameter over time. These changes must occur
     // over a minimum time period much larger than the block time, making timestamp manipulation a non-issue.
     // solhint-disable not-rely-on-time
@@ -101,19 +117,17 @@ contract StablePool is IStablePool, BalancerPoolToken, BasePoolAuthentication, P
     error AmpUpdateNotStarted();
 
     /**
-     * @notice Parameters used to deploy a new Stable Pool.
-     * @param name ERC20 token name
-     * @param symbol ERC20 token symbol
-     * @param amplificationParameter Controls the "flatness" of the invariant curve. higher values = lower slippage,
-     * and assumes prices are near parity. lower values = closer to the constant product curve (e.g., more like a
-     * weighted pool). This has higher slippage, and accommodates greater price volatility
-     * @param version The stable pool version
+     * @notice Allow the swap manager to change the amplification parameter.
+     * @dev Unlike the swap fee percentage setting permission, this is non-exclusive.
      */
-    struct NewPoolParams {
-        string name;
-        string symbol;
-        uint256 amplificationParameter;
-        string version;
+    modifier authenticateByRole() {
+        // Allow if this is the swapFeeManager.
+        if (msg.sender != _vault.getPoolRoleAccounts(address(this)).swapFeeManager) {
+            // Otherwise, defer to governance.
+            _authenticateCaller();
+        }
+
+        _;
     }
 
     constructor(
@@ -196,7 +210,7 @@ contract StablePool is IStablePool, BalancerPoolToken, BasePoolAuthentication, P
     }
 
     /// @inheritdoc IStablePool
-    function startAmplificationParameterUpdate(uint256 rawEndValue, uint256 endTime) external authenticate {
+    function startAmplificationParameterUpdate(uint256 rawEndValue, uint256 endTime) external authenticateByRole {
         if (rawEndValue < StableMath.MIN_AMP) {
             revert AmplificationFactorTooLow();
         }
@@ -246,7 +260,7 @@ contract StablePool is IStablePool, BalancerPoolToken, BasePoolAuthentication, P
     }
 
     /// @inheritdoc IStablePool
-    function stopAmplificationParameterUpdate() external authenticate {
+    function stopAmplificationParameterUpdate() external authenticateByRole {
         (uint256 currentValue, bool isUpdating) = _getAmplificationParameter();
 
         if (isUpdating == false) {

--- a/pkg/pool-stable/test/foundry/StablePool.t.sol
+++ b/pkg/pool-stable/test/foundry/StablePool.t.sol
@@ -158,6 +158,18 @@ contract StablePoolTest is BasePoolTest, StablePoolContractsDeployer {
 
         (, isUpdating, ) = IStablePool(pool).getAmplificationParameter();
         assertFalse(isUpdating, "Amplification update not stopped");
+
+        // Grant to Bob via governance.
+        authorizer.grantRole(
+            IAuthentication(pool).getActionId(StablePool.startAmplificationParameterUpdate.selector),
+            bob
+        );
+
+        vm.startPrank(bob);
+        IStablePool(pool).startAmplificationParameterUpdate(newAmplificationParameter, endTime);
+
+        (, isUpdating, ) = IStablePool(pool).getAmplificationParameter();
+        assertTrue(isUpdating, "Amplification update by Bob not started");
     }
 
     function testGetAmplificationState() public {

--- a/pkg/pool-stable/test/foundry/StablePool.t.sol
+++ b/pkg/pool-stable/test/foundry/StablePool.t.sol
@@ -34,11 +34,8 @@ contract StablePoolTest is BasePoolTest, StablePoolContractsDeployer {
     uint256 constant DEFAULT_AMP_FACTOR = 200;
     uint256 constant TOKEN_AMOUNT = 1e3 * 1e18;
 
-    address swapFeeManager;
-
     function setUp() public virtual override {
         expectedAddLiquidityBptAmountOut = TOKEN_AMOUNT * 2;
-        (swapFeeManager, ) = createUser("swapFeeManager");
 
         BasePoolTest.setUp();
 
@@ -66,7 +63,7 @@ contract StablePoolTest is BasePoolTest, StablePoolContractsDeployer {
         }
 
         PoolRoleAccounts memory roleAccounts;
-        roleAccounts.swapFeeManager = swapFeeManager;
+        roleAccounts.swapFeeManager = alice;
 
         // Allow pools created by `factory` to use poolHooksMock hooks
         PoolHooksMock(poolHooksContract).allowFactory(poolFactory);
@@ -125,20 +122,20 @@ contract StablePoolTest is BasePoolTest, StablePoolContractsDeployer {
 
     function testAmplificationUpdateByRole() public {
         // Ensure the swap manager was set for the pool.
-        assertEq(vault.getPoolRoleAccounts(pool).swapFeeManager, swapFeeManager, "Wrong swap fee manager");
+        assertEq(vault.getPoolRoleAccounts(pool).swapFeeManager, alice, "Wrong swap fee manager");
 
         // Ensure the swap manager doesn't have permission through governance.
         assertFalse(
             authorizer.hasRole(
                 IAuthentication(pool).getActionId(StablePool.startAmplificationParameterUpdate.selector),
-                swapFeeManager
+                alice
             ),
             "Has governance-granted start permission"
         );
         assertFalse(
             authorizer.hasRole(
                 IAuthentication(pool).getActionId(StablePool.stopAmplificationParameterUpdate.selector),
-                swapFeeManager
+                alice
             ),
             "Has governance-granted stop permission"
         );
@@ -150,7 +147,7 @@ contract StablePoolTest is BasePoolTest, StablePoolContractsDeployer {
         uint256 endTime = currentTime + updateInterval;
         uint256 newAmplificationParameter = DEFAULT_AMP_FACTOR * 2;
 
-        vm.startPrank(swapFeeManager);
+        vm.startPrank(alice);
         IStablePool(pool).startAmplificationParameterUpdate(newAmplificationParameter, endTime);
 
         (, bool isUpdating, ) = IStablePool(pool).getAmplificationParameter();


### PR DESCRIPTION
# Description

It is a common pattern for the swap fee manager to also need to adjust the amplification parameter. This PR grants this permission non-exclusively (i.e., governance can still do it).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Resolves #1288.
