### PR TITLE
Changing BigNumberish to bigint in math js tests

### DIFF
--- a/pkg/vault/test/foundry/BasePoolMathRoundingTest.sol
+++ b/pkg/vault/test/foundry/BasePoolMathRoundingTest.sol
@@ -32,7 +32,7 @@ abstract contract BasePoolMathRoundingTest is Test {
     function testComputeProportionalAmountsIn__Fuzz(
         uint256[2] calldata rawBalances,
         uint256 rawBptAmountOut
-    ) external view {
+    ) external virtual {
         uint256[] memory balances = new uint256[](rawBalances.length);
         for (uint256 i = 0; i < balances.length; ++i) {
             balances[i] = bound(rawBalances[i], MIN_BALANCE, MAX_AMOUNT);
@@ -73,7 +73,7 @@ abstract contract BasePoolMathRoundingTest is Test {
     function testComputeProportionalAmountsOut__Fuzz(
         uint256[2] calldata rawBalances,
         uint256 rawBptAmountIn
-    ) external view {
+    ) external virtual {
         uint256[] memory balances = new uint256[](rawBalances.length);
         for (uint256 i = 0; i < balances.length; ++i) {
             balances[i] = bound(rawBalances[i], MIN_BALANCE, MAX_AMOUNT);
@@ -115,7 +115,7 @@ abstract contract BasePoolMathRoundingTest is Test {
         uint256[2] calldata rawBalances,
         uint256[2] calldata rawAmountsIn,
         uint64 rawSwapFee
-    ) external view {
+    ) external virtual {
         uint256[] memory balances = new uint256[](rawBalances.length);
         uint256[] memory amountsIn = new uint256[](2);
         for (uint256 i = 0; i < balances.length; ++i) {
@@ -187,7 +187,7 @@ abstract contract BasePoolMathRoundingTest is Test {
         uint256 rawTokenInIndex,
         uint256 rawBptAmountOut,
         uint64 rawSwapFee
-    ) external view {
+    ) external virtual {
         uint256[] memory balances = new uint256[](2);
         uint256 balance = bound(rawBalance, MIN_BALANCE * 4, MAX_AMOUNT);
         for (uint256 i = 0; i < balances.length; ++i) {
@@ -263,7 +263,7 @@ abstract contract BasePoolMathRoundingTest is Test {
         uint256 rawTokenOutIndex,
         uint256 rawAmountOut,
         uint64 rawSwapFee
-    ) external view {
+    ) external virtual {
         uint256[] memory balances = new uint256[](2);
         uint256 balance = bound(rawBalance, MIN_BALANCE * 5, MAX_AMOUNT);
 
@@ -340,7 +340,7 @@ abstract contract BasePoolMathRoundingTest is Test {
         uint256 rawTokenOutIndex,
         uint256 rawBptAmountIn,
         uint64 rawSwapFee
-    ) external view {
+    ) external virtual {
         uint256[] memory balances = new uint256[](2);
 
         uint balance = bound(rawBalance, MIN_BALANCE, MAX_AMOUNT);

--- a/pkg/vault/test/foundry/BasePoolMathRoundingTest.sol
+++ b/pkg/vault/test/foundry/BasePoolMathRoundingTest.sol
@@ -29,7 +29,10 @@ abstract contract BasePoolMathRoundingTest is Test {
 
     function createMathMock() internal virtual returns (BasePoolMathMock);
 
-    function testComputeProportionalAmountsIn__Fuzz(uint256[2] calldata rawBalances, uint256 rawBptAmountOut) external {
+    function testComputeProportionalAmountsIn__Fuzz(
+        uint256[2] calldata rawBalances,
+        uint256 rawBptAmountOut
+    ) external view {
         uint256[] memory balances = new uint256[](rawBalances.length);
         for (uint256 i = 0; i < balances.length; ++i) {
             balances[i] = bound(rawBalances[i], MIN_BALANCE, MAX_AMOUNT);
@@ -67,7 +70,10 @@ abstract contract BasePoolMathRoundingTest is Test {
         }
     }
 
-    function testComputeProportionalAmountsOut__Fuzz(uint256[2] calldata rawBalances, uint256 rawBptAmountIn) external {
+    function testComputeProportionalAmountsOut__Fuzz(
+        uint256[2] calldata rawBalances,
+        uint256 rawBptAmountIn
+    ) external view {
         uint256[] memory balances = new uint256[](rawBalances.length);
         for (uint256 i = 0; i < balances.length; ++i) {
             balances[i] = bound(rawBalances[i], MIN_BALANCE, MAX_AMOUNT);
@@ -109,7 +115,7 @@ abstract contract BasePoolMathRoundingTest is Test {
         uint256[2] calldata rawBalances,
         uint256[2] calldata rawAmountsIn,
         uint64 rawSwapFee
-    ) external {
+    ) external view {
         uint256[] memory balances = new uint256[](rawBalances.length);
         uint256[] memory amountsIn = new uint256[](2);
         for (uint256 i = 0; i < balances.length; ++i) {
@@ -181,7 +187,7 @@ abstract contract BasePoolMathRoundingTest is Test {
         uint256 rawTokenInIndex,
         uint256 rawBptAmountOut,
         uint64 rawSwapFee
-    ) external {
+    ) external view {
         uint256[] memory balances = new uint256[](2);
         uint256 balance = bound(rawBalance, MIN_BALANCE * 4, MAX_AMOUNT);
         for (uint256 i = 0; i < balances.length; ++i) {
@@ -257,7 +263,7 @@ abstract contract BasePoolMathRoundingTest is Test {
         uint256 rawTokenOutIndex,
         uint256 rawAmountOut,
         uint64 rawSwapFee
-    ) external {
+    ) external view {
         uint256[] memory balances = new uint256[](2);
         uint256 balance = bound(rawBalance, MIN_BALANCE * 5, MAX_AMOUNT);
 
@@ -334,7 +340,7 @@ abstract contract BasePoolMathRoundingTest is Test {
         uint256 rawTokenOutIndex,
         uint256 rawBptAmountIn,
         uint64 rawSwapFee
-    ) external {
+    ) external view {
         uint256[] memory balances = new uint256[](2);
 
         uint balance = bound(rawBalance, MIN_BALANCE, MAX_AMOUNT);

--- a/pkg/vault/test/foundry/BasePoolMathRoundingTest.sol
+++ b/pkg/vault/test/foundry/BasePoolMathRoundingTest.sol
@@ -29,10 +29,7 @@ abstract contract BasePoolMathRoundingTest is Test {
 
     function createMathMock() internal virtual returns (BasePoolMathMock);
 
-    function testComputeProportionalAmountsIn__Fuzz(
-        uint256[2] calldata rawBalances,
-        uint256 rawBptAmountOut
-    ) external virtual {
+    function testComputeProportionalAmountsIn__Fuzz(uint256[2] calldata rawBalances, uint256 rawBptAmountOut) external {
         uint256[] memory balances = new uint256[](rawBalances.length);
         for (uint256 i = 0; i < balances.length; ++i) {
             balances[i] = bound(rawBalances[i], MIN_BALANCE, MAX_AMOUNT);
@@ -70,10 +67,7 @@ abstract contract BasePoolMathRoundingTest is Test {
         }
     }
 
-    function testComputeProportionalAmountsOut__Fuzz(
-        uint256[2] calldata rawBalances,
-        uint256 rawBptAmountIn
-    ) external virtual {
+    function testComputeProportionalAmountsOut__Fuzz(uint256[2] calldata rawBalances, uint256 rawBptAmountIn) external {
         uint256[] memory balances = new uint256[](rawBalances.length);
         for (uint256 i = 0; i < balances.length; ++i) {
             balances[i] = bound(rawBalances[i], MIN_BALANCE, MAX_AMOUNT);
@@ -115,7 +109,7 @@ abstract contract BasePoolMathRoundingTest is Test {
         uint256[2] calldata rawBalances,
         uint256[2] calldata rawAmountsIn,
         uint64 rawSwapFee
-    ) external virtual {
+    ) external {
         uint256[] memory balances = new uint256[](rawBalances.length);
         uint256[] memory amountsIn = new uint256[](2);
         for (uint256 i = 0; i < balances.length; ++i) {
@@ -187,7 +181,7 @@ abstract contract BasePoolMathRoundingTest is Test {
         uint256 rawTokenInIndex,
         uint256 rawBptAmountOut,
         uint64 rawSwapFee
-    ) external virtual {
+    ) external {
         uint256[] memory balances = new uint256[](2);
         uint256 balance = bound(rawBalance, MIN_BALANCE * 4, MAX_AMOUNT);
         for (uint256 i = 0; i < balances.length; ++i) {
@@ -263,7 +257,7 @@ abstract contract BasePoolMathRoundingTest is Test {
         uint256 rawTokenOutIndex,
         uint256 rawAmountOut,
         uint64 rawSwapFee
-    ) external virtual {
+    ) external {
         uint256[] memory balances = new uint256[](2);
         uint256 balance = bound(rawBalance, MIN_BALANCE * 5, MAX_AMOUNT);
 
@@ -340,7 +334,7 @@ abstract contract BasePoolMathRoundingTest is Test {
         uint256 rawTokenOutIndex,
         uint256 rawBptAmountIn,
         uint64 rawSwapFee
-    ) external virtual {
+    ) external {
         uint256[] memory balances = new uint256[](2);
 
         uint balance = bound(rawBalance, MIN_BALANCE, MAX_AMOUNT);

--- a/pvt/helpers/src/math/stable.ts
+++ b/pvt/helpers/src/math/stable.ts
@@ -1,5 +1,4 @@
 import { Decimal } from 'decimal.js';
-import { BigNumberish } from 'ethers';
 import { decimal, bn, fp, fromFp, toFp } from '../numbers';
 
 export enum Rounding {
@@ -8,8 +7,8 @@ export enum Rounding {
 }
 
 export function calculateInvariant(
-  fpRawBalances: BigNumberish[],
-  amplificationParameter: BigNumberish,
+  fpRawBalances: bigint[],
+  amplificationParameter: bigint,
   rounding: Rounding
 ): bigint {
   let invariant = calculateApproxInvariant(fpRawBalances, amplificationParameter);
@@ -19,7 +18,7 @@ export function calculateInvariant(
   return invariant;
 }
 
-export function calculateApproxInvariant(fpRawBalances: BigNumberish[], amplificationParameter: BigNumberish): bigint {
+export function calculateApproxInvariant(fpRawBalances: bigint[], amplificationParameter: bigint): bigint {
   const totalCoins = fpRawBalances.length;
   const balances: Decimal[] = fpRawBalances.map(fromFp);
 
@@ -60,15 +59,15 @@ export function calculateApproxInvariant(fpRawBalances: BigNumberish[], amplific
 }
 
 export function calculateAnalyticalInvariantForTwoTokens(
-  fpRawBalances: BigNumberish[],
-  amplificationParameter: BigNumberish
+  fpRawBalances: bigint[],
+  amplificationParameter: bigint
 ): bigint {
   if (fpRawBalances.length !== 2) {
     throw 'Analytical invariant is solved only for 2 balances';
   }
 
-  const sum = fpRawBalances.reduce((a: Decimal, b: BigNumberish) => a.add(fromFp(b)), decimal(0));
-  const prod = fpRawBalances.reduce((a: Decimal, b: BigNumberish) => a.mul(fromFp(b)), decimal(1));
+  const sum = fpRawBalances.reduce((a: Decimal, b: bigint) => a.add(fromFp(b)), decimal(0));
+  const prod = fpRawBalances.reduce((a: Decimal, b: bigint) => a.mul(fromFp(b)), decimal(1));
 
   // The amplification parameter equals to: A n^(n-1), where A is the amplification coefficient
   const amplificationCoefficient = decimal(amplificationParameter).div(2);
@@ -93,11 +92,11 @@ export function calculateAnalyticalInvariantForTwoTokens(
 }
 
 export function calcOutGivenExactIn(
-  fpBalances: BigNumberish[],
-  amplificationParameter: BigNumberish,
+  fpBalances: bigint[],
+  amplificationParameter: bigint,
   tokenIndexIn: number,
   tokenIndexOut: number,
-  fpTokenAmountIn: BigNumberish
+  fpTokenAmountIn: bigint
 ): Decimal {
   const invariant = fromFp(calculateInvariant(fpBalances, amplificationParameter));
 
@@ -115,11 +114,11 @@ export function calcOutGivenExactIn(
 }
 
 export function calcInGivenExactOut(
-  fpBalances: BigNumberish[],
-  amplificationParameter: BigNumberish,
+  fpBalances: bigint[],
+  amplificationParameter: bigint,
   tokenIndexIn: number,
   tokenIndexOut: number,
-  fpTokenAmountOut: BigNumberish
+  fpTokenAmountOut: bigint
 ): Decimal {
   const invariant = fromFp(calculateInvariant(fpBalances, amplificationParameter));
 
@@ -139,8 +138,8 @@ export function calcInGivenExactOut(
 // The amp factor input must be a number: *not* multiplied by the precision
 export function getTokenBalanceGivenInvariantAndAllOtherBalances(
   amp: number,
-  fpBalances: BigNumberish[],
-  fpInvariant: BigNumberish,
+  fpBalances: bigint[],
+  fpInvariant: bigint,
   tokenIndex: number
 ): bigint {
   const invariant = fromFp(fpInvariant);
@@ -150,7 +149,7 @@ export function getTokenBalanceGivenInvariantAndAllOtherBalances(
 
 function _getTokenBalanceGivenInvariantAndAllOtherBalances(
   balances: Decimal[],
-  amplificationParameter: Decimal | BigNumberish,
+  amplificationParameter: Decimal | bigint,
   invariant: Decimal,
   tokenIndex: number
 ): Decimal {

--- a/pvt/helpers/src/math/weighted.ts
+++ b/pvt/helpers/src/math/weighted.ts
@@ -1,9 +1,8 @@
-import { BigNumberish } from 'ethers';
 import { Decimal } from 'decimal.js';
 
-import { bn, decimal, fp, fromFp, toFp, fpMul, fpDiv, FP_ONE, FP_100_PCT } from '../numbers';
+import { bn, decimal, fp, fromFp, toFp, FP_ONE, FP_100_PCT } from '../numbers';
 
-export function computeInvariant(fpRawBalances: BigNumberish[], fpRawWeights: BigNumberish[]): bigint {
+export function computeInvariant(fpRawBalances: bigint[], fpRawWeights: bigint[]): bigint {
   const normalizedWeights = fpRawWeights.map(fromFp);
   const balances = fpRawBalances.map(decimal);
   const invariant = balances.reduce((inv, balance, i) => inv.mul(balance.pow(normalizedWeights[i])), decimal(1));
@@ -11,40 +10,40 @@ export function computeInvariant(fpRawBalances: BigNumberish[], fpRawWeights: Bi
 }
 
 export function computeOutGivenExactIn(
-  fpBalanceIn: BigNumberish,
-  fpWeightIn: BigNumberish,
-  fpBalanceOut: BigNumberish,
-  fpWeightOut: BigNumberish,
-  fpAmountIn: BigNumberish
+  fpBalanceIn: bigint,
+  fpWeightIn: bigint,
+  fpBalanceOut: bigint,
+  fpWeightOut: bigint,
+  fpAmountIn: bigint
 ): bigint {
   const newBalance = fromFp(fpBalanceIn).add(fromFp(fpAmountIn));
   const base = fromFp(fpBalanceIn).div(newBalance);
   const exponent = fromFp(fpWeightIn).div(fromFp(fpWeightOut));
   const ratio = decimal(1).sub(base.pow(exponent));
-  return bn(toFp(fromFp(fpBalanceOut).mul(ratio)));
+  return fp(fromFp(fpBalanceOut).mul(ratio));
 }
 
 export function computeInGivenExactOut(
-  fpBalanceIn: BigNumberish,
-  fpWeightIn: BigNumberish,
-  fpBalanceOut: BigNumberish,
-  fpWeightOut: BigNumberish,
-  fpAmountOut: BigNumberish
+  fpBalanceIn: bigint,
+  fpWeightIn: bigint,
+  fpBalanceOut: bigint,
+  fpWeightOut: bigint,
+  fpAmountOut: bigint
 ): bigint {
   const newBalance = fromFp(fpBalanceOut).sub(fromFp(fpAmountOut));
   const base = fromFp(fpBalanceOut).div(newBalance);
   const exponent = fromFp(fpWeightOut).div(fromFp(fpWeightIn));
   const ratio = base.pow(exponent).sub(1);
-  return bn(toFp(fromFp(fpBalanceIn).mul(ratio)));
+  return fp(fromFp(fpBalanceIn).mul(ratio));
 }
 
 export function computeBptOutGivenExactTokensIn(
-  fpBalances: BigNumberish[],
-  fpWeights: BigNumberish[],
-  fpAmountsIn: BigNumberish[],
-  fpBptTotalSupply: BigNumberish,
-  fpSwapFeePercentage: BigNumberish
-): BigNumberish {
+  fpBalances: bigint[],
+  fpWeights: bigint[],
+  fpAmountsIn: bigint[],
+  fpBptTotalSupply: bigint,
+  fpSwapFeePercentage: bigint
+): bigint {
   const weights = fpWeights.map(fromFp);
   const balances = fpBalances.map(fromFp);
   const amountsIn = fpAmountsIn.map(fromFp);
@@ -79,12 +78,12 @@ export function computeBptOutGivenExactTokensIn(
 }
 
 export function computeBptOutGivenExactTokenIn(
-  fpBalance: BigNumberish,
-  fpWeight: BigNumberish,
-  fpAmountIn: BigNumberish,
-  fpBptTotalSupply: BigNumberish,
-  fpSwapFeePercentage: BigNumberish
-): BigNumberish {
+  fpBalance: bigint,
+  fpWeight: bigint,
+  fpAmountIn: bigint,
+  fpBptTotalSupply: bigint,
+  fpSwapFeePercentage: bigint
+): bigint {
   const balance = fromFp(fpBalance);
   const normalizedWeight = fromFp(fpWeight);
   const amountIn = fromFp(fpAmountIn);
@@ -119,12 +118,12 @@ export function computeBptOutGivenExactTokenIn(
 }
 
 export function computeTokenInGivenExactBptOut(
-  fpBalance: BigNumberish,
-  fpWeight: BigNumberish,
-  fpBptAmountOut: BigNumberish,
-  fpBptTotalSupply: BigNumberish,
-  fpSwapFeePercentage: BigNumberish
-): BigNumberish {
+  fpBalance: bigint,
+  fpWeight: bigint,
+  fpBptAmountOut: bigint,
+  fpBptTotalSupply: bigint,
+  fpSwapFeePercentage: bigint
+): bigint {
   const bptAmountOut = fromFp(fpBptAmountOut);
   const bptTotalSupply = fromFp(fpBptTotalSupply);
   const weight = fromFp(fpWeight);
@@ -186,12 +185,12 @@ export function computeBptInGivenExactTokensOut(
 }
 
 export function computeBptInGivenExactTokenOut(
-  fpBalance: BigNumberish,
-  fpWeight: BigNumberish,
-  fpAmountOut: BigNumberish,
-  fpBptTotalSupply: BigNumberish,
-  fpSwapFeePercentage: BigNumberish
-): BigNumberish {
+  fpBalance: bigint,
+  fpWeight: bigint,
+  fpAmountOut: bigint,
+  fpBptTotalSupply: bigint,
+  fpSwapFeePercentage: bigint
+): bigint {
   const balance = fromFp(fpBalance);
   const normalizedWeight = fromFp(fpWeight);
   const amountOut = fromFp(fpAmountOut);
@@ -227,12 +226,12 @@ export function computeBptInGivenExactTokenOut(
 }
 
 export function computeTokenOutGivenExactBptIn(
-  fpBalance: BigNumberish,
-  fpWeight: BigNumberish,
-  fpBptAmountIn: BigNumberish,
-  fpBptTotalSupply: BigNumberish,
-  fpSwapFeePercentage: BigNumberish
-): BigNumberish {
+  fpBalance: bigint,
+  fpWeight: bigint,
+  fpBptAmountIn: bigint,
+  fpBptTotalSupply: bigint,
+  fpSwapFeePercentage: bigint
+): bigint {
   const bptAmountIn = fromFp(fpBptAmountIn);
   const bptTotalSupply = fromFp(fpBptTotalSupply);
   const swapFeePercentage = fromFp(fpSwapFeePercentage);
@@ -249,9 +248,9 @@ export function computeTokenOutGivenExactBptIn(
 }
 
 export function computeTokensOutGivenExactBptIn(
-  fpBalances: BigNumberish[],
-  fpBptAmountIn: BigNumberish,
-  fpBptTotalSupply: BigNumberish
+  fpBalances: bigint[],
+  fpBptAmountIn: bigint,
+  fpBptTotalSupply: bigint
 ): bigint[] {
   const balances = fpBalances.map(fromFp);
   const bptRatio = fromFp(fpBptAmountIn).div(fromFp(fpBptTotalSupply));
@@ -260,9 +259,9 @@ export function computeTokensOutGivenExactBptIn(
 }
 
 export function computeOneTokenSwapFeeAmount(
-  fpBalances: BigNumberish[],
-  fpWeights: BigNumberish[],
-  lastInvariant: BigNumberish,
+  fpBalances: bigint[],
+  fpWeights: bigint[],
+  lastInvariant: bigint,
   tokenIndex: number
 ): Decimal {
   const balance = fpBalances.map(fromFp)[tokenIndex];
@@ -276,10 +275,10 @@ export function computeOneTokenSwapFeeAmount(
 }
 
 export function computeBPTSwapFeeAmount(
-  fpInvariantGrowthRatio: BigNumberish,
-  preSupply: BigNumberish,
-  postSupply: BigNumberish,
-  fpProtocolSwapFeePercentage: BigNumberish
+  fpInvariantGrowthRatio: bigint,
+  preSupply: bigint,
+  postSupply: bigint,
+  fpProtocolSwapFeePercentage: bigint
 ): bigint {
   const supplyGrowthRatio = fpDiv(postSupply, preSupply);
 
@@ -296,9 +295,9 @@ export function computeBPTSwapFeeAmount(
 }
 
 export function computeMaxOneTokenSwapFeeAmount(
-  fpBalances: BigNumberish[],
-  fpWeights: BigNumberish[],
-  fpMinInvariantRatio: BigNumberish,
+  fpBalances: bigint[],
+  fpWeights: bigint[],
+  fpMinInvariantRatio: bigint,
   tokenIndex: number
 ): Decimal {
   const balance = fpBalances.map(fromFp)[tokenIndex];
@@ -310,19 +309,19 @@ export function computeMaxOneTokenSwapFeeAmount(
   return toFp(maxAccruedFees);
 }
 
-export function computeSpotPrice(fpBalances: BigNumberish[], fpWeights: BigNumberish[]): bigint {
+export function computeSpotPrice(fpBalances: bigint[], fpWeights: bigint[]): bigint {
   const numerator = fromFp(fpBalances[0]).div(fromFp(fpWeights[0]));
   const denominator = fromFp(fpBalances[1]).div(fromFp(fpWeights[1]));
-  return bn(toFp(numerator.div(denominator)).toFixed(0));
+  return fp(numerator.div(denominator).toFixed(0));
 }
 
-export function computeBPTPrice(fpBalance: BigNumberish, fpWeight: BigNumberish, totalSupply: BigNumberish): bigint {
-  return bn(toFp(fromFp(fpBalance).div(fromFp(fpWeight)).div(fromFp(totalSupply))).toFixed(0));
+export function computeBPTPrice(fpBalance: bigint, fpWeight: bigint, totalSupply: bigint): bigint {
+  return fp(fromFp(fpBalance).div(fromFp(fpWeight)).div(fromFp(totalSupply)).toFixed(0));
 }
 
-export function computeBptOutAddToken(totalSupply: BigNumberish, fpWeight: BigNumberish): bigint {
+export function computeBptOutAddToken(totalSupply: bigint, fpWeight: bigint): bigint {
   const weightSumRatio = decimal(1).div(decimal(1).sub(fromFp(fpWeight)));
-  return bn(toFp(fromFp(totalSupply).mul(weightSumRatio.sub(1))));
+  return fp(fromFp(totalSupply).mul(weightSumRatio.sub(1)));
 }
 
 function complement(val: Decimal) {


### PR DESCRIPTION
# Description

This PR removes the unnecessary cast BigNumbership to bigint in math js tests.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
