### PR TITLE
Fix documentation about salt used by factories

### DIFF
--- a/pkg/interfaces/contracts/pool-cow/ICowPoolFactory.sol
+++ b/pkg/interfaces/contracts/pool-cow/ICowPoolFactory.sol
@@ -23,7 +23,7 @@ interface ICowPoolFactory {
      * @param normalizedWeights The pool weights (must sum to FixedPoint.ONE)
      * @param roleAccounts Addresses the Vault will allow to change certain pool settings
      * @param swapFeePercentage Initial swap fee percentage
-     * @param salt The salt value that will be passed to create2 deployment
+     * @param salt The salt value that will be passed to deployment
      */
     function create(
         string memory name,

--- a/pkg/pool-gyro/contracts/Gyro2CLPPoolFactory.sol
+++ b/pkg/pool-gyro/contracts/Gyro2CLPPoolFactory.sol
@@ -49,7 +49,7 @@ contract Gyro2CLPPoolFactory is IPoolVersion, BasePoolFactory, Version {
      * @param poolHooksContract Contract that implements the hooks for the pool
      * @param enableDonation If true, the pool will support the donation add liquidity mechanism
      * @param disableUnbalancedLiquidity If true, only proportional add and remove liquidity are accepted
-     * @param salt The salt value that will be passed to create2 deployment
+     * @param salt The salt value that will be passed to deployment
      */
     function create(
         string memory name,

--- a/pkg/pool-gyro/contracts/GyroECLPPoolFactory.sol
+++ b/pkg/pool-gyro/contracts/GyroECLPPoolFactory.sol
@@ -52,7 +52,7 @@ contract GyroECLPPoolFactory is IPoolVersion, BasePoolFactory, Version {
      * @param poolHooksContract Contract that implements the hooks for the pool
      * @param enableDonation If true, the pool will support the donation add liquidity mechanism
      * @param disableUnbalancedLiquidity If true, only proportional add and remove liquidity are accepted
-     * @param salt The salt value that will be passed to create3 deployment
+     * @param salt The salt value that will be passed to deployment
      */
     function create(
         string memory name,

--- a/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
@@ -48,7 +48,7 @@ contract WeightedPoolFactory is IPoolVersion, BasePoolFactory, Version {
      * @param poolHooksContract Contract that implements the hooks for the pool
      * @param enableDonation If true, the pool will support the donation add liquidity mechanism
      * @param disableUnbalancedLiquidity If true, only proportional add and remove liquidity are accepted
-     * @param salt The salt value that will be passed to create2 deployment
+     * @param salt The salt value that will be passed to deployment
      */
     function create(
         string memory name,


### PR DESCRIPTION
# Description

The ECLP factory mentioned that salt was passed to create3, but it's used by create2. 
The stable pool only describes that salt is used for deployment and does not specify whether it's for create2 or create3, which seems more future-proof.

So, this PR adopts the Stable Pool Factory comment as the standard.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [x] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge
