### PR TITLE
Fix fuzzParams order in e2eSwapTest

### DIFF
--- a/pkg/vault/test/foundry/E2eSwap.t.sol
+++ b/pkg/vault/test/foundry/E2eSwap.t.sol
@@ -524,12 +524,12 @@ contract E2eSwapTest is BaseVaultTest {
         uint256 newDecimalsTokenB,
         uint256[POOL_SPECIFIC_PARAMS_SIZE] memory params
     ) public {
+        fuzzPoolParams(params);
+
         decimalsTokenA = bound(newDecimalsTokenA, _LOW_DECIMAL_LIMIT, 18);
         decimalsTokenB = bound(newDecimalsTokenB, _LOW_DECIMAL_LIMIT, 18);
 
         _setTokenDecimalsInPool();
-
-        fuzzPoolParams(params);
 
         exactAmountIn = bound(exactAmountIn, minSwapAmountTokenA, maxSwapAmountTokenA);
 
@@ -603,15 +603,15 @@ contract E2eSwapTest is BaseVaultTest {
     }
 
     function testDoUndoExactInBase(uint256 exactAmountIn, DoUndoLocals memory testLocals) internal {
+        if (testLocals.shouldFuzzPoolParams) {
+            fuzzPoolParams(testLocals.poolParams);
+        }
+
         if (testLocals.shouldTestDecimals) {
             decimalsTokenA = bound(testLocals.newDecimalsTokenA, _LOW_DECIMAL_LIMIT, 18);
             decimalsTokenB = bound(testLocals.newDecimalsTokenB, _LOW_DECIMAL_LIMIT, 18);
 
             _setTokenDecimalsInPool();
-        }
-
-        if (testLocals.shouldFuzzPoolParams) {
-            fuzzPoolParams(testLocals.poolParams);
         }
 
         uint256 maxAmountIn = maxSwapAmountTokenA;
@@ -722,15 +722,15 @@ contract E2eSwapTest is BaseVaultTest {
     }
 
     function testDoUndoExactOutBase(uint256 exactAmountOut, DoUndoLocals memory testLocals) internal {
+        if (testLocals.shouldFuzzPoolParams) {
+            fuzzPoolParams(testLocals.poolParams);
+        }
+
         if (testLocals.shouldTestDecimals) {
             decimalsTokenA = bound(testLocals.newDecimalsTokenA, _LOW_DECIMAL_LIMIT, 18);
             decimalsTokenB = bound(testLocals.newDecimalsTokenB, _LOW_DECIMAL_LIMIT, 18);
 
             _setTokenDecimalsInPool();
-        }
-
-        if (testLocals.shouldFuzzPoolParams) {
-            fuzzPoolParams(testLocals.poolParams);
         }
 
         uint256 maxAmountOut = maxSwapAmountTokenB;


### PR DESCRIPTION
# Description

This PR changes the order of the fuzzParams call, placing it before the changes to decimals. This is necessary so that when the pool balances are modified inside fuzzParams, the actions already applied in decimals are not repeated.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
