### PR TITLE
Add stablesurge helper script

### DIFF
--- a/pvt/helpers/package.json
+++ b/pvt/helpers/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",
+    "commander": "^13.1.0",
     "eslint": "^8.26.0",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.8.8"

--- a/pvt/helpers/scripts/stablesurge-calculator.ts
+++ b/pvt/helpers/scripts/stablesurge-calculator.ts
@@ -1,0 +1,88 @@
+import { Command } from 'commander';
+
+interface ProgramOptions {
+  staticFee: number;
+  threshold: number;
+  maxFee: number;
+}
+
+function main() {
+  const program = new Command();
+
+  program.name('stablesurge-calculator').description('Process stable surge internal parameters').version('0.1.0');
+
+  const parseFloatOrThrow = (value: string): number => {
+    const floatValue = parseFloat(value);
+    if (isNaN(floatValue)) {
+      throw new Error(`Invalid numeric argument: ${value}`);
+    }
+    return floatValue;
+  };
+
+  program
+    .argument('[balances...]', 'Pool balances after swap')
+    .option('--sf, --static-fee <fee-percentage>', 'static fee percentage', parseFloatOrThrow, 0.1)
+    .option('--t, --threshold <imbalance-threshold-percentage>', 'imbalance threshold percentage', parseFloatOrThrow, 5)
+    .option('--mf, --max-fee <max-fee-percentage>', 'max fee percentage', parseFloatOrThrow, 100);
+
+  program.parse();
+
+  const options = program.opts() as ProgramOptions;
+
+  // Skip the first two elements to get just the user-provided arguments
+  const args: string[] = program.args;
+
+  // Convert string arguments to numbers
+  const balances: number[] = args.map((arg) => Number(arg));
+
+  if (balances.length < 2) {
+    throw new Error(
+      'Invalid input: Please provide at least two numbers. Usage example: stablesurge-calculator.ts 95 105'
+    );
+  }
+
+  // Check if we have valid numbers
+  if (balances.some(isNaN)) {
+    throw new Error(
+      'Invalid input: Please provide valid numbers. Usage example: stablesurge-calculator.ts 100 200 300'
+    );
+  }
+
+  const median = getMedian(balances);
+  const balanceSum = balances.reduce((acc, balance) => acc + balance, 0);
+  const totalDiff = balances.reduce((acc, balance) => acc + Math.abs(balance - median), 0);
+
+  const imbalancePercentage = (totalDiff / balanceSum) * 100;
+  console.log('Imbalance percentage: ' + imbalancePercentage.toFixed(2) + '%');
+
+  console.log('Static fee percentage: ' + options.staticFee.toFixed(2) + '%');
+  console.log('Surge threshold percentage: ' + options.threshold.toFixed(2) + '%');
+  console.log('Max fee percentage: ' + options.maxFee.toFixed(2) + '%');
+
+  let surgeFeePercentage = options.staticFee;
+  if (imbalancePercentage > options.threshold) {
+    surgeFeePercentage +=
+      ((options.maxFee - options.staticFee) * (imbalancePercentage - options.threshold)) / (100 - options.threshold);
+  }
+
+  console.log('Surge fee percentage: ', surgeFeePercentage.toFixed(2) + '%');
+}
+
+function getMedian(list: number[]): number {
+  if (list.length === 0) {
+    throw new Error('Empty array: Cannot calculate median');
+  }
+
+  const sortedList = [...list].sort((a, b) => a - b);
+  const middleIndex = Math.floor(sortedList.length / 2);
+
+  if (sortedList.length % 2 === 0) {
+    // Even number of elements, average the two middle elements
+    return (sortedList[middleIndex - 1] + sortedList[middleIndex]) / 2;
+  } else {
+    // Odd number of elements, return the middle element
+    return sortedList[middleIndex];
+  }
+}
+
+main();

--- a/pvt/helpers/scripts/stablesurge-calculator.ts
+++ b/pvt/helpers/scripts/stablesurge-calculator.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, InvalidOptionArgumentError } from 'commander';
 
 interface ProgramOptions {
   staticFee: number;
@@ -11,19 +11,37 @@ function main() {
 
   program.name('stablesurge-calculator').description('Process stable surge internal parameters').version('0.1.0');
 
-  const parseFloatOrThrow = (value: string): number => {
-    const floatValue = parseFloat(value);
-    if (isNaN(floatValue)) {
-      throw new Error(`Invalid numeric argument: ${value}`);
+  function parsePercentage(value: string, name: string): number {
+    const num = parseFloat(value);
+    if (isNaN(num)) {
+      throw new InvalidOptionArgumentError(`${name} must be a valid number`);
     }
-    return floatValue;
-  };
+    if (num < 0 || num > 100) {
+      throw new InvalidOptionArgumentError(`${name} must be between 0 and 100`);
+    }
+    return num;
+  }
 
   program
     .argument('[balances...]', 'Pool balances after swap')
-    .option('--sf, --static-fee <fee-percentage>', 'static fee percentage', parseFloatOrThrow, 0.1)
-    .option('--t, --threshold <imbalance-threshold-percentage>', 'imbalance threshold percentage', parseFloatOrThrow, 5)
-    .option('--mf, --max-fee <max-fee-percentage>', 'max fee percentage', parseFloatOrThrow, 100);
+    .option(
+      '--sf, --static-fee <fee-percentage>',
+      'static fee percentage',
+      (value) => parsePercentage(value, 'static fee'),
+      0.1
+    )
+    .option(
+      '--t, --threshold <imbalance-threshold-percentage>',
+      'imbalance threshold percentage',
+      (value) => parsePercentage(value, 'imbalance threshold'),
+      5
+    )
+    .option(
+      '--mf, --max-fee <max-fee-percentage>',
+      'max fee percentage',
+      (value) => parsePercentage(value, 'max fee'),
+      100
+    );
 
   program.parse();
 
@@ -60,7 +78,10 @@ function main() {
   console.log('Max fee percentage: ' + options.maxFee.toFixed(2) + '%');
 
   let surgeFeePercentage = options.staticFee;
-  if (imbalancePercentage > options.threshold) {
+
+  // If the max surge fee percentage is less than the static fee percentage, return the static fee percentage.
+  // No matter where the imbalance is, the fee can never be smaller than the static fee.
+  if (imbalancePercentage > options.threshold && options.maxFee > options.staticFee) {
     surgeFeePercentage +=
       ((options.maxFee - options.staticFee) * (imbalancePercentage - options.threshold)) / (100 - options.threshold);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,6 +174,7 @@ __metadata:
     "@types/node": "npm:^14.14.31"
     "@typescript-eslint/eslint-plugin": "npm:^5.41.0"
     "@typescript-eslint/parser": "npm:^5.41.0"
+    commander: "npm:^13.1.0"
     decimal.js: "npm:^10.4.2"
     eslint: "npm:^8.26.0"
     eslint-plugin-prettier: "npm:^4.2.1"
@@ -2854,6 +2855,13 @@ __metadata:
   version: 10.0.1
   resolution: "commander@npm:10.0.1"
   checksum: b2a03d799104eac407ca031b94126c98198594fcff41554eb253cef748de57fb1a4cdd591baa075de589f2fddf1f968d1ecd1b79e8b47570ee441ab4f3363776
+  languageName: node
+  linkType: hard
+
+"commander@npm:^13.1.0":
+  version: 13.1.0
+  resolution: "commander@npm:13.1.0"
+  checksum: f01b312a04573c11e6156f4216ed0c4aee6c50e37902ebe3d9d3f50c688dcc44432ae449aaaaf54e638687a79588469f4fab7d7aad5c0c17f25be2ccaa24e1f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Add small stable surge helper script to compute imbalance and surge fees.

```
ts-node pvt/helpers/scripts/stablesurge-calculator.ts --help
Usage: stablesurge-calculator [options] [balances...]

Process stable surge internal parameters

Arguments:
  balances                                           Pool balances after swap

Options:
  -V, --version                                      output the version number
  --sf, --static-fee <fee-percentage>                static fee percentage (default: 0.1)
  --t, --threshold <imbalance-threshold-percentage>  imbalance threshold percentage (default: 5)
  --mf, --max-fee <max-fee-percentage>               max fee percentage (default: 100)
  -h, --help                                         display help for command
```

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A