### PR TITLE
Add ERC4626 to ProtocolFeeSweeper

### DIFF
--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol
@@ -95,13 +95,15 @@ interface IProtocolFeeSweeper {
      * @param minTargetTokenAmountOut The minimum number of target tokens to be received
      * @param deadline Deadline for the burn operation (swap), after which it will revert
      * @param feeBurner The protocol fee burner to be used (or the zero address to fall back on direct transfer)
+     * @param shouldUnwrap Whether to unwrap the target token before burning
      */
     function sweepProtocolFeesForToken(
         address pool,
         IERC20 feeToken,
         uint256 minTargetTokenAmountOut,
         uint256 deadline,
-        IProtocolFeeBurner feeBurner
+        IProtocolFeeBurner feeBurner,
+        bool shouldUnwrap
     ) external;
 
     /**

--- a/pkg/standalone-utils/test/foundry/CowSwapFeeBurner.t.sol
+++ b/pkg/standalone-utils/test/foundry/CowSwapFeeBurner.t.sol
@@ -113,7 +113,7 @@ contract CowSwapFeeBurnerTest is BaseVaultTest {
         emit IProtocolFeeBurner.ProtocolFeeBurned(pool, dai, DEFAULT_AMOUNT, usdc, DEFAULT_AMOUNT, feeRecipient);
 
         vm.startPrank(admin);
-        feeSweeper.sweepProtocolFeesForToken(pool, dai, DEFAULT_AMOUNT, orderDeadline, cowSwapFeeBurner);
+        feeSweeper.sweepProtocolFeesForToken(pool, dai, DEFAULT_AMOUNT, orderDeadline, cowSwapFeeBurner, false);
 
         assertEq(
             dai.balanceOf(address(cowSwapFeeBurner)),


### PR DESCRIPTION
# Description

This PR adds an unwrap functionality for ERC4626 tokens. The unwrap happens before interacting with the fee burner, so a boolean flag was added to sweepProtocolFeesForToken to let the admin choose whether to burn the ERC4626 token or unwrap it first. The unwrap is done directly via the token to save gas.

It would’ve been possible to avoid modifying sweepProtocolFeesForToken, but in this case I think that unwrapping the token is a responsibility of the ProtocolFeeSweeper, since the Burner is only responsible for burning tokens.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #1355

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
