### PR TITLE
Add disable flag for wrapped bpt factory

### DIFF
--- a/pkg/interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol
+++ b/pkg/interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol
@@ -7,8 +7,11 @@ interface IWrappedBalancerPoolTokenFactory {
     /// @notice The wrapped BPT already exists
     error WrappedBPTAlreadyExists(address wrappedToken);
 
-    /// @notice The factory is paused
-    error FactoryPaused();
+    /// @notice The factory was disabled by governance.
+    event FactoryDisabled();
+
+    /// @notice Attempted wrapped token creation after the factory was disabled.
+    error Disabled();
 
     /// @notice The Balancer pool token has not been initialized
     error BalancerPoolTokenNotInitialized();
@@ -31,14 +34,15 @@ interface IWrappedBalancerPoolTokenFactory {
     function getWrappedToken(address balancerPoolToken) external view returns (address);
 
     /**
-     * @notice Sets the factory to be disabled or enabled
-     * @param disabled True to disable the factory, false to enable it
+     * @notice Disables the factory
      */
-    function setDisabled(bool disabled) external;
+    function disable() external;
 
     /**
      * @notice Checks if the factory is disabled
      * @return bool True if the factory is disabled, false if it is enabled
      */
     function isDisabled() external view returns (bool);
+
+    
 }

--- a/pkg/interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol
+++ b/pkg/interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol
@@ -43,6 +43,4 @@ interface IWrappedBalancerPoolTokenFactory {
      * @return bool True if the factory is disabled, false if it is enabled
      */
     function isDisabled() external view returns (bool);
-
-    
 }

--- a/pkg/interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol
+++ b/pkg/interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol
@@ -7,6 +7,9 @@ interface IWrappedBalancerPoolTokenFactory {
     /// @notice The wrapped BPT already exists
     error WrappedBPTAlreadyExists(address wrappedToken);
 
+    /// @notice The factory is paused
+    error FactoryPaused();
+
     /// @notice The Balancer pool token has not been initialized
     error BalancerPoolTokenNotInitialized();
 
@@ -26,4 +29,16 @@ interface IWrappedBalancerPoolTokenFactory {
      * @return address The wrapped token address
      */
     function getWrappedToken(address balancerPoolToken) external view returns (address);
+
+    /**
+     * @notice Sets the factory to be disabled or enabled
+     * @param disabled True to disable the factory, false to enable it
+     */
+    function setDisabled(bool disabled) external;
+
+    /**
+     * @notice Checks if the factory is disabled
+     * @return bool True if the factory is disabled, false if it is enabled
+     */
+    function isDisabled() external view returns (bool);
 }

--- a/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
+++ b/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
@@ -24,7 +24,7 @@ contract WrappedBalancerPoolTokenFactory is IWrappedBalancerPoolTokenFactory, Si
 
     modifier notDisabled() {
         if (_isDisabled) {
-            revert FactoryPaused();
+            revert Disabled();
         }
         _;
     }
@@ -56,8 +56,10 @@ contract WrappedBalancerPoolTokenFactory is IWrappedBalancerPoolTokenFactory, Si
     }
 
     /// @inheritdoc IWrappedBalancerPoolTokenFactory
-    function setDisabled(bool disabled) external {
-        _isDisabled = disabled;
+    function disable() external notDisabled authenticate {
+        _isDisabled = true;
+
+        emit FactoryDisabled();
     }
 
     /// @inheritdoc IWrappedBalancerPoolTokenFactory

--- a/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
+++ b/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
@@ -9,8 +9,8 @@ import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol"
 import {
     IWrappedBalancerPoolTokenFactory
 } from "@balancer-labs/v3-interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol";
-import { SingletonAuthentication } from "@balancer-labs/v3-vault/contracts/SingletonAuthentication.sol";
 
+import { SingletonAuthentication } from "./SingletonAuthentication.sol";
 import { WrappedBalancerPoolToken } from "./WrappedBalancerPoolToken.sol";
 
 /// @notice Factory contract for creating wrapped Balancer pool tokens

--- a/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
+++ b/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
@@ -9,32 +9,40 @@ import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol"
 import {
     IWrappedBalancerPoolTokenFactory
 } from "@balancer-labs/v3-interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol";
+import { SingletonAuthentication } from "@balancer-labs/v3-vault/contracts/SingletonAuthentication.sol";
 
 import { WrappedBalancerPoolToken } from "./WrappedBalancerPoolToken.sol";
 
 /// @notice Factory contract for creating wrapped Balancer pool tokens
-contract WrappedBalancerPoolTokenFactory is IWrappedBalancerPoolTokenFactory {
-    IVault internal immutable _vault;
+contract WrappedBalancerPoolTokenFactory is IWrappedBalancerPoolTokenFactory, SingletonAuthentication {
+    bool private _isDisabled;
     mapping(address => address) internal _wrappedTokens;
 
-    constructor(IVault vault) {
-        _vault = vault;
+    constructor(IVault vault) SingletonAuthentication(vault) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    modifier notDisabled() {
+        if (_isDisabled) {
+            revert FactoryPaused();
+        }
+        _;
     }
 
     /// @inheritdoc IWrappedBalancerPoolTokenFactory
-    function createWrappedToken(address balancerPoolToken) external returns (address) {
+    function createWrappedToken(address balancerPoolToken) external notDisabled authenticate returns (address) {
         address wrappedToken = _wrappedTokens[balancerPoolToken];
         if (wrappedToken != address(0)) {
             revert WrappedBPTAlreadyExists(wrappedToken);
         }
 
-        if (_vault.isPoolInitialized(address(balancerPoolToken)) == false) {
+        if (getVault().isPoolInitialized(address(balancerPoolToken)) == false) {
             revert BalancerPoolTokenNotInitialized();
         }
 
         string memory name = string(abi.encodePacked("Wrapped ", IERC20Metadata(balancerPoolToken).name()));
         string memory symbol = string(abi.encodePacked("w", IERC20Metadata(balancerPoolToken).symbol()));
-        wrappedToken = address(new WrappedBalancerPoolToken(_vault, IERC20(balancerPoolToken), name, symbol));
+        wrappedToken = address(new WrappedBalancerPoolToken(getVault(), IERC20(balancerPoolToken), name, symbol));
 
         _wrappedTokens[address(balancerPoolToken)] = wrappedToken;
         emit WrappedTokenCreated(balancerPoolToken, wrappedToken);
@@ -45,5 +53,15 @@ contract WrappedBalancerPoolTokenFactory is IWrappedBalancerPoolTokenFactory {
     /// @inheritdoc IWrappedBalancerPoolTokenFactory
     function getWrappedToken(address balancerPoolToken) external view returns (address) {
         return _wrappedTokens[balancerPoolToken];
+    }
+
+    /// @inheritdoc IWrappedBalancerPoolTokenFactory
+    function setDisabled(bool disabled) external {
+        _isDisabled = disabled;
+    }
+
+    /// @inheritdoc IWrappedBalancerPoolTokenFactory
+    function isDisabled() external view returns (bool) {
+        return _isDisabled;
     }
 }


### PR DESCRIPTION
# Description

This PR adds the ability to stop the factory in case we suddenly decide that we need a new one. The chances of that happening are minimal, but I think it doesn't hurt to have this option.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
