### PR TITLE
Factor common code out of helpers

### DIFF
--- a/pkg/interfaces/contracts/standalone-utils/IPoolHelperCommon.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IPoolHelperCommon.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+interface IPoolHelperCommon {
+    /**
+     * @notice Emitted when a pool is added to the set of pools that can be controlled by the helper contract.
+     * @param pool Address of the pool that was added
+     */
+    event PoolAddedToSet(address pool);
+
+    /**
+     * @notice Emitted when a pool is removed from the set of pools that can be controlled by the helper contract.
+     * @param pool Address of the pool that was removed
+     */
+    event PoolRemovedFromSet(address pool);
+
+    /**
+     * @notice Cannot add a pool that is already there.
+     * @param pool Address of the pool being added
+     */
+    error PoolAlreadyInSet(address pool);
+
+    /**
+     * @notice Cannot remove a pool that was not added.
+     * @param pool Address of the pool being removed
+     */
+    error PoolNotInSet(address pool);
+
+    /// @notice An index is beyond the current bounds of the set.
+    error IndexOutOfBounds();
+
+    /***************************************************************************
+                                    Manage Pools
+    ***************************************************************************/
+
+    /**
+     * @notice Add pools to the set of pools controlled by this helper contract.
+     * @dev This is a permissioned function. Only authorized accounts (e.g., monitoring service providers) may add
+     * pools to the set.
+     *
+     * @param newPools List of pools to add
+     */
+    function addPools(address[] calldata newPools) external;
+
+    /**
+     * @notice Remove pools from the set of pools controlled by this helper contract.
+     * @dev This is a permissioned function. Only authorized accounts (e.g., monitoring service providers) may remove
+     * pools from the set.
+     *
+     * @param pools List of pools to remove
+     */
+    function removePools(address[] memory pools) external;
+
+    /***************************************************************************
+                                    Getters                                
+    ***************************************************************************/
+
+    /**
+     * @notice Get the number of pools.
+     * @dev Needed to support pagination in case the set is too large to process in a single transaction.
+     * @return poolCount The current number of pools in the set
+     */
+    function getPoolCount() external view returns (uint256);
+
+    /**
+     * @notice Check whether a pool is in the set of pools.
+     * @param pool Pool to check
+     * @return isPausable True if the pool is in the set, false otherwise
+     */
+    function hasPool(address pool) external view returns (bool);
+
+    /**
+     * @notice Get a range of pools.
+     * @dev Indexes are 0-based and [start, end) (i.e., inclusive of `start`; exclusive of `end`).
+     * @param from Start index
+     * @param to End index
+     * @return pools List of pools
+     */
+    function getPools(uint256 from, uint256 to) external view returns (address[] memory pools);
+}

--- a/pkg/interfaces/contracts/standalone-utils/IPoolHelperCommon.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IPoolHelperCommon.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.24;
 
+/// @notice Common interface for helper functions that operate on a subset of pools.
 interface IPoolHelperCommon {
     /**
      * @notice Emitted when a pool is added to the set of pools that can be controlled by the helper contract.

--- a/pkg/interfaces/contracts/standalone-utils/IPoolPauseHelper.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IPoolPauseHelper.sol
@@ -2,8 +2,6 @@
 
 pragma solidity ^0.8.24;
 
-import "./IPoolHelperCommon.sol";
-
 /**
  * @notice Maintain a set of pools that can be paused from this helper contract, vs. directly from the Vault.
  * @dev Governance can add a set of pools to this contract, then grant pause permission to accounts here, which
@@ -12,7 +10,7 @@ import "./IPoolHelperCommon.sol";
  * Note that governance must grant this contract permission to pause pools from the Vault. Unpausing is not
  * addressed here, and must still be done through the Vault.
  */
-interface IPoolPauseHelper is IPoolHelperCommon {
+interface IPoolPauseHelper {
     /**
      * @notice Pause a set of pools.
      * @dev This is a permissioned function. Governance must first grant this contract permission to call `pausePool`

--- a/pkg/interfaces/contracts/standalone-utils/IPoolPauseHelper.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IPoolPauseHelper.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.24;
 
+import "./IPoolHelperCommon.sol";
+
 /**
  * @notice Maintain a set of pools that can be paused from this helper contract, vs. directly from the Vault.
  * @dev Governance can add a set of pools to this contract, then grant pause permission to accounts here, which
@@ -10,56 +12,7 @@ pragma solidity ^0.8.24;
  * Note that governance must grant this contract permission to pause pools from the Vault. Unpausing is not
  * addressed here, and must still be done through the Vault.
  */
-interface IPoolPauseHelper {
-    /**
-     * @notice Cannot add a pool that is already there.
-     * @param pool Address of the pool being added
-     */
-    error PoolAlreadyInPausableSet(address pool);
-
-    /**
-     * @notice Cannot remove a pool that was not added.
-     * @param pool Address of the pool being removed
-     */
-    error PoolNotInPausableSet(address pool);
-
-    /// @notice An index is beyond the current bounds of the set.
-    error IndexOutOfBounds();
-
-    /**
-     * @notice Emitted when a pool is added to the list of pools that can be paused.
-     * @param pool Address of the pool that was added
-     */
-    event PoolAddedToPausableSet(address pool);
-
-    /**
-     * @notice Emitted when a pool is removed from the list of pools that can be paused.
-     * @param pool Address of the pool that was removed
-     */
-    event PoolRemovedFromPausableSet(address pool);
-
-    /***************************************************************************
-                                    Manage Pools
-    ***************************************************************************/
-
-    /**
-     * @notice Add pools to the list of pools that can be paused.
-     * @dev This is a permissioned function. Only authorized accounts (e.g., monitoring service providers) may add
-     * pools to the pause list.
-     *
-     * @param newPools List of pools to add
-     */
-    function addPools(address[] calldata newPools) external;
-
-    /**
-     * @notice Remove pools from the list of pools that can be paused.
-     * @dev This is a permissioned function. Only authorized accounts (e.g., monitoring service providers) may remove
-     * pools from the pause list.
-     *
-     * @param pools List of pools to remove
-     */
-    function removePools(address[] memory pools) external;
-
+interface IPoolPauseHelper is IPoolHelperCommon {
     /**
      * @notice Pause a set of pools.
      * @dev This is a permissioned function. Governance must first grant this contract permission to call `pausePool`
@@ -73,31 +26,4 @@ interface IPoolPauseHelper {
      * @param pools List of pools to pause
      */
     function pausePools(address[] memory pools) external;
-
-    /***************************************************************************
-                                    Getters                                
-    ***************************************************************************/
-
-    /**
-     * @notice Get the number of pools.
-     * @dev Needed to support pagination in case the list is too long to process in a single transaction.
-     * @return poolCount The current number of pools in the pausable list
-     */
-    function getPoolCount() external view returns (uint256);
-
-    /**
-     * @notice Check whether a pool is in the list of pausable pools.
-     * @param pool Pool to check
-     * @return isPausable True if the pool is in the list, false otherwise
-     */
-    function hasPool(address pool) external view returns (bool);
-
-    /**
-     * @notice Get a range of pools.
-     * @dev Indexes are 0-based and [start, end) (i.e., inclusive of `start`; exclusive of `end`).
-     * @param from Start index
-     * @param to End index
-     * @return pools List of pools
-     */
-    function getPools(uint256 from, uint256 to) external view returns (address[] memory pools);
 }

--- a/pkg/interfaces/contracts/standalone-utils/IPoolSwapFeeHelper.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IPoolSwapFeeHelper.sol
@@ -2,8 +2,6 @@
 
 pragma solidity ^0.8.24;
 
-import "./IPoolHelperCommon.sol";
-
 /**
  * @notice Maintain a set of pools whose static swap fee percentages can be changed from here, vs. from the Vault.
  * @dev Governance can add a set of pools to this contract, then grant swap fee setting permission to accounts on this
@@ -12,7 +10,7 @@ import "./IPoolHelperCommon.sol";
  * Note that governance must grant this contract permission to set swap fees from the Vault, and only pools that
  * allow governance to set fees can be added (i.e., they must not have swap managers).
  */
-interface IPoolSwapFeeHelper is IPoolHelperCommon {
+interface IPoolSwapFeeHelper {
     /**
      * @notice Cannot add a pool that has a swap manager.
      * @dev The swap manager is an exclusive role. If it is set to a non-zero value during pool registration,

--- a/pkg/interfaces/contracts/standalone-utils/IPoolSwapFeeHelper.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IPoolSwapFeeHelper.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.24;
 
+import "./IPoolHelperCommon.sol";
+
 /**
  * @notice Maintain a set of pools whose static swap fee percentages can be changed from here, vs. from the Vault.
  * @dev Governance can add a set of pools to this contract, then grant swap fee setting permission to accounts on this
@@ -10,19 +12,7 @@ pragma solidity ^0.8.24;
  * Note that governance must grant this contract permission to set swap fees from the Vault, and only pools that
  * allow governance to set fees can be added (i.e., they must not have swap managers).
  */
-interface IPoolSwapFeeHelper {
-    /**
-     * @notice Cannot add a pool that is already there.
-     * @param pool Address of the pool being added
-     */
-    error PoolAlreadyInSwapFeeSet(address pool);
-
-    /**
-     * @notice Cannot remove a pool that was not added.
-     * @param pool Address of the pool being removed
-     */
-    error PoolNotInSwapFeeSet(address pool);
-
+interface IPoolSwapFeeHelper is IPoolHelperCommon {
     /**
      * @notice Cannot add a pool that has a swap manager.
      * @dev The swap manager is an exclusive role. If it is set to a non-zero value during pool registration,
@@ -33,42 +23,9 @@ interface IPoolSwapFeeHelper {
      */
     error PoolHasSwapManager(address pool);
 
-    /// @notice An index is beyond the current bounds of the set.
-    error IndexOutOfBounds();
-
-    /**
-     * @notice Emitted when a pool is added to the list of pools whose swap fee can be changed.
-     * @param pool Address of the pool that was added
-     */
-    event PoolAddedToSwapFeeSet(address pool);
-
-    /**
-     * @notice Emitted when a pool is removed from the list of pools whose swap fee can be changed.
-     * @param pool Address of the pool that was removed
-     */
-    event PoolRemovedFromSwapFeeSet(address pool);
-
     /***************************************************************************
                                     Manage Pools
     ***************************************************************************/
-
-    /**
-     * @notice Add pools to the list of pools whose swap fee can be changed.
-     * @dev This is a permissioned function. Only authorized accounts (e.g., dynamic fee service providers) may add
-     * pools to the set.
-     *
-     * @param newPools List of pools to add
-     */
-    function addPools(address[] calldata newPools) external;
-
-    /**
-     * @notice Remove pools from the list of pools whose swap fee can be changed.
-     * @dev This is a permissioned function. Only authorized accounts (e.g., dynamic fee service providers) may remove
-     * pools from the set.
-     *
-     * @param pools List of pools to remove
-     */
-    function removePools(address[] memory pools) external;
 
     /**
      * @notice Set the static swap fee percentage on a given pool.
@@ -80,31 +37,4 @@ interface IPoolSwapFeeHelper {
      * @param swapFeePercentage The new swap fee percentage
      */
     function setStaticSwapFeePercentage(address pool, uint256 swapFeePercentage) external;
-
-    /***************************************************************************
-                                    Getters                                
-    ***************************************************************************/
-
-    /**
-     * @notice Get the number of pools.
-     * @dev Needed to support pagination in case the list is too long to process in a single transaction.
-     * @return poolCount The current number of pools whose swap fee can be changed from this contract
-     */
-    function getPoolCount() external view returns (uint256);
-
-    /**
-     * @notice Check whether a pool is in the set of pools whose swap fee can be changed.
-     * @param pool Address of the pool
-     * @return isPausable True if the pool is in the set
-     */
-    function hasPool(address pool) external view returns (bool);
-
-    /**
-     * @notice Get a range of pools.
-     * @dev Indexes are 0-based and [start, end) (i.e., inclusive of `start`; exclusive of `end`).
-     * @param from Start index
-     * @param to End index
-     * @return pools List of pools
-     */
-    function getPools(uint256 from, uint256 to) external view returns (address[] memory pools);
 }

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeHelper.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeHelper.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.24;
 
+import "./IPoolHelperCommon.sol";
+
 /**
  * @notice Maintain a set of pools whose protocol fees can be set from this helper contract, vs. the fee controller.
  * @dev Governance can add a set of pools to this contract, then grant permission to call protocol swap- or yield-
@@ -10,53 +12,10 @@ pragma solidity ^0.8.24;
  * Note that governance must grant this contract permission to call the pool protocol fee setting functions on the
  * controller.
  */
-interface IProtocolFeeHelper {
-    /**
-     * @notice Cannot add a pool that is already there.
-     * @param pool Address of the pool being added
-     */
-    error PoolAlreadyInProtocolFeeSet(address pool);
-
-    /**
-     * @notice Cannot remove a pool that was not added.
-     * @param pool Address of the pool being removed
-     */
-    error PoolNotInProtocolFeeSet(address pool);
-
-    /// @notice An index is beyond the current bounds of the set.
-    error IndexOutOfBounds();
-
-    /**
-     * @notice Emitted when a pool is added to the list of pools whose protocol fees can be set.
-     * @param pool Address of the pool that was added
-     */
-    event PoolAddedToProtocolFeeSet(address pool);
-
-    /**
-     * @notice Emitted when a pool is removed from the list of pools whose protocol fees can be set.
-     * @param pool Address of the pool that was removed
-     */
-    event PoolRemovedFromProtocolFeeSet(address pool);
-
+interface IProtocolFeeHelper is IPoolHelperCommon {
     /***************************************************************************
                                     Manage Pools
     ***************************************************************************/
-
-    /**
-     * @notice Add pools to the list of pools whose protocol fees can be set.
-     * @dev This is a permissioned function. Only authorized accounts may add pools to the set.
-     *
-     * @param newPools List of pools to add
-     */
-    function addPools(address[] calldata newPools) external;
-
-    /**
-     * @notice Remove pools from the list of pools whose protocol fees can be set.
-     * @dev This is a permissioned function. Only authorized accounts may remove pools from the set.
-     *
-     * @param pools List of pools to remove
-     */
-    function removePools(address[] memory pools) external;
 
     /**
      * @notice Set the protocol swap fee for a pool.
@@ -77,31 +36,4 @@ interface IProtocolFeeHelper {
      * @param newProtocolYieldFeePercentage The new protocol yield fee percentage
      */
     function setProtocolYieldFeePercentage(address pool, uint256 newProtocolYieldFeePercentage) external;
-
-    /***************************************************************************
-                                    Getters                                
-    ***************************************************************************/
-
-    /**
-     * @notice Get the number of pools.
-     * @dev Needed to support pagination in case the list is too long to process in a single transaction.
-     * @return poolCount The current number of pools in the set
-     */
-    function getPoolCount() external view returns (uint256);
-
-    /**
-     * @notice Check whether a pool is in the set of pools.
-     * @param pool Pool to check
-     * @return isProtocolFee True if the pool is in the list, false otherwise
-     */
-    function hasPool(address pool) external view returns (bool);
-
-    /**
-     * @notice Get a range of pools.
-     * @dev Indexes are 0-based and [start, end) (i.e., inclusive of `start`; exclusive of `end`).
-     * @param from Start index
-     * @param to End index
-     * @return pools List of pools
-     */
-    function getPools(uint256 from, uint256 to) external view returns (address[] memory pools);
 }

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeHelper.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeHelper.sol
@@ -2,8 +2,6 @@
 
 pragma solidity ^0.8.24;
 
-import "./IPoolHelperCommon.sol";
-
 /**
  * @notice Maintain a set of pools whose protocol fees can be set from this helper contract, vs. the fee controller.
  * @dev Governance can add a set of pools to this contract, then grant permission to call protocol swap- or yield-
@@ -12,7 +10,7 @@ import "./IPoolHelperCommon.sol";
  * Note that governance must grant this contract permission to call the pool protocol fee setting functions on the
  * controller.
  */
-interface IProtocolFeeHelper is IPoolHelperCommon {
+interface IProtocolFeeHelper {
     /***************************************************************************
                                     Manage Pools
     ***************************************************************************/

--- a/pkg/standalone-utils/contracts/PoolHelperCommon.sol
+++ b/pkg/standalone-utils/contracts/PoolHelperCommon.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
+import { IPoolHelperCommon } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IPoolHelperCommon.sol";
+import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+
+import { SingletonAuthentication } from "@balancer-labs/v3-vault/contracts/SingletonAuthentication.sol";
+
+abstract contract PoolHelperCommon is IPoolHelperCommon, SingletonAuthentication {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    EnumerableSet.AddressSet internal _pools;
+
+    constructor(IVault vault) SingletonAuthentication(vault) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    /***************************************************************************
+                                    Manage Pools
+    ***************************************************************************/
+
+    /// @inheritdoc IPoolHelperCommon
+    function addPools(address[] calldata newPools) external authenticate {
+        uint256 length = newPools.length;
+
+        for (uint256 i = 0; i < length; i++) {
+            address pool = newPools[i];
+
+            // Ensure the address is a valid pool.
+            if (getVault().isPoolRegistered(pool) == false) {
+                revert IVaultErrors.PoolNotRegistered(pool);
+            }
+
+            // Call virtual function in case additional validation is needed.
+            _validatePool(pool);
+
+            if (_pools.add(pool) == false) {
+                revert PoolAlreadyInSet(pool);
+            }
+
+            emit PoolAddedToSet(pool);
+        }
+    }
+
+    /// @inheritdoc IPoolHelperCommon
+    function removePools(address[] memory pools) public authenticate {
+        uint256 length = pools.length;
+        for (uint256 i = 0; i < length; i++) {
+            address pool = pools[i];
+            if (_pools.remove(pool) == false) {
+                revert PoolNotInSet(pool);
+            }
+
+            emit PoolRemovedFromSet(pool);
+        }
+    }
+
+    /***************************************************************************
+                                    Getters                                
+    ***************************************************************************/
+
+    /// @inheritdoc IPoolHelperCommon
+    function getPoolCount() external view returns (uint256) {
+        return _pools.length();
+    }
+
+    /// @inheritdoc IPoolHelperCommon
+    function hasPool(address pool) external view returns (bool) {
+        return _pools.contains(pool);
+    }
+
+    /// @inheritdoc IPoolHelperCommon
+    function getPools(uint256 from, uint256 to) public view returns (address[] memory pools) {
+        uint256 poolLength = _pools.length();
+        if (from > to || to > poolLength || from >= poolLength) {
+            revert IndexOutOfBounds();
+        }
+
+        pools = new address[](to - from);
+        for (uint256 i = from; i < to; i++) {
+            pools[i - from] = _pools.at(i);
+        }
+    }
+
+    /***************************************************************************
+                                Internal functions                                
+    ***************************************************************************/
+
+    function _ensurePoolAdded(address pool) internal view {
+        if (_pools.contains(pool) == false) {
+            revert PoolNotInSet(pool);
+        }
+    }
+
+    /// @dev Optional function called in addPools for additional validation.
+    function _validatePool(address pool) internal view virtual {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+}

--- a/pkg/standalone-utils/contracts/PoolHelperCommon.sol
+++ b/pkg/standalone-utils/contracts/PoolHelperCommon.sol
@@ -10,6 +10,7 @@ import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol"
 
 import { SingletonAuthentication } from "@balancer-labs/v3-vault/contracts/SingletonAuthentication.sol";
 
+/// @notice Common code for helper functions that operate on a subset of pools.
 abstract contract PoolHelperCommon is IPoolHelperCommon, SingletonAuthentication {
     using EnumerableSet for EnumerableSet.AddressSet;
 

--- a/pkg/standalone-utils/contracts/PoolPauseHelper.sol
+++ b/pkg/standalone-utils/contracts/PoolPauseHelper.sol
@@ -8,14 +8,12 @@ import { IPoolPauseHelper } from "@balancer-labs/v3-interfaces/contracts/standal
 import { IVaultAdmin } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultAdmin.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 
-import { SingletonAuthentication } from "@balancer-labs/v3-vault/contracts/SingletonAuthentication.sol";
+import { PoolHelperCommon } from "./PoolHelperCommon.sol";
 
-contract PoolPauseHelper is IPoolPauseHelper, SingletonAuthentication {
+contract PoolPauseHelper is IPoolPauseHelper, PoolHelperCommon {
     using EnumerableSet for EnumerableSet.AddressSet;
 
-    EnumerableSet.AddressSet private _pausablePools;
-
-    constructor(IVault vault) SingletonAuthentication(vault) {
+    constructor(IVault vault) PoolHelperCommon(vault) {
         // solhint-disable-previous-line no-empty-blocks
     }
 
@@ -24,69 +22,15 @@ contract PoolPauseHelper is IPoolPauseHelper, SingletonAuthentication {
     ***************************************************************************/
 
     /// @inheritdoc IPoolPauseHelper
-    function addPools(address[] calldata newPools) external authenticate {
-        uint256 length = newPools.length;
-
-        for (uint256 i = 0; i < length; i++) {
-            address pool = newPools[i];
-            if (_pausablePools.add(pool) == false) {
-                revert PoolAlreadyInPausableSet(pool);
-            }
-
-            emit PoolAddedToPausableSet(pool);
-        }
-    }
-
-    /// @inheritdoc IPoolPauseHelper
-    function removePools(address[] memory pools) public authenticate {
-        uint256 length = pools.length;
-        for (uint256 i = 0; i < length; i++) {
-            address pool = pools[i];
-            if (_pausablePools.remove(pool) == false) {
-                revert PoolNotInPausableSet(pool);
-            }
-
-            emit PoolRemovedFromPausableSet(pool);
-        }
-    }
-
-    /// @inheritdoc IPoolPauseHelper
     function pausePools(address[] memory pools) public authenticate {
         uint256 length = pools.length;
         for (uint256 i = 0; i < length; i++) {
             address pool = pools[i];
-            if (_pausablePools.contains(pool) == false) {
-                revert PoolNotInPausableSet(pool);
+            if (_pools.contains(pool) == false) {
+                revert PoolNotInSet(pool);
             }
 
             getVault().pausePool(pool);
-        }
-    }
-
-    /***************************************************************************
-                                    Getters                                
-    ***************************************************************************/
-
-    /// @inheritdoc IPoolPauseHelper
-    function getPoolCount() external view returns (uint256) {
-        return _pausablePools.length();
-    }
-
-    /// @inheritdoc IPoolPauseHelper
-    function hasPool(address pool) external view returns (bool) {
-        return _pausablePools.contains(pool);
-    }
-
-    /// @inheritdoc IPoolPauseHelper
-    function getPools(uint256 from, uint256 to) public view returns (address[] memory pools) {
-        uint256 poolLength = _pausablePools.length();
-        if (from > to || to > poolLength || from >= poolLength) {
-            revert IndexOutOfBounds();
-        }
-
-        pools = new address[](to - from);
-        for (uint256 i = from; i < to; i++) {
-            pools[i - from] = _pausablePools.at(i);
         }
     }
 }

--- a/pkg/standalone-utils/contracts/PoolSwapFeeHelper.sol
+++ b/pkg/standalone-utils/contracts/PoolSwapFeeHelper.sol
@@ -5,16 +5,15 @@ pragma solidity ^0.8.24;
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import { IPoolSwapFeeHelper } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IPoolSwapFeeHelper.sol";
-import { SingletonAuthentication } from "@balancer-labs/v3-vault/contracts/SingletonAuthentication.sol";
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 
-contract PoolSwapFeeHelper is IPoolSwapFeeHelper, SingletonAuthentication {
+import { PoolHelperCommon } from "./PoolHelperCommon.sol";
+
+contract PoolSwapFeeHelper is IPoolSwapFeeHelper, PoolHelperCommon {
     using EnumerableSet for EnumerableSet.AddressSet;
 
-    EnumerableSet.AddressSet private _pools;
-
-    constructor(IVault vault) SingletonAuthentication(vault) {
+    constructor(IVault vault) PoolHelperCommon(vault) {
         // solhint-disable-previous-line no-empty-blocks
     }
 
@@ -23,84 +22,21 @@ contract PoolSwapFeeHelper is IPoolSwapFeeHelper, SingletonAuthentication {
     ***************************************************************************/
 
     /// @inheritdoc IPoolSwapFeeHelper
-    function addPools(address[] calldata newPools) external authenticate {
-        uint256 length = newPools.length;
-        IVault vault = getVault();
-
-        for (uint256 i = 0; i < length; i++) {
-            address pool = newPools[i];
-
-            // Ensure the address is a valid pool.
-            if (vault.isPoolRegistered(pool) == false) {
-                revert IVaultErrors.PoolNotRegistered(pool);
-            }
-
-            // Pools cannot have a swap fee manager.
-            if (vault.getPoolRoleAccounts(pool).swapFeeManager != address(0)) {
-                revert PoolHasSwapManager(pool);
-            }
-
-            if (_pools.add(pool) == false) {
-                revert PoolAlreadyInSwapFeeSet(pool);
-            }
-
-            emit PoolAddedToSwapFeeSet(pool);
-        }
-    }
-
-    /// @inheritdoc IPoolSwapFeeHelper
-    function removePools(address[] memory pools) public authenticate {
-        uint256 length = pools.length;
-        for (uint256 i = 0; i < length; i++) {
-            address pool = pools[i];
-            _ensureKnownPool(pool);
-            _pools.remove(pool);
-
-            emit PoolRemovedFromSwapFeeSet(pool);
-        }
-    }
-
-    /// @inheritdoc IPoolSwapFeeHelper
     function setStaticSwapFeePercentage(address pool, uint256 swapFeePercentage) public authenticate {
-        _ensureKnownPool(pool);
+        _ensurePoolAdded(pool);
 
         getVault().setStaticSwapFeePercentage(pool, swapFeePercentage);
-    }
-
-    /***************************************************************************
-                                    Getters                                
-    ***************************************************************************/
-
-    /// @inheritdoc IPoolSwapFeeHelper
-    function getPoolCount() external view returns (uint256) {
-        return _pools.length();
-    }
-
-    /// @inheritdoc IPoolSwapFeeHelper
-    function hasPool(address pool) external view returns (bool) {
-        return _pools.contains(pool);
-    }
-
-    /// @inheritdoc IPoolSwapFeeHelper
-    function getPools(uint256 from, uint256 to) public view returns (address[] memory pools) {
-        uint256 poolLength = _pools.length();
-        if (from > to || to > poolLength || from >= poolLength) {
-            revert IndexOutOfBounds();
-        }
-
-        pools = new address[](to - from);
-        for (uint256 i = from; i < to; i++) {
-            pools[i - from] = _pools.at(i);
-        }
     }
 
     /***************************************************************************
                                 Internal functions                                
     ***************************************************************************/
 
-    function _ensureKnownPool(address pool) internal view {
-        if (_pools.contains(pool) == false) {
-            revert PoolNotInSwapFeeSet(pool);
+    /// @inheritdoc PoolHelperCommon
+    function _validatePool(address pool) internal view override {
+        // Pools cannot have a swap fee manager.
+        if (getVault().getPoolRoleAccounts(pool).swapFeeManager != address(0)) {
+            revert PoolHasSwapManager(pool);
         }
     }
 }

--- a/pkg/standalone-utils/contracts/ProtocolFeeHelper.sol
+++ b/pkg/standalone-utils/contracts/ProtocolFeeHelper.sol
@@ -9,59 +9,23 @@ import { IProtocolFeeController } from "@balancer-labs/v3-interfaces/contracts/v
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 
-import { SingletonAuthentication } from "@balancer-labs/v3-vault/contracts/SingletonAuthentication.sol";
+import { PoolHelperCommon } from "./PoolHelperCommon.sol";
 
-contract ProtocolFeeHelper is IProtocolFeeHelper, SingletonAuthentication {
+contract ProtocolFeeHelper is IProtocolFeeHelper, PoolHelperCommon {
     using EnumerableSet for EnumerableSet.AddressSet;
 
-    EnumerableSet.AddressSet private _pools;
-
     modifier withKnownPool(address pool) {
-        _ensureKnownPool(pool);
+        _ensurePoolAdded(pool);
         _;
     }
 
-    constructor(IVault vault) SingletonAuthentication(vault) {
+    constructor(IVault vault) PoolHelperCommon(vault) {
         // solhint-disable-previous-line no-empty-blocks
     }
 
     /***************************************************************************
                                     Manage Pools
     ***************************************************************************/
-
-    /// @inheritdoc IProtocolFeeHelper
-    function addPools(address[] calldata newPools) external authenticate {
-        uint256 length = newPools.length;
-        IVault vault = getVault();
-
-        for (uint256 i = 0; i < length; i++) {
-            address pool = newPools[i];
-
-            // Ensure the address is a valid pool.
-            if (vault.isPoolRegistered(pool) == false) {
-                revert IVaultErrors.PoolNotRegistered(pool);
-            }
-
-            if (_pools.add(pool) == false) {
-                revert PoolAlreadyInProtocolFeeSet(pool);
-            }
-
-            emit PoolAddedToProtocolFeeSet(pool);
-        }
-    }
-
-    /// @inheritdoc IProtocolFeeHelper
-    function removePools(address[] memory pools) public authenticate {
-        uint256 length = pools.length;
-        for (uint256 i = 0; i < length; i++) {
-            address pool = pools[i];
-            _ensureKnownPool(pool);
-
-            _pools.remove(pool);
-
-            emit PoolRemovedFromProtocolFeeSet(pool);
-        }
-    }
 
     /// @inheritdoc IProtocolFeeHelper
     function setProtocolSwapFeePercentage(
@@ -80,44 +44,11 @@ contract ProtocolFeeHelper is IProtocolFeeHelper, SingletonAuthentication {
     }
 
     /***************************************************************************
-                                    Getters                                
-    ***************************************************************************/
-
-    /// @inheritdoc IProtocolFeeHelper
-    function getPoolCount() external view returns (uint256) {
-        return _pools.length();
-    }
-
-    /// @inheritdoc IProtocolFeeHelper
-    function hasPool(address pool) external view returns (bool) {
-        return _pools.contains(pool);
-    }
-
-    /// @inheritdoc IProtocolFeeHelper
-    function getPools(uint256 from, uint256 to) public view returns (address[] memory pools) {
-        uint256 poolLength = _pools.length();
-        if (from > to || to > poolLength || from >= poolLength) {
-            revert IndexOutOfBounds();
-        }
-
-        pools = new address[](to - from);
-        for (uint256 i = from; i < to; i++) {
-            pools[i - from] = _pools.at(i);
-        }
-    }
-
-    /***************************************************************************
                                 Internal functions                                
     ***************************************************************************/
 
     // The protocol fee controller is upgradeable in the Vault, so we must fetch it every time.
     function _getProtocolFeeController() internal view returns (IProtocolFeeController) {
         return getVault().getProtocolFeeController();
-    }
-
-    function _ensureKnownPool(address pool) internal view {
-        if (_pools.contains(pool) == false) {
-            revert PoolNotInProtocolFeeSet(pool);
-        }
     }
 }

--- a/pkg/standalone-utils/test/foundry/PoolSwapFeeHelper.t.sol
+++ b/pkg/standalone-utils/test/foundry/PoolSwapFeeHelper.t.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.24;
 
-import { IPoolSwapFeeHelper } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IPoolSwapFeeHelper.sol";
 import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
+import { IPoolSwapFeeHelper } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IPoolSwapFeeHelper.sol";
+import { IPoolHelperCommon } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IPoolHelperCommon.sol";
 import { PoolRoleAccounts } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 
@@ -37,7 +38,7 @@ contract PoolSwapFeeHelperTest is BaseVaultTest {
         address[] memory firstPools = _generatePools(10);
         for (uint256 i = 0; i < firstPools.length; i++) {
             vm.expectEmit();
-            emit IPoolSwapFeeHelper.PoolAddedToSwapFeeSet(firstPools[i]);
+            emit IPoolHelperCommon.PoolAddedToSet(firstPools[i]);
         }
 
         feeHelper.addPools(firstPools);
@@ -51,7 +52,7 @@ contract PoolSwapFeeHelperTest is BaseVaultTest {
         address[] memory secondPools = _generatePools(10);
         for (uint256 i = 0; i < secondPools.length; i++) {
             vm.expectEmit();
-            emit IPoolSwapFeeHelper.PoolAddedToSwapFeeSet(secondPools[i]);
+            emit IPoolHelperCommon.PoolAddedToSet(secondPools[i]);
         }
 
         feeHelper.addPools(secondPools);
@@ -71,7 +72,7 @@ contract PoolSwapFeeHelperTest is BaseVaultTest {
         address[] memory pools = _addPools(2);
         pools[1] = pools[0];
 
-        vm.expectRevert(abi.encodeWithSelector(IPoolSwapFeeHelper.PoolAlreadyInSwapFeeSet.selector, pools[1]));
+        vm.expectRevert(abi.encodeWithSelector(IPoolHelperCommon.PoolAlreadyInSet.selector, pools[1]));
         feeHelper.addPools(pools);
     }
 
@@ -111,7 +112,7 @@ contract PoolSwapFeeHelperTest is BaseVaultTest {
 
         for (uint256 i = 0; i < pools.length; i++) {
             vm.expectEmit();
-            emit IPoolSwapFeeHelper.PoolRemovedFromSwapFeeSet(pools[i]);
+            emit IPoolHelperCommon.PoolRemovedFromSet(pools[i]);
         }
 
         feeHelper.removePools(pools);
@@ -126,7 +127,7 @@ contract PoolSwapFeeHelperTest is BaseVaultTest {
     function testRemoveNotExistingPool() public {
         _addPools(10);
 
-        vm.expectRevert(abi.encodeWithSelector(IPoolSwapFeeHelper.PoolNotInSwapFeeSet.selector, address(0x00)));
+        vm.expectRevert(abi.encodeWithSelector(IPoolHelperCommon.PoolNotInSet.selector, address(0x00)));
         feeHelper.removePools(new address[](1));
     }
 
@@ -156,7 +157,7 @@ contract PoolSwapFeeHelperTest is BaseVaultTest {
     function testSetSwapFeeIfPoolIsNotInList() public {
         _addPools(10);
 
-        vm.expectRevert(abi.encodeWithSelector(IPoolSwapFeeHelper.PoolNotInSwapFeeSet.selector, address(0x00)));
+        vm.expectRevert(abi.encodeWithSelector(IPoolHelperCommon.PoolNotInSet.selector, address(0x00)));
         feeHelper.setStaticSwapFeePercentage(address(0), NEW_SWAP_FEE_PERCENTAGE);
     }
 
@@ -202,13 +203,13 @@ contract PoolSwapFeeHelperTest is BaseVaultTest {
         uint256 poolsNum = 10;
 
         _addPools(poolsNum);
-        vm.expectRevert(IPoolSwapFeeHelper.IndexOutOfBounds.selector);
+        vm.expectRevert(IPoolHelperCommon.IndexOutOfBounds.selector);
         feeHelper.getPools(2, 1);
 
-        vm.expectRevert(IPoolSwapFeeHelper.IndexOutOfBounds.selector);
+        vm.expectRevert(IPoolHelperCommon.IndexOutOfBounds.selector);
         feeHelper.getPools(2, poolsNum + 1);
 
-        vm.expectRevert(IPoolSwapFeeHelper.IndexOutOfBounds.selector);
+        vm.expectRevert(IPoolHelperCommon.IndexOutOfBounds.selector);
         feeHelper.getPools(poolsNum, poolsNum);
     }
 

--- a/pkg/standalone-utils/test/foundry/ProtocolFeeHelper.t.sol
+++ b/pkg/standalone-utils/test/foundry/ProtocolFeeHelper.t.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.24;
 
-import { IProtocolFeeHelper } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IProtocolFeeHelper.sol";
 import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
+import { IPoolHelperCommon } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IPoolHelperCommon.sol";
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 
 import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVaultTest.sol";
@@ -47,7 +47,7 @@ contract PoolPauseHelperTest is BaseVaultTest {
         address[] memory firstPools = _generatePools(10);
         for (uint256 i = 0; i < firstPools.length; i++) {
             vm.expectEmit();
-            emit IProtocolFeeHelper.PoolAddedToProtocolFeeSet(firstPools[i]);
+            emit IPoolHelperCommon.PoolAddedToSet(firstPools[i]);
         }
 
         feeHelper.addPools(firstPools);
@@ -61,7 +61,7 @@ contract PoolPauseHelperTest is BaseVaultTest {
         address[] memory secondPools = _generatePools(10);
         for (uint256 i = 0; i < secondPools.length; i++) {
             vm.expectEmit();
-            emit IProtocolFeeHelper.PoolAddedToProtocolFeeSet(secondPools[i]);
+            emit IPoolHelperCommon.PoolAddedToSet(secondPools[i]);
         }
 
         feeHelper.addPools(secondPools);
@@ -81,7 +81,7 @@ contract PoolPauseHelperTest is BaseVaultTest {
         address[] memory pools = _generatePools(2);
         pools[1] = pools[0];
 
-        vm.expectRevert(abi.encodeWithSelector(IProtocolFeeHelper.PoolAlreadyInProtocolFeeSet.selector, pools[1]));
+        vm.expectRevert(abi.encodeWithSelector(IPoolHelperCommon.PoolAlreadyInSet.selector, pools[1]));
         feeHelper.addPools(pools);
     }
 
@@ -100,7 +100,7 @@ contract PoolPauseHelperTest is BaseVaultTest {
 
         for (uint256 i = 0; i < pools.length; i++) {
             vm.expectEmit();
-            emit IProtocolFeeHelper.PoolRemovedFromProtocolFeeSet(pools[i]);
+            emit IPoolHelperCommon.PoolRemovedFromSet(pools[i]);
         }
 
         feeHelper.removePools(pools);
@@ -115,7 +115,7 @@ contract PoolPauseHelperTest is BaseVaultTest {
     function testRemoveNotExistingPool() public {
         _addPools(10);
 
-        vm.expectRevert(abi.encodeWithSelector(IProtocolFeeHelper.PoolNotInProtocolFeeSet.selector, address(0x00)));
+        vm.expectRevert(abi.encodeWithSelector(IPoolHelperCommon.PoolNotInSet.selector, address(0x00)));
         feeHelper.removePools(new address[](1));
     }
 
@@ -148,7 +148,7 @@ contract PoolPauseHelperTest is BaseVaultTest {
     function testSetProtocolFeeIfPoolIsNotInList() public {
         _addPools(10);
 
-        vm.expectRevert(abi.encodeWithSelector(IProtocolFeeHelper.PoolNotInProtocolFeeSet.selector, address(0x00)));
+        vm.expectRevert(abi.encodeWithSelector(IPoolHelperCommon.PoolNotInSet.selector, address(0x00)));
         feeHelper.setProtocolSwapFeePercentage(address(0), NEW_SWAP_FEE_PERCENTAGE);
     }
 
@@ -206,13 +206,13 @@ contract PoolPauseHelperTest is BaseVaultTest {
         uint256 poolsNum = 10;
 
         _addPools(poolsNum);
-        vm.expectRevert(IProtocolFeeHelper.IndexOutOfBounds.selector);
+        vm.expectRevert(IPoolHelperCommon.IndexOutOfBounds.selector);
         feeHelper.getPools(2, 1);
 
-        vm.expectRevert(IProtocolFeeHelper.IndexOutOfBounds.selector);
+        vm.expectRevert(IPoolHelperCommon.IndexOutOfBounds.selector);
         feeHelper.getPools(2, poolsNum + 1);
 
-        vm.expectRevert(IProtocolFeeHelper.IndexOutOfBounds.selector);
+        vm.expectRevert(IPoolHelperCommon.IndexOutOfBounds.selector);
         feeHelper.getPools(poolsNum, poolsNum);
     }
 


### PR DESCRIPTION
# Description

We have three nearly identical helpers that share most of their code. This factors out everything common, so that the helpers really just add their particular function, and it's really easy to make more if we need to.

Could probably factor things out of tests, too, but leaving them to ensure this doesn't break anything.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Resolves #1345.
