### PR TITLE
Remove deprecated library

### DIFF
--- a/pkg/solidity-utils/test/foundry/utils/BaseTest.sol
+++ b/pkg/solidity-utils/test/foundry/utils/BaseTest.sol
@@ -4,8 +4,6 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 
-import { GasSnapshot } from "forge-gas-snapshot/GasSnapshot.sol";
-
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 
@@ -16,7 +14,7 @@ import { ERC4626TestToken } from "../../../contracts/test/ERC4626TestToken.sol";
 import { ERC20TestToken } from "../../../contracts/test/ERC20TestToken.sol";
 import { WETHTestToken } from "../../../contracts/test/WETHTestToken.sol";
 
-abstract contract BaseTest is Test, GasSnapshot {
+abstract contract BaseTest is Test {
     using CastingHelpers for *;
 
     uint256 internal constant DEFAULT_BALANCE = 1e9 * 1e18;

--- a/pvt/solidity-toolbox/package.json
+++ b/pvt/solidity-toolbox/package.json
@@ -26,7 +26,6 @@
     "dotenv": "^16.4.7",
     "ds-test": "https://github.com/dapphub/ds-test#e282159d5170298eb2455a6c05280ab5a73a4ef0",
     "ethers": "^6.13.5",
-    "forge-gas-snapshot": "https://github.com/ylv-io/forge-gas-snapshot",
     "forge-std": "https://github.com/foundry-rs/forge-std.git#v1.8.1",
     "hardhat-contract-sizer": "^2.10.0",
     "hardhat-gas-reporter": "^1.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,7 +80,6 @@ __metadata:
     dotenv: "npm:^16.4.7"
     ds-test: "https://github.com/dapphub/ds-test#e282159d5170298eb2455a6c05280ab5a73a4ef0"
     ethers: "npm:^6.13.5"
-    forge-gas-snapshot: "https://github.com/ylv-io/forge-gas-snapshot"
     forge-std: "https://github.com/foundry-rs/forge-std.git#v1.8.1"
     hardhat-contract-sizer: "npm:^2.10.0"
     hardhat-gas-reporter: "npm:^1.0.9"
@@ -3900,13 +3899,6 @@ __metadata:
   version: 0.6.1
   resolution: "forever-agent@npm:0.6.1"
   checksum: b426cf45f0bdea79970a4320cb550b84d0bcd0530d544e0424456f44272a19641a000ea921f8e58dba5511b71f94d95c80692e3d13ce5f0b766f18426430efd5
-  languageName: node
-  linkType: hard
-
-"forge-gas-snapshot@https://github.com/ylv-io/forge-gas-snapshot":
-  version: 0.1.4
-  resolution: "forge-gas-snapshot@https://github.com/ylv-io/forge-gas-snapshot.git#commit=ee8e1f02009785ab81a5058a18c75d5d3b7a894d"
-  checksum: b36a2ab3e20c1f8a7bcaa65e4e7b1c95f6965c425ecca0422dd51afbc9c82a753c2dd7822c6a17b2b2271a3bca65e3d0f2606f85d36f6afbf2a76fb734e09ea5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

`forge-gas-snapshot` has been added to the newer version of Forge, and the standalone library has been deprecated. Moreover, we do not need the changes implemented by Igor, the tests are working without it.

The dependency of `forge-gas-snapshot` makes the creation of a Custom Pool repository harder, because test files do not compile if the developer does not clone the custom repo.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge
