### PR TITLE
Add vault getter to aggregator router

### DIFF
--- a/pkg/interfaces/contracts/vault/IAggregatorRouter.sol
+++ b/pkg/interfaces/contracts/vault/IAggregatorRouter.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.24;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+
 import { SwapKind } from "./VaultTypes.sol";
 
 interface IAggregatorRouter {
@@ -12,6 +14,9 @@ interface IAggregatorRouter {
 
     /// @notice Thrown when the sender does not transfer the correct amount of tokens to the Vault.
     error SwapInsufficientPayment();
+
+    /// @notice Get the address of the Balancer Vault.
+    function getVault() external view returns (IVault);
 
     /**
      * @notice Executes a swap operation specifying an exact input token amount.

--- a/pkg/interfaces/contracts/vault/IAggregatorRouter.sol
+++ b/pkg/interfaces/contracts/vault/IAggregatorRouter.sol
@@ -4,8 +4,7 @@ pragma solidity ^0.8.24;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
-
+import { IVault } from "./IVault.sol";
 import { SwapKind } from "./VaultTypes.sol";
 
 interface IAggregatorRouter {

--- a/pkg/vault/contracts/AggregatorRouter.sol
+++ b/pkg/vault/contracts/AggregatorRouter.sol
@@ -32,6 +32,11 @@ contract AggregatorRouter is IAggregatorRouter, SenderGuard, VaultGuard, Reentra
         // solhint-disable-previous-line no-empty-blocks
     }
 
+    /// @inheritdoc IAggregatorRouter
+    function getVault() public view returns (IVault) {
+        return _vault;
+    }
+
     /***************************************************************************
                                        Swaps
     ***************************************************************************/

--- a/pkg/vault/test/foundry/AggregatorsRouter.t.sol
+++ b/pkg/vault/test/foundry/AggregatorsRouter.t.sol
@@ -74,6 +74,11 @@ contract AggregatorsRouterTest is BaseVaultTest {
         poolArgs = abi.encode(vault, name, symbol);
     }
 
+    function testGetVault() public view {
+        assertNotEq(address(vault), address(0), "Vault not set");
+        assertEq(address(aggregatorsRouter.getVault()), address(vault), "Wrong vault");
+    }
+
     /************************************
                   EXACT IN
     ************************************/


### PR DESCRIPTION
# Description

For regular routers it's not much of a utility since if you interact with the router you don't even need to know about the vault.

But in the aggregator router you need to pay the vault directly, so a getter can be handy.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A