### PR TITLE
LBP fixes according to Certora's report

### DIFF
--- a/pkg/pool-weighted/contracts/lbp/LBPool.sol
+++ b/pkg/pool-weighted/contracts/lbp/LBPool.sol
@@ -152,7 +152,7 @@ contract LBPool is ILBPool, WeightedPool, Ownable2Step, BaseHooks {
             lbpParams.reserveTokenEndWeight
         );
 
-        emit GradualWeightUpdateScheduled(lbpParams.startTime, lbpParams.endTime, startWeights, endWeights);
+        emit GradualWeightUpdateScheduled(_startTime, _endTime, startWeights, endWeights);
     }
 
     /**

--- a/pkg/pool-weighted/contracts/lib/GradualValueChange.sol
+++ b/pkg/pool-weighted/contracts/lib/GradualValueChange.sol
@@ -30,7 +30,7 @@ library GradualValueChange {
         // only 10% of the period in the future, the value would immediately jump 90%
         resolvedStartTime = Math.max(block.timestamp, startTime);
 
-        if (resolvedStartTime > endTime) {
+        if (resolvedStartTime >= endTime) {
             revert GradualUpdateTimeTravel(resolvedStartTime, endTime);
         }
     }

--- a/pkg/pool-weighted/test/LBPool.test.ts
+++ b/pkg/pool-weighted/test/LBPool.test.ts
@@ -227,7 +227,7 @@ describe('LBPool', function () {
 
     describe('Owner operations and events', () => {
       it('should emit GradualWeightUpdateScheduled event on deployment', async () => {
-        const startTime = await currentTimestamp();
+        const startTime = (await currentTimestamp()) + 100n;
         const endTime = startTime + bn(bn(MONTH));
         const endWeights = [fp(0.7), fp(0.3)];
 
@@ -237,11 +237,9 @@ describe('LBPool', function () {
 
         const pool = (await deployedAt('LBPool', event.args.pool)) as unknown as LBPool;
 
-        const actualStartTime = await currentTimestamp();
-
         await expect(tx)
           .to.emit(pool, 'GradualWeightUpdateScheduled')
-          .withArgs(actualStartTime - 1n, endTime, WEIGHTS, endWeights);
+          .withArgs(startTime, endTime, WEIGHTS, endWeights);
       });
 
       it('should only allow owner to be the LP', async () => {

--- a/pkg/pool-weighted/test/foundry/LBPool.t.sol
+++ b/pkg/pool-weighted/test/foundry/LBPool.t.sol
@@ -145,6 +145,24 @@ contract LBPoolTest is BaseLBPTest {
         );
     }
 
+    function testCreatePoolTimeTravelSameTime() public {
+        uint32 startTime = uint32(block.timestamp + 200);
+        uint32 endTime = uint32(block.timestamp + 200);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(GradualValueChange.GradualUpdateTimeTravel.selector, startTime, endTime)
+        );
+        _createLBPoolWithCustomWeights(
+            startWeights[projectIdx],
+            startWeights[reserveIdx],
+            endWeights[projectIdx],
+            endWeights[reserveIdx],
+            startTime,
+            endTime, // EndTime = StartTime, it should revert.
+            DEFAULT_PROJECT_TOKENS_SWAP_IN
+        );
+    }
+
     function testCreatePoolStartTimeInPast() public {
         // Set startTime in the past
         uint32 pastStartTime = uint32(block.timestamp - 100);
@@ -154,7 +172,7 @@ contract LBPoolTest is BaseLBPTest {
         // The event should be emitted with block.timestamp as startTime, not the past time
         emit LBPool.GradualWeightUpdateScheduled(block.timestamp, endTime, startWeights, endWeights);
 
-        (address newPool, ) = _createLBPoolWithCustomWeights(
+        _createLBPoolWithCustomWeights(
             startWeights[projectIdx],
             startWeights[reserveIdx],
             endWeights[projectIdx],

--- a/pkg/pool-weighted/test/foundry/LBPool.t.sol
+++ b/pkg/pool-weighted/test/foundry/LBPool.t.sol
@@ -145,6 +145,26 @@ contract LBPoolTest is BaseLBPTest {
         );
     }
 
+    function testCreatePoolStartTimeInPast() public {
+        // Set startTime in the past
+        uint32 pastStartTime = uint32(block.timestamp - 100);
+        uint32 endTime = uint32(block.timestamp + DEFAULT_END_OFFSET);
+
+        vm.expectEmit();
+        // The event should be emitted with block.timestamp as startTime, not the past time
+        emit LBPool.GradualWeightUpdateScheduled(block.timestamp, endTime, startWeights, endWeights);
+
+        (address newPool, ) = _createLBPoolWithCustomWeights(
+            startWeights[projectIdx],
+            startWeights[reserveIdx],
+            endWeights[projectIdx],
+            endWeights[reserveIdx],
+            pastStartTime,
+            endTime,
+            DEFAULT_PROJECT_TOKENS_SWAP_IN
+        );
+    }
+
     function testCreatePoolEvents() public {
         uint32 startTime = uint32(block.timestamp + DEFAULT_START_OFFSET);
         uint32 endTime = uint32(block.timestamp + DEFAULT_END_OFFSET);


### PR DESCRIPTION
# Description

According to Certora's report, there were 3 informational fixes to implement:
1. Emit `GradualWeightUpdateScheduled` with the correct startTime when the configured startTime is in the past.
2. Do not allow startTime == endTime when creating an LBP Pool
3. Optimize if clause to negate a boolean instead of comparing with constant false (`!` instead of `== false`). We decided not to do this one, since it saves only 3 gas and degrade the UX.

This PR implements numbers 1 and 2.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution:

Closes #1303 