### PR TITLE
Move ProtocolFeePercentagesProvider to standalone-utils

### DIFF
--- a/pkg/standalone-utils/contracts/ProtocolFeePercentagesProvider.sol
+++ b/pkg/standalone-utils/contracts/ProtocolFeePercentagesProvider.sol
@@ -17,8 +17,8 @@ import {
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 
-import { SingletonAuthentication } from "./SingletonAuthentication.sol";
-import { ProtocolFeeController } from "./ProtocolFeeController.sol";
+import { SingletonAuthentication } from "@balancer-labs/v3-vault/contracts/SingletonAuthentication.sol";
+import { ProtocolFeeController } from "@balancer-labs/v3-vault/contracts/ProtocolFeeController.sol";
 
 contract ProtocolFeePercentagesProvider is IProtocolFeePercentagesProvider, SingletonAuthentication {
     using SafeCast for uint256;

--- a/pkg/standalone-utils/test/foundry/ProtocolFeePercentagesProvider.t.sol
+++ b/pkg/standalone-utils/test/foundry/ProtocolFeePercentagesProvider.t.sol
@@ -17,13 +17,12 @@ import {
 } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IBalancerContractRegistry.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 
-import { BalancerContractRegistry } from "@balancer-labs/v3-standalone-utils/contracts/BalancerContractRegistry.sol";
+import { ProtocolFeeController } from "@balancer-labs/v3-vault/contracts/ProtocolFeeController.sol";
+import { PoolFactoryMock } from "@balancer-labs/v3-vault/contracts/test/PoolFactoryMock.sol";
+import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVaultTest.sol";
 
 import { ProtocolFeePercentagesProvider } from "../../contracts/ProtocolFeePercentagesProvider.sol";
-import { ProtocolFeeController } from "../../contracts/ProtocolFeeController.sol";
-import { PoolFactoryMock } from "../../contracts/test/PoolFactoryMock.sol";
-
-import { BaseVaultTest } from "./utils/BaseVaultTest.sol";
+import { BalancerContractRegistry } from "../../contracts/BalancerContractRegistry.sol";
 
 contract ProtocolFeePercentagesProviderTest is BaseVaultTest {
     address internal constant INVALID_ADDRESS = address(0x1234);


### PR DESCRIPTION
# Description

When looking at the rest of the helpers (and preparing for deployment), there's really no reason for this helper to be in the Vault package. This PR moves it to standalone-utils with the rest.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [X] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
