### PR TITLE
Use swapFeeManager as owner in mev hook

### DIFF
--- a/pkg/pool-hooks/contracts/MevCaptureHook.sol
+++ b/pkg/pool-hooks/contracts/MevCaptureHook.sol
@@ -244,7 +244,7 @@ contract MevCaptureHook is BaseHooks, SingletonAuthentication, VaultGuard, IMevC
     function setPoolMevTaxMultiplier(
         address pool,
         uint256 newPoolMevTaxMultiplier
-    ) external withMevTaxEnabledPool(pool) onlySwapFeeManagerOrAuthentication(pool) {
+    ) external withMevTaxEnabledPool(pool) onlySwapFeeManagerOrGovernance(pool) {
         _setPoolMevTaxMultiplier(pool, newPoolMevTaxMultiplier);
     }
 
@@ -279,7 +279,7 @@ contract MevCaptureHook is BaseHooks, SingletonAuthentication, VaultGuard, IMevC
     function setPoolMevTaxThreshold(
         address pool,
         uint256 newPoolMevTaxThreshold
-    ) external withMevTaxEnabledPool(pool) onlySwapFeeManagerOrAuthentication(pool) {
+    ) external withMevTaxEnabledPool(pool) onlySwapFeeManagerOrGovernance(pool) {
         _setPoolMevTaxThreshold(pool, newPoolMevTaxThreshold);
     }
 

--- a/pkg/pool-hooks/contracts/MevCaptureHook.sol
+++ b/pkg/pool-hooks/contracts/MevCaptureHook.sol
@@ -244,7 +244,7 @@ contract MevCaptureHook is BaseHooks, SingletonAuthentication, VaultGuard, IMevC
     function setPoolMevTaxMultiplier(
         address pool,
         uint256 newPoolMevTaxMultiplier
-    ) external withMevTaxEnabledPool(pool) authenticate {
+    ) external withMevTaxEnabledPool(pool) onlySwapFeeManagerOrAuthentication(pool) {
         _setPoolMevTaxMultiplier(pool, newPoolMevTaxMultiplier);
     }
 
@@ -279,7 +279,7 @@ contract MevCaptureHook is BaseHooks, SingletonAuthentication, VaultGuard, IMevC
     function setPoolMevTaxThreshold(
         address pool,
         uint256 newPoolMevTaxThreshold
-    ) external withMevTaxEnabledPool(pool) authenticate {
+    ) external withMevTaxEnabledPool(pool) onlySwapFeeManagerOrAuthentication(pool) {
         _setPoolMevTaxThreshold(pool, newPoolMevTaxThreshold);
     }
 

--- a/pkg/pool-hooks/contracts/StableSurgeHook.sol
+++ b/pkg/pool-hooks/contracts/StableSurgeHook.sol
@@ -280,7 +280,7 @@ contract StableSurgeHook is BaseHooks, VaultGuard, SingletonAuthentication {
     function setMaxSurgeFeePercentage(
         address pool,
         uint256 newMaxSurgeSurgeFeePercentage
-    ) external withValidPercentage(newMaxSurgeSurgeFeePercentage) onlySwapFeeManagerOrAuthentication(pool) {
+    ) external withValidPercentage(newMaxSurgeSurgeFeePercentage) onlySwapFeeManagerOrGovernance(pool) {
         _setMaxSurgeFeePercentage(pool, newMaxSurgeSurgeFeePercentage);
     }
 
@@ -292,7 +292,7 @@ contract StableSurgeHook is BaseHooks, VaultGuard, SingletonAuthentication {
     function setSurgeThresholdPercentage(
         address pool,
         uint256 newSurgeThresholdPercentage
-    ) external withValidPercentage(newSurgeThresholdPercentage) onlySwapFeeManagerOrAuthentication(pool) {
+    ) external withValidPercentage(newSurgeThresholdPercentage) onlySwapFeeManagerOrGovernance(pool) {
         _setSurgeThresholdPercentage(pool, newSurgeThresholdPercentage);
     }
 

--- a/pkg/pool-hooks/test/foundry/MevCaptureHook.t.sol
+++ b/pkg/pool-hooks/test/foundry/MevCaptureHook.t.sol
@@ -5,7 +5,12 @@ pragma solidity ^0.8.24;
 import "forge-std/Test.sol";
 
 import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
-import { PoolSwapParams, MAX_FEE_PERCENTAGE } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+import {
+    PoolSwapParams,
+    MAX_FEE_PERCENTAGE,
+    PoolRoleAccounts
+} from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+import { IVaultExplorer } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultExplorer.sol";
 import { IMevCaptureHook } from "@balancer-labs/v3-interfaces/contracts/pool-hooks/IMevCaptureHook.sol";
 import { IHooks } from "@balancer-labs/v3-interfaces/contracts/vault/IHooks.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
@@ -417,6 +422,19 @@ contract MevCaptureHookTest is BaseVaultTest {
         );
     }
 
+    function testSetPoolMevTaxMultiplierRevertIfSenderIsNotFeeManager() public {
+        _mockPoolRoleAccounts(address(0x01));
+
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        _mevCaptureHook.setPoolMevTaxMultiplier(pool, 5e18);
+    }
+
+    function testSetPoolMevTaxMultiplierWithSwapFeeManager() public {
+        _mockPoolRoleAccounts(address(this));
+
+        _mevCaptureHook.setPoolMevTaxMultiplier(pool, 5e18);
+    }
+
     /********************************************************
                    getPoolMevTaxThreshold()
     ********************************************************/
@@ -447,6 +465,19 @@ contract MevCaptureHookTest is BaseVaultTest {
 
     function testSetPoolMevTaxThresholdIsPermissioned() public {
         vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        _mevCaptureHook.setPoolMevTaxThreshold(pool, 5e18);
+    }
+
+    function testSetPoolMevTaxThresholdRevertIfSenderIsNotFeeManager() public {
+        _mockPoolRoleAccounts(address(0x01));
+
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        _mevCaptureHook.setPoolMevTaxThreshold(pool, 5e18);
+    }
+
+    function testSetPoolMevTaxThresholdWithSwapFeeManager() public {
+        _mockPoolRoleAccounts(address(this));
+
         _mevCaptureHook.setPoolMevTaxThreshold(pool, 5e18);
     }
 
@@ -730,5 +761,21 @@ contract MevCaptureHookTest is BaseVaultTest {
         assertTrue(_mevCaptureHook.isMevTaxExemptSender(lp), "LP is not exempt");
         assertFalse(_mevCaptureHook.isMevTaxExemptSender(bob), "Bob is exempt");
         assertTrue(_mevCaptureHook.isMevTaxExemptSender(alice), "Alice is not exempt");
+    }
+
+    /********************************************************
+                            Other
+    ********************************************************/
+    function _mockPoolRoleAccounts(address swapFeeManager) private {
+        PoolRoleAccounts memory poolRoleAccounts = PoolRoleAccounts({
+            pauseManager: address(0x01),
+            swapFeeManager: swapFeeManager,
+            poolCreator: address(0x01)
+        });
+        vm.mockCall(
+            address(vault),
+            abi.encodeWithSelector(IVaultExplorer.getPoolRoleAccounts.selector, pool),
+            abi.encode(poolRoleAccounts)
+        );
     }
 }

--- a/pkg/pool-hooks/test/foundry/MevCaptureHook.t.sol
+++ b/pkg/pool-hooks/test/foundry/MevCaptureHook.t.sol
@@ -10,7 +10,7 @@ import {
     MAX_FEE_PERCENTAGE,
     PoolRoleAccounts
 } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
-import { IVaultExplorer } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultExplorer.sol";
+import { IVaultExtension } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultExtension.sol";
 import { IMevCaptureHook } from "@balancer-labs/v3-interfaces/contracts/pool-hooks/IMevCaptureHook.sol";
 import { IHooks } from "@balancer-labs/v3-interfaces/contracts/vault/IHooks.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
@@ -774,7 +774,7 @@ contract MevCaptureHookTest is BaseVaultTest {
         });
         vm.mockCall(
             address(vault),
-            abi.encodeWithSelector(IVaultExplorer.getPoolRoleAccounts.selector, pool),
+            abi.encodeWithSelector(IVaultExtension.getPoolRoleAccounts.selector, pool),
             abi.encode(poolRoleAccounts)
         );
     }


### PR DESCRIPTION
# Description

This PR changes the authorization logic for mev hook: if swapFeeManager is set, use it as owner instead of governance.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #1300 

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
