### PR TITLE
Add missing getter to factory fee helper

### DIFF
--- a/pkg/interfaces/contracts/vault/IProtocolFeePercentagesProvider.sol
+++ b/pkg/interfaces/contracts/vault/IProtocolFeePercentagesProvider.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.24;
 
+import { IBalancerContractRegistry } from "../standalone-utils/IBalancerContractRegistry.sol";
 import { IProtocolFeeController } from "./IProtocolFeeController.sol";
 
 interface IProtocolFeePercentagesProvider {
@@ -48,7 +49,13 @@ interface IProtocolFeePercentagesProvider {
      * @notice Get the address of the `ProtocolFeeController` used to set fees.
      * @return protocolFeeController The address of the fee controller
      */
-    function getProtocolFeeController() external view returns (IProtocolFeeController);
+    function getProtocolFeeController() external view returns (IProtocolFeeController protocolFeeController);
+
+    /**
+     * @notice Get the address of the `BalancerContractRegistry` used to validate factory contracts.
+     * @return balancerContractRegistry The address of the Balancer contract registry
+     */
+    function getBalancerContractRegistry() external view returns (IBalancerContractRegistry balancerContractRegistry);
 
     /**
      * @notice Query the protocol fee percentages for a given factory.

--- a/pkg/vault/contracts/ProtocolFeePercentagesProvider.sol
+++ b/pkg/vault/contracts/ProtocolFeePercentagesProvider.sol
@@ -71,6 +71,11 @@ contract ProtocolFeePercentagesProvider is IProtocolFeePercentagesProvider, Sing
     }
 
     /// @inheritdoc IProtocolFeePercentagesProvider
+    function getBalancerContractRegistry() external view returns (IBalancerContractRegistry) {
+        return _trustedContractRegistry;
+    }
+
+    /// @inheritdoc IProtocolFeePercentagesProvider
     function getFactorySpecificProtocolFeePercentages(
         address factory
     ) external view returns (uint256 protocolSwapFeePercentage, uint256 protocolYieldFeePercentage) {

--- a/pkg/vault/test/foundry/ProtocolFeePercentagesProvider.t.sol
+++ b/pkg/vault/test/foundry/ProtocolFeePercentagesProvider.t.sol
@@ -84,6 +84,14 @@ contract ProtocolFeePercentagesProviderTest is BaseVaultTest {
         );
     }
 
+    function testGetBalancerContractRegistry() public view {
+        assertEq(
+            address(percentagesProvider.getBalancerContractRegistry()),
+            address(trustedContractRegistry),
+            "Wrong Balancer contract registry"
+        );
+    }
+
     function testGetFactorySpecificProtocolFeePercentagesUnregisteredFactory() public {
         vm.expectRevert(
             abi.encodeWithSelector(IProtocolFeePercentagesProvider.FactoryFeesNotSet.selector, INVALID_ADDRESS)


### PR DESCRIPTION
# Description

In preparing the deployment, I realized we were missing a getter here.

I noticed I need to import from standalone-utils, while the percentages provider is in the Vault package. Should it be in standalone-utils as well?

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
