### PR TITLE
Feat/add-is-buffer-initialized

### DIFF
--- a/pkg/interfaces/contracts/vault/IVaultExplorer.sol
+++ b/pkg/interfaces/contracts/vault/IVaultExplorer.sol
@@ -542,4 +542,12 @@ interface IVaultExplorer {
     function getBufferBalance(
         IERC4626 wrappedToken
     ) external view returns (uint256 underlyingBalanceRaw, uint256 wrappedBalanceRaw);
+
+    /**
+     * @notice Checks if the wrapped token has an initialized buffer in the Vault.
+     * @dev An initialized buffer should have an asset registered in the Vault.
+     * @param wrappedToken Address of the wrapped token that implements IERC4626
+     * @return isBufferInitialized True if the ERC4626 buffer is initialized
+     */
+    function isERC4626BufferInitialized(IERC4626 wrappedToken) external view returns (bool isBufferInitialized);
 }

--- a/pkg/vault/contracts/VaultExplorer.sol
+++ b/pkg/vault/contracts/VaultExplorer.sol
@@ -373,4 +373,9 @@ contract VaultExplorer is IVaultExplorer {
     ) external view returns (uint256 underlyingBalanceRaw, uint256 wrappedBalanceRaw) {
         return _vault.getBufferBalance(wrappedToken);
     }
+
+    /// @inheritdoc IVaultExplorer
+    function isERC4626BufferInitialized(IERC4626 wrappedToken) external view returns (bool isBufferInitialized) {
+        return _vault.isERC4626BufferInitialized(wrappedToken);
+    }
 }

--- a/pkg/vault/test/foundry/VaultExplorer.t.sol
+++ b/pkg/vault/test/foundry/VaultExplorer.t.sol
@@ -749,6 +749,11 @@ contract VaultExplorerTest is BaseVaultTest {
         feeController.updateProtocolSwapFeePercentage(pool);
         feeController.updateProtocolYieldFeePercentage(pool);
     }
+    function testIsERC4626BufferInitialized() public {
+        _setupBuffer();
+        bool isInitialized = explorer.isERC4626BufferInitialized(waDAI);
+        assertTrue(isInitialized, "Buffer is not initialized");
+    }
 
     function testGetBufferOwnerShares() public {
         _setupBuffer();


### PR DESCRIPTION
# Description

As part of reviewing an erc4626 vault I need to check if a buffer is initialized for a certain wrapped asset. 

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
