### PR TITLE
Wrapped BPT

### DIFF
--- a/pkg/interfaces/contracts/vault/IWrappedBalancerPoolToken.sol
+++ b/pkg/interfaces/contracts/vault/IWrappedBalancerPoolToken.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+interface IWrappedBalancerPoolToken {
+    /// @notice The vault is unlocked
+    error VaultIsUnlocked();
+
+    /**
+     * @notice Mints wrapped BPTs in exchange for locked BPTs
+     * @param amount The amount of locked BPTs to exchange for wrapped BPTs
+     */
+    function mint(uint256 amount) external;
+
+    /**
+     * @notice Burns wrapped BPTs to unlock the underlying locked BPTs
+     * @param value The amount of wrapped BPTs to burn in order to unlock locked BPTs
+     */
+    function burn(uint256 value) external;
+
+    /**
+     * @notice Burns wrapped BPTs on behalf of an approved account to unlock their locked BPTs
+     * @param account The address from which the wrapped BPTs will be burned
+     * @param value The amount of wrapped BPTs to burn in order to unlock locked BPTs
+     */
+    function burnFrom(address account, uint256 value) external;
+}

--- a/pkg/interfaces/contracts/vault/IWrappedBalancerPoolToken.sol
+++ b/pkg/interfaces/contracts/vault/IWrappedBalancerPoolToken.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.24;
 
+/// @notice Interface for wrapped Balancer pool tokens
 interface IWrappedBalancerPoolToken {
     /// @notice The vault is unlocked
     error VaultIsUnlocked();

--- a/pkg/interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol
+++ b/pkg/interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+interface IWrappedBalancerPoolTokenFactory {
+    /// @notice The wrapped BPT already exists
+    error WrappedBPTAlreadyExists(address wrappedToken);
+
+    /// @notice The Balancer pool token has not been initialized
+    error BalancerPoolTokenNotInitialized();
+
+    /// @notice Wrapped Token was created
+    event WrappedTokenCreated(address indexed bpt, address wrappedToken);
+
+    /// @notice Creates a wrapped token for the given Balancer pool token
+    /// @param bpt The Balancer pool token to wrap
+    /// @return address The wrapped token address
+    function createWrappedToken(address bpt) external returns (address);
+
+    /// @notice Gets the wrapped token for the given Balancer pool token
+    /// @param bpt The Balancer pool token
+    /// @return address The wrapped token address
+    function getWrappedToken(address bpt) external view returns (address);
+}

--- a/pkg/interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol
+++ b/pkg/interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.24;
 
+/// @notice Interface for factory contract for creating wrapped Balancer pool tokens
 interface IWrappedBalancerPoolTokenFactory {
     /// @notice The wrapped BPT already exists
     error WrappedBPTAlreadyExists(address wrappedToken);

--- a/pkg/interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol
+++ b/pkg/interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol
@@ -11,15 +11,19 @@ interface IWrappedBalancerPoolTokenFactory {
     error BalancerPoolTokenNotInitialized();
 
     /// @notice Wrapped Token was created
-    event WrappedTokenCreated(address indexed bpt, address wrappedToken);
+    event WrappedTokenCreated(address indexed balancerPoolToken, address wrappedToken);
 
-    /// @notice Creates a wrapped token for the given Balancer pool token
-    /// @param bpt The Balancer pool token to wrap
-    /// @return address The wrapped token address
-    function createWrappedToken(address bpt) external returns (address);
+    /**
+     * @notice Creates a wrapped token for the given Balancer pool token
+     * @param balancerPoolToken The Balancer pool token to wrap
+     * @return address The wrapped token address
+     */
+    function createWrappedToken(address balancerPoolToken) external returns (address);
 
-    /// @notice Gets the wrapped token for the given Balancer pool token
-    /// @param bpt The Balancer pool token
-    /// @return address The wrapped token address
-    function getWrappedToken(address bpt) external view returns (address);
+    /**
+     * @notice Gets the wrapped token for the given Balancer pool token
+     * @param balancerPoolToken The Balancer pool token
+     * @return address The wrapped token address
+     */
+    function getWrappedToken(address balancerPoolToken) external view returns (address);
 }

--- a/pkg/vault/contracts/WrappedBalancerPoolToken.sol
+++ b/pkg/vault/contracts/WrappedBalancerPoolToken.sol
@@ -11,24 +11,26 @@ import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol"
 import { IWrappedBalancerPoolToken } from "@balancer-labs/v3-interfaces/contracts/vault/IWrappedBalancerPoolToken.sol";
 
 /**
- * @notice ERC20 wrapper for Balancer Pool Token (BPT), allowing users to deposit BPT
- * and receive 1:1 wrapped tokens, or burn wrapped tokens to redeem the original BPT.
+ * @notice ERC20 wrapper for Balancer Pool Token (BPT).
+ * @dev This allows users to deposit BPT and receive wrapped tokens 1:1, or burn wrapped tokens to redeem the original
+ * amount of BPT.
+ *
  * Minting and burning are only allowed when the Vault is locked.
  */
 contract WrappedBalancerPoolToken is IWrappedBalancerPoolToken, ERC20, ERC20Permit {
     using SafeERC20 for *;
 
-    IERC20 public immutable bpt;
+    IERC20 public immutable balancerPoolToken;
     IVault public immutable vault;
 
     constructor(
         IVault vault_,
-        IERC20 bpt_,
+        IERC20 balancerPoolToken_,
         string memory name,
         string memory symbol
     ) ERC20(name, symbol) ERC20Permit(name) {
         vault = vault_;
-        bpt = bpt_;
+        balancerPoolToken = balancerPoolToken_;
     }
 
     modifier onlyIfVaultLocked() {
@@ -40,7 +42,7 @@ contract WrappedBalancerPoolToken is IWrappedBalancerPoolToken, ERC20, ERC20Perm
 
     /// @inheritdoc IWrappedBalancerPoolToken
     function mint(uint256 amount) public onlyIfVaultLocked {
-        bpt.safeTransferFrom(msg.sender, address(this), amount);
+        balancerPoolToken.safeTransferFrom(msg.sender, address(this), amount);
 
         _mint(msg.sender, amount);
     }
@@ -60,6 +62,6 @@ contract WrappedBalancerPoolToken is IWrappedBalancerPoolToken, ERC20, ERC20Perm
     function _burnAndTransfer(address account, uint256 value) internal {
         _burn(account, value);
 
-        bpt.transfer(account, value);
+        balancerPoolToken.transfer(account, value);
     }
 }

--- a/pkg/vault/contracts/WrappedBalancerPoolToken.sol
+++ b/pkg/vault/contracts/WrappedBalancerPoolToken.sol
@@ -10,6 +10,11 @@ import { ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/ERC2
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import { IWrappedBalancerPoolToken } from "@balancer-labs/v3-interfaces/contracts/vault/IWrappedBalancerPoolToken.sol";
 
+/**
+ * @notice ERC20 wrapper for Balancer Pool Token (BPT), allowing users to deposit BPT
+ * and receive 1:1 wrapped tokens, or burn wrapped tokens to redeem the original BPT.
+ * Minting and burning are only allowed when the Vault is locked.
+ */
 contract WrappedBalancerPoolToken is IWrappedBalancerPoolToken, ERC20, ERC20Permit {
     using SafeERC20 for *;
 

--- a/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
+++ b/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import {
+    IWrappedBalancerPoolTokenFactory
+} from "@balancer-labs/v3-interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol";
+
+import { WrappedBalancerPoolToken } from "./WrappedBalancerPoolToken.sol";
+
+contract WrappedBalancerPoolTokenFactory is IWrappedBalancerPoolTokenFactory {
+    IVault internal immutable vault;
+    mapping(address => address) internal _wrappedTokens;
+
+    constructor(IVault vault_) {
+        vault = vault_;
+    }
+
+    /// @inheritdoc IWrappedBalancerPoolTokenFactory
+    function createWrappedToken(address bpt) external returns (address) {
+        address wrappedToken = _wrappedTokens[bpt];
+        if (wrappedToken != address(0)) {
+            revert WrappedBPTAlreadyExists(wrappedToken);
+        }
+
+        if (!vault.isPoolInitialized(address(bpt))) {
+            revert BalancerPoolTokenNotInitialized();
+        }
+
+        string memory name = string(abi.encodePacked("Wrapped ", IERC20Metadata(bpt).name()));
+        string memory symbol = string(abi.encodePacked("w", IERC20Metadata(bpt).symbol()));
+        wrappedToken = address(new WrappedBalancerPoolToken(vault, IERC20(bpt), name, symbol));
+
+        _wrappedTokens[address(bpt)] = wrappedToken;
+        emit WrappedTokenCreated(bpt, wrappedToken);
+
+        return address(wrappedToken);
+    }
+
+    /// @inheritdoc IWrappedBalancerPoolTokenFactory
+    function getWrappedToken(address bpt) external view returns (address) {
+        return _wrappedTokens[bpt];
+    }
+}

--- a/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
+++ b/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
@@ -12,6 +12,7 @@ import {
 
 import { WrappedBalancerPoolToken } from "./WrappedBalancerPoolToken.sol";
 
+/// @notice Factory contract for creating wrapped Balancer pool tokens
 contract WrappedBalancerPoolTokenFactory is IWrappedBalancerPoolTokenFactory {
     IVault internal immutable _vault;
     mapping(address => address) internal _wrappedTokens;

--- a/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
+++ b/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
@@ -17,33 +17,33 @@ contract WrappedBalancerPoolTokenFactory is IWrappedBalancerPoolTokenFactory {
     IVault internal immutable _vault;
     mapping(address => address) internal _wrappedTokens;
 
-    constructor(IVault vault_) {
-        _vault = vault_;
+    constructor(IVault vault) {
+        _vault = vault;
     }
 
     /// @inheritdoc IWrappedBalancerPoolTokenFactory
-    function createWrappedToken(address bpt) external returns (address) {
-        address wrappedToken = _wrappedTokens[bpt];
+    function createWrappedToken(address balancerPoolToken) external returns (address) {
+        address wrappedToken = _wrappedTokens[balancerPoolToken];
         if (wrappedToken != address(0)) {
             revert WrappedBPTAlreadyExists(wrappedToken);
         }
 
-        if (!_vault.isPoolInitialized(address(bpt))) {
+        if (_vault.isPoolInitialized(address(balancerPoolToken)) == false) {
             revert BalancerPoolTokenNotInitialized();
         }
 
-        string memory name = string(abi.encodePacked("Wrapped ", IERC20Metadata(bpt).name()));
-        string memory symbol = string(abi.encodePacked("w", IERC20Metadata(bpt).symbol()));
-        wrappedToken = address(new WrappedBalancerPoolToken(_vault, IERC20(bpt), name, symbol));
+        string memory name = string(abi.encodePacked("Wrapped ", IERC20Metadata(balancerPoolToken).name()));
+        string memory symbol = string(abi.encodePacked("w", IERC20Metadata(balancerPoolToken).symbol()));
+        wrappedToken = address(new WrappedBalancerPoolToken(_vault, IERC20(balancerPoolToken), name, symbol));
 
-        _wrappedTokens[address(bpt)] = wrappedToken;
-        emit WrappedTokenCreated(bpt, wrappedToken);
+        _wrappedTokens[address(balancerPoolToken)] = wrappedToken;
+        emit WrappedTokenCreated(balancerPoolToken, wrappedToken);
 
         return address(wrappedToken);
     }
 
     /// @inheritdoc IWrappedBalancerPoolTokenFactory
-    function getWrappedToken(address bpt) external view returns (address) {
-        return _wrappedTokens[bpt];
+    function getWrappedToken(address balancerPoolToken) external view returns (address) {
+        return _wrappedTokens[balancerPoolToken];
     }
 }

--- a/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
+++ b/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
@@ -5,10 +5,10 @@ pragma solidity ^0.8.24;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
-import { IVault } from "@balancer-labs/v3-interfaces/contracts/_vault/IVault.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import {
     IWrappedBalancerPoolTokenFactory
-} from "@balancer-labs/v3-interfaces/contracts/_vault/IWrappedBalancerPoolTokenFactory.sol";
+} from "@balancer-labs/v3-interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol";
 
 import { WrappedBalancerPoolToken } from "./WrappedBalancerPoolToken.sol";
 

--- a/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
+++ b/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
@@ -5,19 +5,19 @@ pragma solidity ^0.8.24;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
-import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/_vault/IVault.sol";
 import {
     IWrappedBalancerPoolTokenFactory
-} from "@balancer-labs/v3-interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol";
+} from "@balancer-labs/v3-interfaces/contracts/_vault/IWrappedBalancerPoolTokenFactory.sol";
 
 import { WrappedBalancerPoolToken } from "./WrappedBalancerPoolToken.sol";
 
 contract WrappedBalancerPoolTokenFactory is IWrappedBalancerPoolTokenFactory {
-    IVault internal immutable vault;
+    IVault internal immutable _vault;
     mapping(address => address) internal _wrappedTokens;
 
     constructor(IVault vault_) {
-        vault = vault_;
+        _vault = vault_;
     }
 
     /// @inheritdoc IWrappedBalancerPoolTokenFactory
@@ -27,13 +27,13 @@ contract WrappedBalancerPoolTokenFactory is IWrappedBalancerPoolTokenFactory {
             revert WrappedBPTAlreadyExists(wrappedToken);
         }
 
-        if (!vault.isPoolInitialized(address(bpt))) {
+        if (!_vault.isPoolInitialized(address(bpt))) {
             revert BalancerPoolTokenNotInitialized();
         }
 
         string memory name = string(abi.encodePacked("Wrapped ", IERC20Metadata(bpt).name()));
         string memory symbol = string(abi.encodePacked("w", IERC20Metadata(bpt).symbol()));
-        wrappedToken = address(new WrappedBalancerPoolToken(vault, IERC20(bpt), name, symbol));
+        wrappedToken = address(new WrappedBalancerPoolToken(_vault, IERC20(bpt), name, symbol));
 
         _wrappedTokens[address(bpt)] = wrappedToken;
         emit WrappedTokenCreated(bpt, wrappedToken);

--- a/pkg/vault/test/foundry/WrappedBalancerPoolToken.t.sol
+++ b/pkg/vault/test/foundry/WrappedBalancerPoolToken.t.sol
@@ -22,7 +22,7 @@ contract WrappedBalancerPoolTokenTest is BaseVaultTest {
 
     function testConstructor() public view {
         assertEq(address(wBPT.vault()), address(vault), "Invalid vault address");
-        assertEq(address(wBPT.bpt()), pool, "Invalid pool address");
+        assertEq(address(wBPT.balancerPoolToken()), pool, "Invalid pool address");
     }
 
     function testMint() public {
@@ -37,6 +37,8 @@ contract WrappedBalancerPoolTokenTest is BaseVaultTest {
 
         assertEq(bpt.balanceOf(lp), balanceBefore - DEFAULT_AMOUNT, "Invalid BPT balance");
         assertEq(wBPT.balanceOf(lp), DEFAULT_AMOUNT, "Invalid wBPT balance");
+        assertEq(bpt.balanceOf(address(wBPT)), wBPT.totalSupply(), "Invalid BPT balance in wBPT");
+        assertEq(wBPT.totalSupply(), DEFAULT_AMOUNT, "Invalid wBPT total supply");
     }
 
     function testMintIfVaultUnlocked() public {
@@ -59,6 +61,8 @@ contract WrappedBalancerPoolTokenTest is BaseVaultTest {
 
         assertEq(bpt.balanceOf(lp), balanceBefore + DEFAULT_AMOUNT, "Invalid BPT balance");
         assertEq(wBPT.balanceOf(lp), 0, "Invalid wBPT balance");
+        assertEq(bpt.balanceOf(address(wBPT)), wBPT.totalSupply(), "Invalid BPT balance in wBPT");
+        assertEq(wBPT.totalSupply(), 0, "Invalid wBPT total supply");
     }
 
     function testBurnIfVaultUnlocked() public {
@@ -86,6 +90,8 @@ contract WrappedBalancerPoolTokenTest is BaseVaultTest {
 
         assertEq(bpt.balanceOf(lp), balanceBefore + DEFAULT_AMOUNT, "Invalid BPT balance");
         assertEq(wBPT.balanceOf(lp), 0, "Invalid wBPT balance");
+        assertEq(bpt.balanceOf(address(wBPT)), wBPT.totalSupply(), "Invalid BPT balance in wBPT");
+        assertEq(wBPT.totalSupply(), 0, "Invalid wBPT total supply");
     }
 
     function testBurnFromIfVaultUnlocked() public {

--- a/pkg/vault/test/foundry/WrappedBalancerPoolToken.t.sol
+++ b/pkg/vault/test/foundry/WrappedBalancerPoolToken.t.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IWrappedBalancerPoolToken } from "@balancer-labs/v3-interfaces/contracts/vault/IWrappedBalancerPoolToken.sol";
+
+import { WrappedBalancerPoolToken } from "../../contracts/WrappedBalancerPoolToken.sol";
+import { BaseVaultTest } from "./utils/BaseVaultTest.sol";
+
+contract WrappedBalancerPoolTokenTest is BaseVaultTest {
+    WrappedBalancerPoolToken public wBPT;
+
+    function setUp() public virtual override {
+        BaseVaultTest.setUp();
+
+        wBPT = new WrappedBalancerPoolToken(vault, IERC20(pool), "Wrapped BPT", "wBPT");
+    }
+
+    function testConstructor() public view {
+        assertEq(address(wBPT.vault()), address(vault), "Invalid vault address");
+        assertEq(address(wBPT.bpt()), pool, "Invalid pool address");
+    }
+
+    function testMint() public {
+        IERC20 bpt = IERC20(pool);
+
+        uint256 balanceBefore = bpt.balanceOf(lp);
+
+        vm.startPrank(lp);
+        bpt.approve(address(wBPT), DEFAULT_AMOUNT);
+        wBPT.mint(DEFAULT_AMOUNT);
+        vm.stopPrank();
+
+        assertEq(bpt.balanceOf(lp), balanceBefore - DEFAULT_AMOUNT, "Invalid BPT balance");
+        assertEq(wBPT.balanceOf(lp), DEFAULT_AMOUNT, "Invalid wBPT balance");
+    }
+
+    function testMintIfVaultUnlocked() public {
+        vault.forceUnlock();
+
+        vm.expectRevert(IWrappedBalancerPoolToken.VaultIsUnlocked.selector);
+        wBPT.mint(DEFAULT_AMOUNT);
+    }
+
+    function testBurn() public {
+        IERC20 bpt = IERC20(pool);
+
+        vm.startPrank(lp);
+        bpt.approve(address(wBPT), DEFAULT_AMOUNT);
+        wBPT.mint(DEFAULT_AMOUNT);
+
+        uint256 balanceBefore = bpt.balanceOf(lp);
+        wBPT.burn(DEFAULT_AMOUNT);
+        vm.stopPrank();
+
+        assertEq(bpt.balanceOf(lp), balanceBefore + DEFAULT_AMOUNT, "Invalid BPT balance");
+        assertEq(wBPT.balanceOf(lp), 0, "Invalid wBPT balance");
+    }
+
+    function testBurnIfVaultUnlocked() public {
+        vault.forceUnlock();
+
+        vm.expectRevert(IWrappedBalancerPoolToken.VaultIsUnlocked.selector);
+        wBPT.burn(DEFAULT_AMOUNT);
+    }
+
+    function testBurnFrom() public {
+        IERC20 bpt = IERC20(pool);
+
+        vm.startPrank(lp);
+        bpt.approve(address(wBPT), DEFAULT_AMOUNT);
+        wBPT.mint(DEFAULT_AMOUNT);
+        vm.stopPrank();
+
+        uint256 balanceBefore = bpt.balanceOf(lp);
+
+        vm.prank(lp);
+        wBPT.approve(alice, DEFAULT_AMOUNT);
+
+        vm.prank(alice);
+        wBPT.burnFrom(lp, DEFAULT_AMOUNT);
+
+        assertEq(bpt.balanceOf(lp), balanceBefore + DEFAULT_AMOUNT, "Invalid BPT balance");
+        assertEq(wBPT.balanceOf(lp), 0, "Invalid wBPT balance");
+    }
+
+    function testBurnFromIfVaultUnlocked() public {
+        vault.forceUnlock();
+
+        vm.expectRevert(IWrappedBalancerPoolToken.VaultIsUnlocked.selector);
+        wBPT.burnFrom(lp, DEFAULT_AMOUNT);
+    }
+}

--- a/pkg/vault/test/foundry/WrappedBalancerPoolTokenFactory.t.sol
+++ b/pkg/vault/test/foundry/WrappedBalancerPoolTokenFactory.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+import {
+    IWrappedBalancerPoolTokenFactory
+} from "@balancer-labs/v3-interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol";
+
+import { WrappedBalancerPoolTokenFactory } from "../../contracts/WrappedBalancerPoolTokenFactory.sol";
+import { BaseVaultTest } from "./utils/BaseVaultTest.sol";
+
+contract WrappedBalancerPoolTokenFactoryTest is BaseVaultTest {
+    WrappedBalancerPoolTokenFactory factory;
+
+    function setUp() public virtual override {
+        BaseVaultTest.setUp();
+
+        factory = new WrappedBalancerPoolTokenFactory(vault);
+    }
+
+    function testCreateWrappedToken() public {
+        assertEq(factory.getWrappedToken(pool), ZERO_ADDRESS, "Wrapped token should not exist");
+
+        // get a wrapped token address
+        uint256 snapshot = vm.snapshot();
+        address wrappedToken = factory.createWrappedToken(pool);
+        vm.revertTo(snapshot);
+
+        emit IWrappedBalancerPoolTokenFactory.WrappedTokenCreated(pool, wrappedToken);
+        factory.createWrappedToken(pool);
+
+        assertEq(factory.getWrappedToken(pool), wrappedToken, "Wrapped token should exist");
+
+        assertEq(IERC20Metadata(wrappedToken).name(), "Wrapped ERC20 Pool", "Wrapped token name should be correct");
+        assertEq(IERC20Metadata(wrappedToken).symbol(), "wERC20POOL", "Wrapped token symbol should be correct");
+    }
+
+    function testCreateWithExistingWrappedToken() public {
+        address wrappedToken = factory.createWrappedToken(pool);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IWrappedBalancerPoolTokenFactory.WrappedBPTAlreadyExists.selector, wrappedToken)
+        );
+        factory.createWrappedToken(pool);
+    }
+
+    function testCreateWhenPoolNotInitialized() public {
+        vault.manualSetInitializedPool(pool, false);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IWrappedBalancerPoolTokenFactory.BalancerPoolTokenNotInitialized.selector)
+        );
+        factory.createWrappedToken(pool);
+    }
+}


### PR DESCRIPTION
# Description

The current BPT can be minted on credit as long as the vault is unlocked. This means we cannot use BPT as a token in a pool or in flash loan protocols. This PR fixes that and introduces a wrapped BPT (wBPT), which allows minting only when the Vault is locked.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #1332
<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
