### PR TITLE
Add initial global protocol fees to the ProtocolFeeController

### DIFF
--- a/pkg/vault/contracts/ProtocolFeeController.sol
+++ b/pkg/vault/contracts/ProtocolFeeController.sol
@@ -171,8 +171,13 @@ contract ProtocolFeeController is
         _;
     }
 
-    constructor(IVault vault_) SingletonAuthentication(vault_) VaultGuard(vault_) {
-        // solhint-disable-previous-line no-empty-blocks
+    constructor(
+        IVault vault_,
+        uint256 initialGlobalSwapFeePercentage,
+        uint256 initialGlobalYieldFeePercentage
+    ) SingletonAuthentication(vault_) VaultGuard(vault_) {
+        _setGlobalProtocolSwapFeePercentage(initialGlobalSwapFeePercentage);
+        _setGlobalProtocolYieldFeePercentage(initialGlobalYieldFeePercentage);
     }
 
     /// @inheritdoc IProtocolFeeController
@@ -518,18 +523,26 @@ contract ProtocolFeeController is
     }
 
     /// @inheritdoc IProtocolFeeController
-    function setGlobalProtocolSwapFeePercentage(
+    function setGlobalProtocolSwapFeePercentage(uint256 newProtocolSwapFeePercentage) external authenticate {
+        _setGlobalProtocolSwapFeePercentage(newProtocolSwapFeePercentage);
+    }
+
+    function _setGlobalProtocolSwapFeePercentage(
         uint256 newProtocolSwapFeePercentage
-    ) external withValidSwapFee(newProtocolSwapFeePercentage) authenticate {
+    ) internal withValidSwapFee(newProtocolSwapFeePercentage) {
         _globalProtocolSwapFeePercentage = newProtocolSwapFeePercentage;
 
         emit GlobalProtocolSwapFeePercentageChanged(newProtocolSwapFeePercentage);
     }
 
     /// @inheritdoc IProtocolFeeController
-    function setGlobalProtocolYieldFeePercentage(
+    function setGlobalProtocolYieldFeePercentage(uint256 newProtocolYieldFeePercentage) external authenticate {
+        _setGlobalProtocolYieldFeePercentage(newProtocolYieldFeePercentage);
+    }
+
+    function _setGlobalProtocolYieldFeePercentage(
         uint256 newProtocolYieldFeePercentage
-    ) external withValidYieldFee(newProtocolYieldFeePercentage) authenticate {
+    ) internal withValidYieldFee(newProtocolYieldFeePercentage) {
         _globalProtocolYieldFeePercentage = newProtocolYieldFeePercentage;
 
         emit GlobalProtocolYieldFeePercentageChanged(newProtocolYieldFeePercentage);

--- a/pkg/vault/contracts/VaultFactory.sol
+++ b/pkg/vault/contracts/VaultFactory.sol
@@ -6,6 +6,7 @@ import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 
+import { IProtocolFeeController } from "@balancer-labs/v3-interfaces/contracts/vault/IProtocolFeeController.sol";
 import { IAuthorizer } from "@balancer-labs/v3-interfaces/contracts/vault/IAuthorizer.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 
@@ -14,7 +15,6 @@ import {
 } from "@balancer-labs/v3-solidity-utils/contracts/openzeppelin/ReentrancyGuardTransient.sol";
 import { CREATE3 } from "@balancer-labs/v3-solidity-utils/contracts/solmate/CREATE3.sol";
 
-import { ProtocolFeeController } from "./ProtocolFeeController.sol";
 import { VaultExtension } from "./VaultExtension.sol";
 import { VaultAdmin } from "./VaultAdmin.sol";
 
@@ -24,7 +24,6 @@ contract VaultFactory is ReentrancyGuardTransient, Ownable2Step {
     bytes32 public immutable vaultAdminCreationCodeHash;
     bytes32 public immutable vaultExtensionCreationCodeHash;
 
-    mapping(address vaultAddress => ProtocolFeeController) public deployedProtocolFeeControllers;
     mapping(address vaultAddress => VaultExtension) public deployedVaultExtensions;
     mapping(address vaultAddress => VaultAdmin) public deployedVaultAdmins;
     mapping(address vaultAddress => bool deployed) public isDeployed;
@@ -56,6 +55,9 @@ contract VaultFactory is ReentrancyGuardTransient, Ownable2Step {
      */
     error VaultAlreadyDeployed(address vault);
 
+    /// @notice The ProtocolFeeController cannot be the zero address.
+    error InvalidProtocolFeeController();
+
     constructor(
         IAuthorizer authorizer,
         uint32 pauseWindowDuration,
@@ -84,6 +86,7 @@ contract VaultFactory is ReentrancyGuardTransient, Ownable2Step {
      * @param salt Salt used to create the Vault. See `getDeploymentAddress`
      * @param targetAddress Expected Vault address. The function will revert if the given salt does not deploy the
      * Vault to the target address
+     * @param protocolFeeController The address of the previously deployed ProtocolFeeController
      * @param vaultCreationCode Creation code for the Vault
      * @param vaultExtensionCreationCode Creation code for the VaultExtension
      * @param vaultAdminCreationCode Creation code for the VaultAdmin
@@ -91,6 +94,7 @@ contract VaultFactory is ReentrancyGuardTransient, Ownable2Step {
     function create(
         bytes32 salt,
         address targetAddress,
+        IProtocolFeeController protocolFeeController,
         bytes calldata vaultCreationCode,
         bytes calldata vaultExtensionCreationCode,
         bytes calldata vaultAdminCreationCode
@@ -107,13 +111,14 @@ contract VaultFactory is ReentrancyGuardTransient, Ownable2Step {
             revert InvalidBytecode("VaultExtension");
         }
 
-        address vaultAddress = getDeploymentAddress(salt);
-        if (targetAddress != vaultAddress) {
+        // If this passes, we know we can use the targetAddress for the vaultAddress.
+        if (targetAddress != getDeploymentAddress(salt)) {
             revert VaultAddressMismatch();
         }
 
-        ProtocolFeeController protocolFeeController = new ProtocolFeeController(IVault(vaultAddress));
-        deployedProtocolFeeControllers[vaultAddress] = protocolFeeController;
+        if (protocolFeeController == IProtocolFeeController(address(0))) {
+            revert InvalidProtocolFeeController();
+        }
 
         VaultAdmin vaultAdmin = VaultAdmin(
             payable(
@@ -123,7 +128,7 @@ contract VaultFactory is ReentrancyGuardTransient, Ownable2Step {
                     abi.encodePacked(
                         vaultAdminCreationCode,
                         abi.encode(
-                            IVault(vaultAddress),
+                            IVault(targetAddress),
                             _pauseWindowDuration,
                             _bufferPeriodDuration,
                             _minTradeAmount,
@@ -133,18 +138,18 @@ contract VaultFactory is ReentrancyGuardTransient, Ownable2Step {
                 )
             )
         );
-        deployedVaultAdmins[vaultAddress] = vaultAdmin;
+        deployedVaultAdmins[targetAddress] = vaultAdmin;
 
         VaultExtension vaultExtension = VaultExtension(
             payable(
                 Create2.deploy(
                     0, // ETH value
                     salt,
-                    abi.encodePacked(vaultExtensionCreationCode, abi.encode(vaultAddress, vaultAdmin))
+                    abi.encodePacked(vaultExtensionCreationCode, abi.encode(targetAddress, vaultAdmin))
                 )
             )
         );
-        deployedVaultExtensions[vaultAddress] = vaultExtension;
+        deployedVaultExtensions[targetAddress] = vaultExtension;
 
         address deployedAddress = CREATE3.deploy(
             salt,
@@ -153,13 +158,13 @@ contract VaultFactory is ReentrancyGuardTransient, Ownable2Step {
         );
 
         // This should always be the case, but we enforce the end state to match the expected outcome anyway.
-        if (deployedAddress != vaultAddress) {
+        if (deployedAddress != targetAddress) {
             revert VaultAddressMismatch();
         }
 
-        emit VaultCreated(vaultAddress);
+        emit VaultCreated(targetAddress);
 
-        isDeployed[vaultAddress] = true;
+        isDeployed[targetAddress] = true;
     }
 
     /// @notice Gets deployment address for a given salt.

--- a/pkg/vault/contracts/test/ProtocolFeeControllerMock.sol
+++ b/pkg/vault/contracts/test/ProtocolFeeControllerMock.sol
@@ -9,7 +9,11 @@ import { IVaultMock } from "@balancer-labs/v3-interfaces/contracts/test/IVaultMo
 import { ProtocolFeeController } from "../ProtocolFeeController.sol";
 
 contract ProtocolFeeControllerMock is ProtocolFeeController {
-    constructor(IVaultMock vault_) ProtocolFeeController(vault_) {
+    constructor(
+        IVaultMock vault_,
+        uint256 protocolSwapFeePercentage,
+        uint256 protocolYieldFeePercentage
+    ) ProtocolFeeController(vault_, protocolSwapFeePercentage, protocolYieldFeePercentage) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/vault/test/foundry/ProtocolFeeController.t.sol
+++ b/pkg/vault/test/foundry/ProtocolFeeController.t.sol
@@ -1376,7 +1376,7 @@ contract ProtocolFeeControllerTest is BaseVaultTest {
         vm.prank(admin);
         feeController.setProtocolYieldFeePercentage(pool, MAX_PROTOCOL_YIELD_FEE_PCT / 2);
 
-        ProtocolFeeController newFeeController = new ProtocolFeeController(vault);
+        ProtocolFeeController newFeeController = new ProtocolFeeController(vault, 0, 0);
         vm.label(address(newFeeController), "New fee controller");
 
         // Migrate the pool to a new controller.
@@ -1411,6 +1411,30 @@ contract ProtocolFeeControllerTest is BaseVaultTest {
     function testSelfMigration() public {
         vm.expectRevert(ProtocolFeeController.InvalidMigrationSource.selector);
         ProtocolFeeController(address(feeController)).migratePool(pool);
+    }
+
+    function testFeeInitialization() public {
+        uint256 swapFeePercentage = 50e16;
+        uint256 yieldFeePercentage = 10e16;
+
+        vm.expectEmit();
+        emit IProtocolFeeController.GlobalProtocolSwapFeePercentageChanged(swapFeePercentage);
+
+        vm.expectEmit();
+        emit IProtocolFeeController.GlobalProtocolYieldFeePercentageChanged(yieldFeePercentage);
+
+        ProtocolFeeController feeController = new ProtocolFeeController(vault, swapFeePercentage, yieldFeePercentage);
+
+        assertEq(
+            feeController.getGlobalProtocolSwapFeePercentage(),
+            swapFeePercentage,
+            "Wrong initial swap fee percentage"
+        );
+        assertEq(
+            feeController.getGlobalProtocolYieldFeePercentage(),
+            yieldFeePercentage,
+            "Wrong initial yield fee percentage"
+        );
     }
 
     function _registerPoolWithMaxProtocolFees() internal {

--- a/pkg/vault/test/foundry/unit/VaultUnit.t.sol
+++ b/pkg/vault/test/foundry/unit/VaultUnit.t.sol
@@ -43,7 +43,7 @@ contract VaultUnitTest is BaseTest, VaultContractsDeployer {
 
     function setUp() public virtual override {
         BaseTest.setUp();
-        vault = deployVaultMock(MIN_TRADE_AMOUNT, MIN_WRAP_AMOUNT);
+        vault = deployVaultMock(MIN_TRADE_AMOUNT, MIN_WRAP_AMOUNT, 0, 0); // Zero args are protocol fee percentages
     }
 
     function testBuildPoolSwapParams() public view {

--- a/pkg/vault/test/foundry/utils/BaseMedusaTest.sol
+++ b/pkg/vault/test/foundry/utils/BaseMedusaTest.sol
@@ -163,7 +163,7 @@ contract BaseMedusaTest is Test {
             minWrapAmount
         );
         vaultExtension = new VaultExtensionMock(IVault(payable(address(newVault))), vaultAdmin);
-        feeController = new ProtocolFeeControllerMock(IVaultMock(payable(address(newVault))));
+        feeController = new ProtocolFeeControllerMock(IVaultMock(payable(address(newVault))), 0, 0);
 
         _create3(abi.encode(vaultExtension, authorizer, feeController), vaultMockBytecode, salt);
 

--- a/pkg/vault/test/foundry/utils/BaseVaultTest.sol
+++ b/pkg/vault/test/foundry/utils/BaseVaultTest.sol
@@ -131,6 +131,10 @@ abstract contract BaseVaultTest is VaultContractsDeployer, VaultStorage, BaseTes
     // Change this value before calling `setUp` to test under real conditions.
     uint256 vaultMockMinWrapAmount = 1;
 
+    // These are passed into the Protocol Fee Controller (keep zero for now to avoid breaking tests).
+    uint256 vaultMockInitialProtocolSwapFeePercentage = 0;
+    uint256 vaultMockInitialProtocolYieldFeePercentage = 0;
+
     // ------------------------------ Hooks ------------------------------
     function onAfterDeployMainContracts() internal virtual {}
 
@@ -155,7 +159,12 @@ abstract contract BaseVaultTest is VaultContractsDeployer, VaultStorage, BaseTes
     }
 
     function _deployMainContracts() private {
-        vault = deployVaultMock(vaultMockMinTradeAmount, vaultMockMinWrapAmount);
+        vault = deployVaultMock(
+            vaultMockMinTradeAmount,
+            vaultMockMinWrapAmount,
+            vaultMockInitialProtocolSwapFeePercentage,
+            vaultMockInitialProtocolYieldFeePercentage
+        );
 
         vm.label(address(vault), "vault");
         vaultExtension = IVaultExtension(vault.getVaultExtension());

--- a/pvt/helpers/src/models/vault/VaultDeployer.ts
+++ b/pvt/helpers/src/models/vault/VaultDeployer.ts
@@ -49,7 +49,7 @@ async function deployReal(deployment: VaultDeploymentParams, authorizer: BaseCon
   });
 
   const protocolFeeController: ProtocolFeeController = await contract.deploy('v3-vault/ProtocolFeeController', {
-    args: [futureVaultAddress],
+    args: [futureVaultAddress, 0, 0],
     from: admin,
   });
 
@@ -75,7 +75,7 @@ async function deployMocked(deployment: VaultDeploymentParams, authorizer: BaseC
   });
 
   const protocolFeeController: ProtocolFeeController = await contract.deploy('v3-vault/ProtocolFeeController', {
-    args: [futureVaultAddress],
+    args: [futureVaultAddress, 0, 0],
     from: admin,
   });
 


### PR DESCRIPTION
# Description

We had a request to incorporate default fees into the protocol fee controller, so that we don't need to use governance to set them after deployment.

Another issue related to new chains is the fact that the Protocol Fee Controller used to be deployed with the Vault in the Vault factory. This means we'd have to redeploy the Vault factory every time we migrated the fee controller. To avoid this, we pass the fee controller address to the Vault factory, so that it can be deployed externally and these two deployments are decoupled.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
