### PR TITLE
ProtocolFeeController v2 (working migration edition)

### DIFF
--- a/pkg/vault/contracts/ProtocolFeeController.sol
+++ b/pkg/vault/contracts/ProtocolFeeController.sol
@@ -463,8 +463,22 @@ contract ProtocolFeeController is
             isOverride: yieldFeeIsOverride
         });
 
-        _poolCreatorSwapFeePercentages[pool] = oldFeeController.getPoolCreatorSwapFeePercentage(pool);
-        _poolCreatorYieldFeePercentages[pool] = oldFeeController.getPoolCreatorYieldFeePercentage(pool);
+        // On the first migration, these functions won't exist, as they were not included in the originally deployed
+        // contract. This is ok, as the first time the contract will be migrated, there will be no pool creators.
+        // In the event a pool that did have a pool creator was missed, the pool creator can simply set the fee
+        // percentage again on the new controller. The fact that a pool has a pool creator cannot be lost, as this
+        // is stored in the Vault on initial registration.
+        try oldFeeController.getPoolCreatorSwapFeePercentage(pool) returns (uint256 poolCreatorSwapFeePercentage) {
+            _poolCreatorSwapFeePercentages[pool] = poolCreatorSwapFeePercentage;
+        } catch {
+            // solhint-disable-previous-line no-empty-blocks
+        }
+
+        try oldFeeController.getPoolCreatorYieldFeePercentage(pool) returns (uint256 poolCreatorYieldFeePercentage) {
+            _poolCreatorYieldFeePercentages[pool] = poolCreatorYieldFeePercentage;
+        } catch {
+            // solhint-disable-previous-line no-empty-blocks
+        }
     }
 
     /***************************************************************************


### PR DESCRIPTION
# Description

So... turns out the original plan for two migration scripts (a first simple and a later more comprehensive one) doesn't actually work. We need the full migration even for the first time; the "update" functions must be called by the current fee controller, so can't be used during a migration.

It's actually simpler this way, as there's only one migration script now. The only catch is we have to tolerate the pool creator fee getters failing the first time, as they don't exist in the original fee controller. This is fine the first time, as there are no overrides or pool creators (both of which can be recreated in the new fee controller using permissioned calls from governance and the pool creators respectively, in case we miss one).

For the second and all subsequent migrations, they will work and copy the entire state.

I noticed that since we now derived from `SingletonAuthentication`, we have both `vault()` and `getVault()` defined, which of course do the same thing. We could theoretically remove `vault()` from the interface -- except it's being called by Gyro and CoW pools, so now we're stuck with it.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution
