### PR TITLE
Replace `isPoolInitialized` for `isPoolRegistered` in BPT wrapper factory

### DIFF
--- a/pkg/interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol
+++ b/pkg/interfaces/contracts/vault/IWrappedBalancerPoolTokenFactory.sol
@@ -12,8 +12,8 @@ interface IWrappedBalancerPoolTokenFactory {
      */
     error WrappedBPTAlreadyExists(address wrappedToken);
 
-    /// @notice The Balancer pool token has not been initialized.
-    error BalancerPoolTokenNotInitialized();
+    /// @notice The Balancer pool token has not been registered.
+    error BalancerPoolTokenNotRegistered();
 
     /**
      * @notice A new wrapped token was created.

--- a/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
+++ b/pkg/vault/contracts/WrappedBalancerPoolTokenFactory.sol
@@ -35,8 +35,8 @@ contract WrappedBalancerPoolTokenFactory is IWrappedBalancerPoolTokenFactory {
             revert WrappedBPTAlreadyExists(wrappedToken);
         }
 
-        if (_vault.isPoolInitialized(address(balancerPoolToken)) == false) {
-            revert BalancerPoolTokenNotInitialized();
+        if (_vault.isPoolRegistered(address(balancerPoolToken)) == false) {
+            revert BalancerPoolTokenNotRegistered();
         }
 
         string memory name = string(abi.encodePacked("Wrapped ", IERC20Metadata(balancerPoolToken).name()));

--- a/pkg/vault/test/foundry/WrappedBalancerPoolTokenFactory.t.sol
+++ b/pkg/vault/test/foundry/WrappedBalancerPoolTokenFactory.t.sol
@@ -48,11 +48,11 @@ contract WrappedBalancerPoolTokenFactoryTest is BaseVaultTest {
         factory.createWrappedToken(pool);
     }
 
-    function testCreateWhenPoolNotInitialized() public {
-        vault.manualSetInitializedPool(pool, false);
+    function testCreateWhenPoolNotRegistered() public {
+        vault.manualSetPoolRegistered(pool, false);
 
         vm.expectRevert(
-            abi.encodeWithSelector(IWrappedBalancerPoolTokenFactory.BalancerPoolTokenNotInitialized.selector)
+            abi.encodeWithSelector(IWrappedBalancerPoolTokenFactory.BalancerPoolTokenNotRegistered.selector)
         );
         factory.createWrappedToken(pool);
     }


### PR DESCRIPTION
# Description

While it's technically a bit better to use the `initialized` flag as you really can't mint any wrapped BPT without the pool being initialized, it's harder to verify the wrapper contract onchain automatically like this, as we'd need the address of an initialized pool on every network.

By using the `registered` flag, we can just get pool mock addresses, deploy a mock bpt wrapper and verify it automatically in the deployment script.

I don't think this adds any risk, as you still need to initialize the pool at some point to be able to mint wrapped shares anyways. This just allows creating the wrapper contract earlier on.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A