### PR TITLE
Remove unused state variable in StableSurgeHook

### DIFF
--- a/pkg/pool-hooks/contracts/StableSurgeHook.sol
+++ b/pkg/pool-hooks/contracts/StableSurgeHook.sol
@@ -88,9 +88,6 @@ contract StableSurgeHook is BaseHooks, VaultGuard, SingletonAuthentication {
         _;
     }
 
-    // Store the current threshold for each pool.
-    mapping(address pool => uint256 threshold) private _surgeThresholdPercentage;
-
     constructor(
         IVault vault,
         uint256 defaultMaxSurgeFeePercentage,


### PR DESCRIPTION
# Description

Somehow this was missed in reviews... We replaced `_surgeThresholdPercentage ` with `_surgeFeePoolData`, but never removed the old mapping. It's not hurting anything (and we already deployed it like that), but might as well clean it up for the future. Thanks, @mingbaile!

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Resolves #1325 
