### PR TITLE
Create lib to handle Weth in routers

### DIFF
--- a/pkg/vault/contracts/Router.sol
+++ b/pkg/vault/contracts/Router.sol
@@ -13,6 +13,7 @@ import { IRouter } from "@balancer-labs/v3-interfaces/contracts/vault/IRouter.so
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
+import { RouterWethLib } from "./lib/RouterWethLib.sol";
 import { RouterCommon } from "./RouterCommon.sol";
 
 /**
@@ -22,6 +23,7 @@ import { RouterCommon } from "./RouterCommon.sol";
  */
 contract Router is IRouter, RouterCommon {
     using Address for address payable;
+    using RouterWethLib for IWETH;
     using SafeCast for *;
 
     constructor(
@@ -94,14 +96,7 @@ contract Router is IRouter, RouterCommon {
 
             // There can be only one WETH token in the pool.
             if (params.wethIsEth && address(token) == address(_weth)) {
-                if (address(this).balance < amountIn) {
-                    revert InsufficientEth();
-                }
-
-                _weth.deposit{ value: amountIn }();
-                // Transfer WETH from the Router to the Vault.
-                _weth.transfer(address(_vault), amountIn);
-                _vault.settle(_weth, amountIn);
+                _weth.wrapEthAndSettle(_vault, amountIn);
             } else {
                 // Transfer tokens from the user to the Vault.
                 // Any value over MAX_UINT128 would revert above in `initialize`, so this SafeCast shouldn't be
@@ -305,13 +300,7 @@ contract Router is IRouter, RouterCommon {
 
             // There can be only one WETH token in the pool.
             if (params.wethIsEth && address(token) == address(_weth)) {
-                if (address(this).balance < amountIn) {
-                    revert InsufficientEth();
-                }
-
-                _weth.deposit{ value: amountIn }();
-                _weth.transfer(address(_vault), amountIn);
-                _vault.settle(_weth, amountIn);
+                _weth.wrapEthAndSettle(_vault, amountIn);
             } else {
                 // Any value over MAX_UINT128 would revert above in `addLiquidity`, so this SafeCast shouldn't be
                 // necessary. Done out of an abundance of caution.
@@ -510,11 +499,7 @@ contract Router is IRouter, RouterCommon {
 
             // There can be only one WETH token in the pool.
             if (params.wethIsEth && address(token) == address(_weth)) {
-                // Send WETH here and unwrap to native ETH.
-                _vault.sendTo(_weth, address(this), amountOut);
-                _weth.withdraw(amountOut);
-                // Send ETH to sender.
-                payable(params.sender).sendValue(amountOut);
+                _weth.unwrapWethAndTransferToSender(_vault, params.sender, amountOut);
             } else {
                 // Transfer the token to the sender (amountOut).
                 _vault.sendTo(token, params.sender, amountOut);

--- a/pkg/vault/contracts/lib/RouterWethLib.sol
+++ b/pkg/vault/contracts/lib/RouterWethLib.sol
@@ -22,25 +22,6 @@ library RouterWethLib {
     /// @notice The amount of ETH paid is insufficient to complete this operation.
     error InsufficientEth();
 
-    /**
-     * @dev Returns excess ETH back to the contract caller. Checks for sufficient ETH balance are made right before
-     * each deposit, ensuring it will revert with a friendly custom error. If there is any balance remaining when
-     * `_returnEth` is called, return it to the sender.
-     *
-     * Because the caller might not know exactly how much ETH a Vault action will require, they may send extra.
-     * Note that this excess value is returned *to the contract caller* (msg.sender). If caller and e.g. swap sender
-     * are not the same (because the caller is a relayer for the sender), then it is up to the caller to manage this
-     * returned ETH.
-     */
-    function returnEth(IWETH, address sender) internal {
-        uint256 excess = address(this).balance;
-        if (excess == 0) {
-            return;
-        }
-
-        payable(sender).sendValue(excess);
-    }
-
     function wrapEthAndSettle(IWETH weth, IVault vault, uint256 amountToSettle) internal {
         if (address(this).balance < amountToSettle) {
             revert InsufficientEth();

--- a/pkg/vault/contracts/lib/RouterWethLib.sol
+++ b/pkg/vault/contracts/lib/RouterWethLib.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+
+import { IWETH } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/misc/IWETH.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+
+import { StorageSlotExtension } from "@balancer-labs/v3-solidity-utils/contracts/openzeppelin/StorageSlotExtension.sol";
+import {
+    TransientStorageHelpers
+} from "@balancer-labs/v3-solidity-utils/contracts/helpers/TransientStorageHelpers.sol";
+
+library RouterWethLib {
+    using Address for address payable;
+    using StorageSlotExtension for *;
+    using SafeERC20 for IWETH;
+
+    /// @notice The amount of ETH paid is insufficient to complete this operation.
+    error InsufficientEth();
+
+    /**
+     * @dev Returns excess ETH back to the contract caller. Checks for sufficient ETH balance are made right before
+     * each deposit, ensuring it will revert with a friendly custom error. If there is any balance remaining when
+     * `_returnEth` is called, return it to the sender.
+     *
+     * Because the caller might not know exactly how much ETH a Vault action will require, they may send extra.
+     * Note that this excess value is returned *to the contract caller* (msg.sender). If caller and e.g. swap sender
+     * are not the same (because the caller is a relayer for the sender), then it is up to the caller to manage this
+     * returned ETH.
+     */
+    function returnEth(IWETH, address sender) internal {
+        uint256 excess = address(this).balance;
+        if (excess == 0) {
+            return;
+        }
+
+        payable(sender).sendValue(excess);
+    }
+
+    function wrapEthAndSettle(IWETH weth, IVault vault, uint256 amountToSettle) internal {
+        if (address(this).balance < amountToSettle) {
+            revert InsufficientEth();
+        }
+
+        // wrap amountIn to WETH.
+        weth.deposit{ value: amountToSettle }();
+        // send WETH to Vault.
+        weth.safeTransfer(address(vault), amountToSettle);
+        // update Vault accounting.
+        vault.settle(weth, amountToSettle);
+    }
+
+    function unwrapWethAndTransferToSender(IWETH weth, IVault vault, address sender, uint256 amountToSend) internal {
+        // Receive the WETH amountOut.
+        vault.sendTo(weth, address(this), amountToSend);
+        // Withdraw WETH to ETH.
+        weth.withdraw(amountToSend);
+        // Send ETH to sender.
+        payable(sender).sendValue(amountToSend);
+    }
+}

--- a/pkg/vault/test/foundry/Router.t.sol
+++ b/pkg/vault/test/foundry/Router.t.sol
@@ -24,10 +24,10 @@ import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/Fixe
 
 import { RateProviderMock } from "../../contracts/test/RateProviderMock.sol";
 import { MOCK_ROUTER_VERSION } from "../../contracts/test/RouterMock.sol";
+import { RouterWethLib } from "../../contracts/lib/RouterWethLib.sol";
 import { RouterCommon } from "../../contracts/RouterCommon.sol";
 import { BasePoolMath } from "../../contracts/BasePoolMath.sol";
 import { PoolMock } from "../../contracts/test/PoolMock.sol";
-
 import { PoolFactoryMock, BaseVaultTest } from "./utils/BaseVaultTest.sol";
 
 contract RouterTest is BaseVaultTest {
@@ -233,7 +233,7 @@ contract RouterTest is BaseVaultTest {
         checkAddLiquidityPreConditions();
 
         // Caller does not have enough ETH, even if they hold weth.
-        vm.expectRevert(RouterCommon.InsufficientEth.selector);
+        vm.expectRevert(RouterWethLib.InsufficientEth.selector);
         vm.prank(alice);
         router.initialize(address(wethPoolNoInit), wethDaiTokens, wethDaiAmountsIn, initBpt, true, bytes(""));
     }
@@ -302,7 +302,7 @@ contract RouterTest is BaseVaultTest {
         checkAddLiquidityPreConditions();
 
         // Caller does not have enough ETH, even if they hold weth.
-        vm.expectRevert(RouterCommon.InsufficientEth.selector);
+        vm.expectRevert(RouterWethLib.InsufficientEth.selector);
         vm.prank(alice);
         router.addLiquidityCustom(address(wethPool), wethDaiAmountsIn, bptAmountOut, true, bytes(""));
     }

--- a/pkg/vault/test/foundry/RouterCommon.t.sol
+++ b/pkg/vault/test/foundry/RouterCommon.t.sol
@@ -4,22 +4,23 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 
+import { IAllowanceTransfer } from "permit2/src/interfaces/IAllowanceTransfer.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { IAllowanceTransfer } from "permit2/src/interfaces/IAllowanceTransfer.sol";
 
 import { IRouterCommon } from "@balancer-labs/v3-interfaces/contracts/vault/IRouterCommon.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 
+import { StorageSlotExtension } from "@balancer-labs/v3-solidity-utils/contracts/openzeppelin/StorageSlotExtension.sol";
 import { ReentrancyAttack } from "@balancer-labs/v3-solidity-utils/contracts/test/ReentrancyAttack.sol";
 import {
     ReentrancyGuardTransient
 } from "@balancer-labs/v3-solidity-utils/contracts/openzeppelin/ReentrancyGuardTransient.sol";
-import { StorageSlotExtension } from "@balancer-labs/v3-solidity-utils/contracts/openzeppelin/StorageSlotExtension.sol";
 
-import { BaseVaultTest } from "./utils/BaseVaultTest.sol";
-import { RouterCommon } from "../../contracts/RouterCommon.sol";
 import { RouterCommonMock } from "../../contracts/test/RouterCommonMock.sol";
+import { RouterWethLib } from "../../contracts/lib/RouterWethLib.sol";
+import { RouterCommon } from "../../contracts/RouterCommon.sol";
+import { BaseVaultTest } from "./utils/BaseVaultTest.sol";
 
 contract RouterCommonTest is BaseVaultTest {
     ReentrancyAttack internal reentrancyAttack;
@@ -74,7 +75,7 @@ contract RouterCommonTest is BaseVaultTest {
     function testTakeTokenInWethIsEth() public {
         uint256 routerEthBalance = address(routerMock).balance;
 
-        vm.expectRevert(RouterCommon.InsufficientEth.selector);
+        vm.expectRevert(RouterWethLib.InsufficientEth.selector);
         routerMock.mockTakeTokenIn(bob, IERC20(weth), routerEthBalance + 1, true);
     }
 

--- a/pkg/vault/test/foundry/RouterWethLib.t.sol
+++ b/pkg/vault/test/foundry/RouterWethLib.t.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IWETH } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/misc/IWETH.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+
+import { BaseVaultTest } from "./utils/BaseVaultTest.sol";
+import { RouterWethLib } from "../../contracts/lib/RouterWethLib.sol";
+
+// @dev The test contract will act as the router.
+contract RouterWethLibTest is BaseVaultTest {
+    uint256 internal constant TRANSFER_AMOUNT = 1e18;
+
+    function setUp() public override {
+        BaseVaultTest.setUp();
+
+        // Ensure the contract has no ETH balance.
+        payable(0).call{ value: address(this).balance }("");
+    }
+
+    function testWrapEthAndSettleInsufficientBalance() public {
+        // Ensure contract has no ETH balance
+        require(address(this).balance < TRANSFER_AMOUNT, "Contract has ETH");
+
+        vm.expectRevert(RouterWethLib.InsufficientEth.selector);
+        RouterWethLib.wrapEthAndSettle(weth, vault, TRANSFER_AMOUNT);
+    }
+
+    function testWrapEthAndSettleSuccess() public {
+        // Send ETH to contract
+        vm.deal(address(this), TRANSFER_AMOUNT);
+        require(address(this).balance >= TRANSFER_AMOUNT, "Contract does not have ETH");
+
+        uint256 vaultWethBalanceBefore = weth.balanceOf(address(vault));
+        uint256 vaultWethReserveBefore = vault.getReservesOf(weth);
+        uint256 routerWethBalanceBefore = weth.balanceOf(address(this));
+        uint256 routerEthBalanceBefore = address(this).balance;
+
+        vault.forceUnlock();
+        RouterWethLib.wrapEthAndSettle(weth, vault, TRANSFER_AMOUNT);
+
+        // Vault balances and reserves.
+        assertEq(
+            weth.balanceOf(address(vault)),
+            vaultWethBalanceBefore + TRANSFER_AMOUNT,
+            "Vault WETH balance should increase"
+        );
+        assertEq(
+            vault.getReservesOf(weth),
+            vaultWethReserveBefore + TRANSFER_AMOUNT,
+            "Vault WETH reserve should increase"
+        );
+
+        // Router balances.
+        assertEq(address(this).balance, routerEthBalanceBefore - TRANSFER_AMOUNT, "Router ETH balance should decrease");
+        assertEq(weth.balanceOf(address(this)), routerWethBalanceBefore, "Router WETH balance should not change");
+    }
+
+    function testUnwrapWethAndTransferToSenderInsufficientBalance() public {
+        // Ensure Vault has no WETH balance.
+        vm.startPrank(address(vault));
+        weth.transfer(address(1), weth.balanceOf(address(vault)));
+        vm.stopPrank();
+
+        vault.forceUnlock();
+        vm.expectRevert(); // Expect math underflow due to insufficient WETH balance
+        RouterWethLibTest(payable(this)).externalUnwrapWethAndTransferToSender(
+            weth,
+            vault,
+            address(this),
+            TRANSFER_AMOUNT
+        );
+    }
+
+    function testUnwrapWethAndTransferToSenderSuccess() public {
+        // Send WETH to Vault.
+        vm.deal(address(this), TRANSFER_AMOUNT);
+
+        vault.forceUnlock();
+        RouterWethLib.wrapEthAndSettle(weth, vault, TRANSFER_AMOUNT);
+
+        require(weth.balanceOf(address(vault)) >= TRANSFER_AMOUNT, "Vault has insufficient WETH");
+
+        uint256 vaultWethBalanceBefore = weth.balanceOf(address(vault));
+        uint256 vaultWethReserveBefore = vault.getReservesOf(weth);
+        uint256 routerWethBalanceBefore = weth.balanceOf(address(this));
+        uint256 routerEthBalanceBefore = address(this).balance;
+
+        RouterWethLib.unwrapWethAndTransferToSender(weth, vault, address(this), TRANSFER_AMOUNT);
+
+        // Vault balances and reserves.
+        assertEq(
+            weth.balanceOf(address(vault)),
+            vaultWethBalanceBefore - TRANSFER_AMOUNT,
+            "Vault WETH balance should decrease"
+        );
+        assertEq(
+            vault.getReservesOf(weth),
+            vaultWethReserveBefore - TRANSFER_AMOUNT,
+            "Vault WETH reserve should decrease"
+        );
+
+        // Router balances.
+        assertEq(address(this).balance, routerEthBalanceBefore + TRANSFER_AMOUNT, "Router ETH balance should increase");
+        assertEq(weth.balanceOf(address(this)), routerWethBalanceBefore, "Router WETH balance should not change");
+    }
+
+    // Required to receive ETH
+    receive() external payable {}
+
+    function externalUnwrapWethAndTransferToSender(IWETH weth, IVault vault, address sender, uint256 amount) external {
+        RouterWethLib.unwrapWethAndTransferToSender(weth, vault, sender, amount);
+    }
+}


### PR DESCRIPTION
# Description

Some routers (like CowRouter) will need to handle Native ETH, but don't need extra features from RouterCommon (like Permit2 or some transient states).

This PR decouples the logic to handle Weth from RouterCommon, so it can be reused by other routers.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge
