### PR TITLE
Stable surge hook V2

### DIFF
--- a/pkg/interfaces/contracts/pool-hooks/IStableSurgeHook.sol
+++ b/pkg/interfaces/contracts/pool-hooks/IStableSurgeHook.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+interface IStableSurgeHook {
+    /**
+     * @notice A new `StableSurgeHook` contract has been registered successfully.
+     * @dev If the registration fails the call will revert, so there will be no event.
+     * @param pool The pool on which the hook was registered
+     * @param factory The factory that registered the pool
+     */
+    event StableSurgeHookRegistered(address indexed pool, address indexed factory);
+
+    /**
+     * @notice The threshold percentage has been changed for a pool in a `StableSurgeHook` contract.
+     * @dev Note, the initial threshold percentage is set on deployment, and an event is emitted.
+     * @param pool The pool for which the threshold percentage has been changed
+     * @param newSurgeThresholdPercentage The new threshold percentage
+     */
+    event ThresholdSurgePercentageChanged(address indexed pool, uint256 newSurgeThresholdPercentage);
+
+    /**
+     * @notice The maximum surge fee percentage has been changed for a pool in a `StableSurgeHook` contract.
+     * @dev Note, the initial max surge fee percentage is set on deployment, and an event is emitted.
+     * @param pool The pool for which the max surge fee percentage has been changed
+     * @param newMaxSurgeFeePercentage The new max surge fee percentage
+     */
+    event MaxSurgeFeePercentageChanged(address indexed pool, uint256 newMaxSurgeFeePercentage);
+
+    /// @notice The max surge fee and threshold values must be valid percentages.
+    error InvalidPercentage();
+
+    /**
+     * @notice Getter for the default maximum surge surge fee percentage.
+     * @return maxSurgeFeePercentage The default max surge fee percentage for this hook contract
+     */
+    function getDefaultMaxSurgeFeePercentage() external view returns (uint256);
+
+    /**
+     * @notice Getter for the default surge threshold percentage.
+     * @return surgeThresholdPercentage The default surge threshold percentage for this hook contract
+     */
+    function getDefaultSurgeThresholdPercentage() external view returns (uint256);
+
+    /**
+     * @notice Getter for the maximum surge fee percentage for a pool.
+     * @param pool The pool for which the max surge fee percentage is requested
+     * @return maxSurgeFeePercentage The max surge fee percentage for the pool
+     */
+    function getMaxSurgeFeePercentage(address pool) external view returns (uint256);
+
+    /**
+     * @notice Getter for the surge threshold percentage for a pool.
+     * @param pool The pool for which the surge threshold percentage is requested
+     * @return surgeThresholdPercentage The surge threshold percentage for the pool
+     */
+    function getSurgeThresholdPercentage(address pool) external view returns (uint256);
+
+    /**
+     * @notice Sets the max surge fee percentage.
+     * @dev This function must be permissioned. If the pool does not have a swap fee manager role set, the max surge
+     * fee can only be changed by governance. It is initially set to the default max surge fee for this hook contract.
+     */
+    function setMaxSurgeFeePercentage(address pool, uint256 newMaxSurgeSurgeFeePercentage) external;
+
+    /**
+     * @notice Sets the hook threshold percentage.
+     * @dev This function must be permissioned. If the pool does not have a swap fee manager role set, the surge
+     * threshold can only be changed by governance. It is initially set to the default threshold for this hook contract.
+     */
+    function setSurgeThresholdPercentage(address pool, uint256 newSurgeThresholdPercentage) external;
+}

--- a/pkg/pool-hooks/contracts/StableSurgeHook.sol
+++ b/pkg/pool-hooks/contracts/StableSurgeHook.sol
@@ -39,9 +39,6 @@ contract StableSurgeHook is BaseHooks, VaultGuard, SingletonAuthentication, Vers
     using FixedPoint for uint256;
     using SafeCast for *;
 
-    // Only pools from the allowed factory are able to register and use this hook.
-    address private immutable _allowedPoolFactory;
-
     // Percentages are 18-decimal FP values, which fit in 64 bits (sized ensure a single slot).
     struct SurgeFeeData {
         uint64 thresholdPercentage;

--- a/pkg/pool-hooks/contracts/StableSurgeHook.sol
+++ b/pkg/pool-hooks/contracts/StableSurgeHook.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
+import { IStableSurgeHook } from "@balancer-labs/v3-interfaces/contracts/pool-hooks/IStableSurgeHook.sol";
 import { IBasePoolFactory } from "@balancer-labs/v3-interfaces/contracts/vault/IBasePoolFactory.sol";
 import { IHooks } from "@balancer-labs/v3-interfaces/contracts/vault/IHooks.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
@@ -35,7 +36,7 @@ import { StableSurgeMedianMath } from "./utils/StableSurgeMedianMath.sol";
  * @notice Hook that charges a fee on trades that push a pool into an imbalanced state beyond a given threshold.
  * @dev Uses the dynamic fee mechanism to apply a "surge" fee on trades that unbalance the pool beyond the threshold.
  */
-contract StableSurgeHook is BaseHooks, VaultGuard, SingletonAuthentication, Version {
+contract StableSurgeHook is IStableSurgeHook, BaseHooks, VaultGuard, SingletonAuthentication, Version {
     using FixedPoint for uint256;
     using SafeCast for *;
 
@@ -53,33 +54,6 @@ contract StableSurgeHook is BaseHooks, VaultGuard, SingletonAuthentication, Vers
 
     // Store the current threshold and max fee for each pool.
     mapping(address pool => SurgeFeeData data) internal _surgeFeePoolData;
-
-    /**
-     * @notice A new `StableSurgeHook` contract has been registered successfully.
-     * @dev If the registration fails the call will revert, so there will be no event.
-     * @param pool The pool on which the hook was registered
-     * @param factory The factory that registered the pool
-     */
-    event StableSurgeHookRegistered(address indexed pool, address indexed factory);
-
-    /**
-     * @notice The threshold percentage has been changed for a pool in a `StableSurgeHook` contract.
-     * @dev Note, the initial threshold percentage is set on deployment, and an event is emitted.
-     * @param pool The pool for which the threshold percentage has been changed
-     * @param newSurgeThresholdPercentage The new threshold percentage
-     */
-    event ThresholdSurgePercentageChanged(address indexed pool, uint256 newSurgeThresholdPercentage);
-
-    /**
-     * @notice The maximum surge fee percentage has been changed for a pool in a `StableSurgeHook` contract.
-     * @dev Note, the initial max surge fee percentage is set on deployment, and an event is emitted.
-     * @param pool The pool for which the max surge fee percentage has been changed
-     * @param newMaxSurgeFeePercentage The new max surge fee percentage
-     */
-    event MaxSurgeFeePercentageChanged(address indexed pool, uint256 newMaxSurgeFeePercentage);
-
-    /// @notice The max surge fee and threshold values must be valid percentages.
-    error InvalidPercentage();
 
     modifier withValidPercentage(uint256 percentageValue) {
         _ensureValidPercentage(percentageValue);
@@ -106,36 +80,22 @@ contract StableSurgeHook is BaseHooks, VaultGuard, SingletonAuthentication, Vers
         hookFlags.shouldCallAfterRemoveLiquidity = true;
     }
 
-    /**
-     * @notice Getter for the default maximum surge surge fee percentage.
-     * @return maxSurgeFeePercentage The default max surge fee percentage for this hook contract
-     */
+    /// @inheritdoc IStableSurgeHook
     function getDefaultMaxSurgeFeePercentage() external view returns (uint256) {
         return _defaultMaxSurgeFeePercentage;
     }
 
-    /**
-     * @notice Getter for the default surge threshold percentage.
-     * @return surgeThresholdPercentage The default surge threshold percentage for this hook contract
-     */
+    /// @inheritdoc IStableSurgeHook
     function getDefaultSurgeThresholdPercentage() external view returns (uint256) {
         return _defaultSurgeThresholdPercentage;
     }
 
-    /**
-     * @notice Getter for the maximum surge fee percentage for a pool.
-     * @param pool The pool for which the max surge fee percentage is requested
-     * @return maxSurgeFeePercentage The max surge fee percentage for the pool
-     */
+    /// @inheritdoc IStableSurgeHook
     function getMaxSurgeFeePercentage(address pool) external view returns (uint256) {
         return _surgeFeePoolData[pool].maxSurgeFeePercentage;
     }
 
-    /**
-     * @notice Getter for the surge threshold percentage for a pool.
-     * @param pool The pool for which the surge threshold percentage is requested
-     * @return surgeThresholdPercentage The surge threshold percentage for the pool
-     */
+    /// @inheritdoc IStableSurgeHook
     function getSurgeThresholdPercentage(address pool) external view returns (uint256) {
         return _surgeFeePoolData[pool].thresholdPercentage;
     }
@@ -251,11 +211,7 @@ contract StableSurgeHook is BaseHooks, VaultGuard, SingletonAuthentication, Vers
         return (isSurging == false, amountsOutRaw);
     }
 
-    /**
-     * @notice Sets the max surge fee percentage.
-     * @dev This function must be permissioned. If the pool does not have a swap fee manager role set, the max surge
-     * fee can only be changed by governance. It is initially set to the default max surge fee for this hook contract.
-     */
+    /// @inheritdoc IStableSurgeHook
     function setMaxSurgeFeePercentage(
         address pool,
         uint256 newMaxSurgeSurgeFeePercentage
@@ -263,11 +219,7 @@ contract StableSurgeHook is BaseHooks, VaultGuard, SingletonAuthentication, Vers
         _setMaxSurgeFeePercentage(pool, newMaxSurgeSurgeFeePercentage);
     }
 
-    /**
-     * @notice Sets the hook threshold percentage.
-     * @dev This function must be permissioned. If the pool does not have a swap fee manager role set, the surge
-     * threshold can only be changed by governance. It is initially set to the default threshold for this hook contract.
-     */
+    /// @inheritdoc IStableSurgeHook
     function setSurgeThresholdPercentage(
         address pool,
         uint256 newSurgeThresholdPercentage

--- a/pkg/pool-hooks/contracts/StableSurgePoolFactory.sol
+++ b/pkg/pool-hooks/contracts/StableSurgePoolFactory.sol
@@ -25,17 +25,16 @@ contract StableSurgePoolFactory is IPoolVersion, BasePoolFactory, Version {
     string private _poolVersion;
 
     constructor(
-        IVault vault,
+        StableSurgeHook stableSurgeHook,
         uint32 pauseWindowDuration,
-        uint256 defaultMaxSurgeFeePercentage,
-        uint256 defaultSurgeThresholdPercentage,
         string memory factoryVersion,
         string memory poolVersion
-    ) BasePoolFactory(vault, pauseWindowDuration, type(StablePool).creationCode) Version(factoryVersion) {
+    )
+        BasePoolFactory(stableSurgeHook.getVault(), pauseWindowDuration, type(StablePool).creationCode)
+        Version(factoryVersion)
+    {
+        _stableSurgeHook = address(stableSurgeHook);
         _poolVersion = poolVersion;
-        _stableSurgeHook = address(
-            new StableSurgeHook(vault, defaultMaxSurgeFeePercentage, defaultSurgeThresholdPercentage)
-        );
     }
 
     /// @inheritdoc IPoolVersion

--- a/pkg/pool-hooks/contracts/StableSurgePoolFactory.sol
+++ b/pkg/pool-hooks/contracts/StableSurgePoolFactory.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.24;
 
+import { IStableSurgeHook } from "@balancer-labs/v3-interfaces/contracts/pool-hooks/IStableSurgeHook.sol";
 import { IPoolVersion } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IPoolVersion.sol";
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
@@ -20,7 +21,7 @@ import { StableSurgeHook } from "./StableSurgeHook.sol";
 
 /// @notice Stable Pool factory that deploys a standard StablePool with a StableSurgeHook.
 contract StableSurgePoolFactory is IPoolVersion, BasePoolFactory, Version {
-    address private immutable _stableSurgeHook;
+    IStableSurgeHook private immutable _stableSurgeHook;
 
     string private _poolVersion;
 
@@ -33,7 +34,7 @@ contract StableSurgePoolFactory is IPoolVersion, BasePoolFactory, Version {
         BasePoolFactory(stableSurgeHook.getVault(), pauseWindowDuration, type(StablePool).creationCode)
         Version(factoryVersion)
     {
-        _stableSurgeHook = address(stableSurgeHook);
+        _stableSurgeHook = stableSurgeHook;
         _poolVersion = poolVersion;
     }
 
@@ -47,7 +48,7 @@ contract StableSurgePoolFactory is IPoolVersion, BasePoolFactory, Version {
      * @dev This hook will be registered to every pool created by this factory.
      * @return address stableSurgeHook Address of the deployed StableSurgeHook
      */
-    function getStableSurgeHook() external view returns (address) {
+    function getStableSurgeHook() external view returns (IStableSurgeHook) {
         return _stableSurgeHook;
     }
 
@@ -104,7 +105,7 @@ contract StableSurgePoolFactory is IPoolVersion, BasePoolFactory, Version {
             swapFeePercentage,
             false, // not exempt from protocol fees
             roleAccounts,
-            _stableSurgeHook,
+            address(_stableSurgeHook),
             liquidityManagement
         );
     }

--- a/pkg/pool-hooks/contracts/test/StableSurgeHookMock.sol
+++ b/pkg/pool-hooks/contracts/test/StableSurgeHookMock.sol
@@ -13,7 +13,9 @@ contract StableSurgeHookMock is StableSurgeHook {
         uint256 defaultMaxSurgeFeePercentage,
         uint256 defaultSurgeThresholdPercentage,
         string memory version
-    ) StableSurgeHook(vault, defaultMaxSurgeFeePercentage, defaultSurgeThresholdPercentage, version) {}
+    ) StableSurgeHook(vault, defaultMaxSurgeFeePercentage, defaultSurgeThresholdPercentage, version) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
 
     function getSurgeFeePercentage(
         PoolSwapParams calldata params,

--- a/pkg/pool-hooks/contracts/test/StableSurgeHookMock.sol
+++ b/pkg/pool-hooks/contracts/test/StableSurgeHookMock.sol
@@ -11,8 +11,9 @@ contract StableSurgeHookMock is StableSurgeHook {
     constructor(
         IVault vault,
         uint256 defaultMaxSurgeFeePercentage,
-        uint256 defaultSurgeThresholdPercentage
-    ) StableSurgeHook(vault, defaultMaxSurgeFeePercentage, defaultSurgeThresholdPercentage) {}
+        uint256 defaultSurgeThresholdPercentage,
+        string memory version
+    ) StableSurgeHook(vault, defaultMaxSurgeFeePercentage, defaultSurgeThresholdPercentage, version) {}
 
     function getSurgeFeePercentage(
         PoolSwapParams calldata params,

--- a/pkg/pool-hooks/test/foundry/StableSurgeHook.t.sol
+++ b/pkg/pool-hooks/test/foundry/StableSurgeHook.t.sol
@@ -20,18 +20,17 @@ import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/Fixe
 import { ScalingHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/ScalingHelpers.sol";
 import { PoolSwapParams, SwapKind } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
+import { StableSurgeHookDeployer } from "./utils/StableSurgeHookDeployer.sol";
 import { StableSurgeHook } from "../../contracts/StableSurgeHook.sol";
 import { StableSurgeHookMock } from "../../contracts/test/StableSurgeHookMock.sol";
 import { StableSurgeMedianMathMock } from "../../contracts/test/StableSurgeMedianMathMock.sol";
 
-contract StableSurgeHookTest is BaseVaultTest {
+contract StableSurgeHookTest is BaseVaultTest, StableSurgeHookDeployer {
     using ArrayHelpers for *;
     using CastingHelpers for *;
     using FixedPoint for uint256;
 
     uint256 internal constant DEFAULT_AMP_FACTOR = 200;
-    uint256 constant DEFAULT_SURGE_THRESHOLD_PERCENTAGE = 30e16; // 30%
-    uint256 constant DEFAULT_MAX_SURGE_FEE_PERCENTAGE = 95e16; // 95%
     uint256 constant DEFAULT_POOL_TOKEN_COUNT = 2;
 
     uint256 internal daiIdx;
@@ -56,10 +55,11 @@ contract StableSurgeHookTest is BaseVaultTest {
 
     function createHook() internal override returns (address) {
         vm.prank(poolFactory);
-        stableSurgeHook = new StableSurgeHookMock(
+        stableSurgeHook = deployStableSurgeHookMock(
             vault,
             DEFAULT_MAX_SURGE_FEE_PERCENTAGE,
-            DEFAULT_SURGE_THRESHOLD_PERCENTAGE
+            DEFAULT_SURGE_THRESHOLD_PERCENTAGE,
+            "Test"
         );
         vm.label(address(stableSurgeHook), "StableSurgeHook");
         return address(stableSurgeHook);

--- a/pkg/pool-hooks/test/foundry/StableSurgeHook.t.sol
+++ b/pkg/pool-hooks/test/foundry/StableSurgeHook.t.sol
@@ -11,6 +11,7 @@ import { PoolRoleAccounts } from "@balancer-labs/v3-interfaces/contracts/vault/V
 import { StablePool } from "@balancer-labs/v3-pool-stable/contracts/StablePool.sol";
 
 import { StablePoolFactory } from "@balancer-labs/v3-pool-stable/contracts/StablePoolFactory.sol";
+import { CommonAuthentication } from "@balancer-labs/v3-vault/contracts/CommonAuthentication.sol";
 import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVaultTest.sol";
 
 import { StableMath } from "@balancer-labs/v3-solidity-utils/contracts/math/StableMath.sol";
@@ -96,6 +97,16 @@ contract StableSurgeHookTest is BaseVaultTest, StableSurgeHookDeployer {
                 }),
                 vault
             )
+        );
+    }
+
+    function testValidVault() public {
+        vm.expectRevert(CommonAuthentication.VaultNotSet.selector);
+        deployStableSurgeHook(
+            IVault(address(0)),
+            DEFAULT_MAX_SURGE_FEE_PERCENTAGE,
+            DEFAULT_SURGE_THRESHOLD_PERCENTAGE,
+            ""
         );
     }
 

--- a/pkg/pool-hooks/test/foundry/StableSurgeHookUnit.t.sol
+++ b/pkg/pool-hooks/test/foundry/StableSurgeHookUnit.t.sol
@@ -16,6 +16,7 @@ import {
 import { IVaultExplorer } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultExplorer.sol";
 import { IAuthorizer } from "@balancer-labs/v3-interfaces/contracts/vault/IAuthorizer.sol";
 import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
+
 import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
 import { ScalingHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/ScalingHelpers.sol";
 import { StablePool } from "@balancer-labs/v3-pool-stable/contracts/StablePool.sol";

--- a/pkg/pool-hooks/test/foundry/StableSurgeHookUnit.t.sol
+++ b/pkg/pool-hooks/test/foundry/StableSurgeHookUnit.t.sol
@@ -3,6 +3,8 @@
 pragma solidity ^0.8.24;
 
 import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVaultTest.sol";
+
+import { IStableSurgeHook } from "@balancer-labs/v3-interfaces/contracts/pool-hooks/IStableSurgeHook.sol";
 import {
     LiquidityManagement,
     TokenConfig,
@@ -48,12 +50,12 @@ contract StableSurgeHookUnitTest is BaseVaultTest, StableSurgeHookDeployer {
         );
 
         authorizer.grantRole(
-            IAuthentication(address(stableSurgeHook)).getActionId(StableSurgeHook.setMaxSurgeFeePercentage.selector),
+            IAuthentication(address(stableSurgeHook)).getActionId(IStableSurgeHook.setMaxSurgeFeePercentage.selector),
             admin
         );
     }
 
-    function testVersion() public {
+    function testVersion() public view {
         assertEq(stableSurgeHook.version(), version, "Incorrect version");
     }
 
@@ -61,7 +63,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest, StableSurgeHookDeployer {
         assertEq(stableSurgeHook.getSurgeThresholdPercentage(pool), 0, "Surge threshold percentage should be 0");
 
         vm.expectEmit();
-        emit StableSurgeHook.StableSurgeHookRegistered(pool, poolFactory);
+        emit IStableSurgeHook.StableSurgeHookRegistered(pool, poolFactory);
         _registerPool();
 
         assertEq(
@@ -106,7 +108,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest, StableSurgeHookDeployer {
         uint256 newSurgeThresholdPercentage = 0.5e18;
 
         vm.expectEmit();
-        emit StableSurgeHook.ThresholdSurgePercentageChanged(pool, newSurgeThresholdPercentage);
+        emit IStableSurgeHook.ThresholdSurgePercentageChanged(pool, newSurgeThresholdPercentage);
 
         PoolRoleAccounts memory poolRoleAccounts = PoolRoleAccounts({
             pauseManager: address(this),
@@ -143,7 +145,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest, StableSurgeHookDeployer {
             abi.encode(poolRoleAccounts)
         );
 
-        vm.expectRevert(StableSurgeHook.InvalidPercentage.selector);
+        vm.expectRevert(IStableSurgeHook.InvalidPercentage.selector);
         stableSurgeHook.setSurgeThresholdPercentage(pool, newSurgeThresholdPercentage);
     }
 

--- a/pkg/pool-hooks/test/foundry/StableSurgePoolFactory.t.sol
+++ b/pkg/pool-hooks/test/foundry/StableSurgePoolFactory.t.sol
@@ -17,10 +17,12 @@ import { BalancerPoolToken } from "@balancer-labs/v3-vault/contracts/BalancerPoo
 import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVaultTest.sol";
 import { StableMath } from "@balancer-labs/v3-solidity-utils/contracts/math/StableMath.sol";
 
+import { StableSurgeHookDeployer } from "./utils/StableSurgeHookDeployer.sol";
 import { StableSurgePoolFactoryDeployer } from "./utils/StableSurgePoolFactoryDeployer.sol";
+import { StableSurgeHook } from "../../contracts/StableSurgeHook.sol";
 import { StableSurgePoolFactory } from "../../contracts/StableSurgePoolFactory.sol";
 
-contract StableSurgePoolFactoryTest is BaseVaultTest, StableSurgePoolFactoryDeployer {
+contract StableSurgePoolFactoryTest is BaseVaultTest, StableSurgeHookDeployer, StableSurgePoolFactoryDeployer {
     using CastingHelpers for address[];
     using ArrayHelpers for *;
 
@@ -40,12 +42,14 @@ contract StableSurgePoolFactoryTest is BaseVaultTest, StableSurgePoolFactoryDepl
     function setUp() public override {
         super.setUp();
 
-        stablePoolFactory = deployStableSurgePoolFactory(
-            IVault(address(vault)),
-            365 days,
-            FACTORY_VERSION,
-            POOL_VERSION
+        StableSurgeHook stableSurgeHook = deployStableSurgeHook(
+            vault,
+            DEFAULT_MAX_SURGE_FEE_PERCENTAGE,
+            DEFAULT_SURGE_THRESHOLD_PERCENTAGE,
+            "Test"
         );
+
+        stablePoolFactory = deployStableSurgePoolFactory(stableSurgeHook, 365 days, FACTORY_VERSION, POOL_VERSION);
         vm.label(address(stablePoolFactory), "stable pool factory");
 
         (daiIdx, usdcIdx) = getSortedIndexes(address(dai), address(usdc));

--- a/pkg/pool-hooks/test/foundry/StableSurgePoolFactory.t.sol
+++ b/pkg/pool-hooks/test/foundry/StableSurgePoolFactory.t.sol
@@ -56,7 +56,7 @@ contract StableSurgePoolFactoryTest is BaseVaultTest, StableSurgeHookDeployer, S
     }
 
     function testFactoryHasHook() public {
-        address surgeHook = stablePoolFactory.getStableSurgeHook();
+        address surgeHook = address(stablePoolFactory.getStableSurgeHook());
         assertNotEq(surgeHook, address(0), "No surge hook deployed");
 
         address stablePool = _deployAndInitializeStablePool(false);

--- a/pkg/pool-hooks/test/foundry/utils/StableSurgeHookDeployer.sol
+++ b/pkg/pool-hooks/test/foundry/utils/StableSurgeHookDeployer.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { Test } from "forge-std/Test.sol";
+
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+
+import { BaseContractsDeployer } from "@balancer-labs/v3-solidity-utils/test/foundry/utils/BaseContractsDeployer.sol";
+
+import { StableSurgeHook } from "../../../contracts/StableSurgeHook.sol";
+import { StableSurgeHookMock } from "../../../contracts/test/StableSurgeHookMock.sol";
+import { StableSurgePoolFactory } from "../../../contracts/StableSurgePoolFactory.sol";
+
+/**
+ * @dev This contract contains functions for deploying mocks and contracts related to the "StableSurgeHook".
+ * These functions should have support for reusing artifacts from the hardhat compilation.
+ */
+contract StableSurgeHookDeployer is BaseContractsDeployer {
+    uint256 public constant DEFAULT_SURGE_THRESHOLD_PERCENTAGE = 30e16; // 30%
+    uint256 public constant DEFAULT_MAX_SURGE_FEE_PERCENTAGE = 95e16; // 95%
+
+    string private artifactsRootDir = "artifacts/";
+
+    constructor() {
+        // if this external artifact path exists, it means we are running outside of this repo
+        if (vm.exists("artifacts/@balancer-labs/v3-pool-hooks/")) {
+            artifactsRootDir = "artifacts/@balancer-labs/v3-pool-hooks/";
+        }
+    }
+
+    function deployStableSurgeHook(
+        IVault vault,
+        uint256 defaultMaxSurgeFeePercentage,
+        uint256 defaultSurgeThresholdPercentage,
+        string memory version
+    ) internal returns (StableSurgeHook) {
+        if (reusingArtifacts) {
+            return
+                StableSurgeHook(
+                    deployCode(
+                        "artifacts/contracts/StableSurgeHook.sol/StableSurgeHook.json",
+                        abi.encode(vault, defaultMaxSurgeFeePercentage, defaultSurgeThresholdPercentage, version)
+                    )
+                );
+        } else {
+            return new StableSurgeHook(vault, defaultMaxSurgeFeePercentage, defaultSurgeThresholdPercentage, version);
+        }
+    }
+
+    function deployStableSurgeHookMock(
+        IVault vault,
+        uint256 defaultMaxSurgeFeePercentage,
+        uint256 defaultSurgeThresholdPercentage,
+        string memory version
+    ) internal returns (StableSurgeHookMock) {
+        if (reusingArtifacts) {
+            return
+                StableSurgeHookMock(
+                    deployCode(
+                        "artifacts/contracts/test/StableSurgeHookMock.sol/StableSurgeHookMock.json",
+                        abi.encode(vault, defaultMaxSurgeFeePercentage, defaultSurgeThresholdPercentage, version)
+                    )
+                );
+        } else {
+            return
+                new StableSurgeHookMock(vault, defaultMaxSurgeFeePercentage, defaultSurgeThresholdPercentage, version);
+        }
+    }
+}

--- a/pkg/pool-hooks/test/foundry/utils/StableSurgePoolFactoryDeployer.sol
+++ b/pkg/pool-hooks/test/foundry/utils/StableSurgePoolFactoryDeployer.sol
@@ -8,15 +8,13 @@ import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol"
 
 import { BaseContractsDeployer } from "@balancer-labs/v3-solidity-utils/test/foundry/utils/BaseContractsDeployer.sol";
 
+import { StableSurgeHook } from "../../../contracts/StableSurgeHook.sol";
 import { StableSurgePoolFactory } from "../../../contracts/StableSurgePoolFactory.sol";
 
 /**
  * @dev This contract contains functions for deploying mocks and contracts related to the "StablePool". These functions should have support for reusing artifacts from the hardhat compilation.
  */
 contract StableSurgePoolFactoryDeployer is BaseContractsDeployer {
-    uint256 public constant DEFAULT_SURGE_THRESHOLD_PERCENTAGE = 30e16; // 30%
-    uint256 public constant DEFAULT_MAX_SURGE_FEE_PERCENTAGE = 95e16; // 95%
-
     string private artifactsRootDir = "artifacts/";
 
     constructor() {
@@ -27,7 +25,7 @@ contract StableSurgePoolFactoryDeployer is BaseContractsDeployer {
     }
 
     function deployStableSurgePoolFactory(
-        IVault vault,
+        StableSurgeHook stableSurgeHook,
         uint32 pauseWindowDuration,
         string memory factoryVersion,
         string memory poolVersion
@@ -37,30 +35,11 @@ contract StableSurgePoolFactoryDeployer is BaseContractsDeployer {
                 StableSurgePoolFactory(
                     deployCode(
                         "artifacts/contracts/StableSurgePoolFactory.sol/StableSurgePoolFactory.json",
-                        abi.encode(
-                            vault,
-                            pauseWindowDuration,
-                            DEFAULT_MAX_SURGE_FEE_PERCENTAGE,
-                            DEFAULT_SURGE_THRESHOLD_PERCENTAGE,
-                            factoryVersion,
-                            poolVersion
-                        )
+                        abi.encode(stableSurgeHook, pauseWindowDuration, factoryVersion, poolVersion)
                     )
                 );
         } else {
-            return
-                new StableSurgePoolFactory(
-                    vault,
-                    pauseWindowDuration,
-                    DEFAULT_MAX_SURGE_FEE_PERCENTAGE,
-                    DEFAULT_SURGE_THRESHOLD_PERCENTAGE,
-                    factoryVersion,
-                    poolVersion
-                );
+            return new StableSurgePoolFactory(stableSurgeHook, pauseWindowDuration, factoryVersion, poolVersion);
         }
-    }
-
-    function _computeStablePoolPath(string memory name) private view returns (string memory) {
-        return string(abi.encodePacked(artifactsRootDir, "contracts/", name, ".sol/", name, ".json"));
     }
 }

--- a/pkg/vault/contracts/CommonAuthentication.sol
+++ b/pkg/vault/contracts/CommonAuthentication.sol
@@ -7,6 +7,8 @@ import { Authentication } from "@balancer-labs/v3-solidity-utils/contracts/helpe
 
 /// @dev Base contract for performing access control on external functions within pools.
 abstract contract CommonAuthentication is Authentication {
+    error VaultNotSet();
+
     IVault private immutable _vault;
 
     /// @notice Caller must be the swapFeeManager, if defined. Otherwise, default to governance.
@@ -17,6 +19,10 @@ abstract contract CommonAuthentication is Authentication {
     }
 
     constructor(IVault vault, bytes32 actionIdDisambiguator) Authentication(actionIdDisambiguator) {
+        if (address(vault) == address(0)) {
+            revert VaultNotSet();
+        }
+
         _vault = vault;
     }
 

--- a/pkg/vault/contracts/CommonAuthentication.sol
+++ b/pkg/vault/contracts/CommonAuthentication.sol
@@ -7,6 +7,7 @@ import { Authentication } from "@balancer-labs/v3-solidity-utils/contracts/helpe
 
 /// @dev Base contract for performing access control on external functions within pools.
 abstract contract CommonAuthentication is Authentication {
+    /// @dev Vault cannot be address(0).
     error VaultNotSet();
 
     IVault private immutable _vault;


### PR DESCRIPTION
# Description

Minor changes to stable surge hook pool factory / stable surge hook to be able to deploy to Avalanche (and below 15M gas limit):
- Do not deploy hook and factory in the same tx, but rather receive hook as argument in `StableSurgePoolFactory`. This also removes the requirement for the vault argument in the stable surge pool factory.
- Remove check to allow using the hook with a single factory (seems to be a bit overkill).
- Add versioning, fix tests, etc.

The next deployment will also point to stable pool factory V2, which allows the swap fee manager to tweak the amp factor and also pushes the amp factor to 50k max.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A