### PR TITLE
Remove redundant setter in vault mock

### DIFF
--- a/pkg/interfaces/contracts/test/IVaultExtensionMock.sol
+++ b/pkg/interfaces/contracts/test/IVaultExtensionMock.sol
@@ -7,9 +7,6 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { TokenConfig, PoolRoleAccounts, LiquidityManagement } from "../../contracts/vault/VaultTypes.sol";
 
 interface IVaultExtensionMock {
-    // Used in tests to circumvent minimum swap fees.
-    function manuallySetSwapFee(address pool, uint256 swapFeePercentage) external;
-
     function manualRegisterPoolReentrancy(
         address pool,
         TokenConfig[] memory tokenConfig,

--- a/pkg/pool-hooks/test/foundry/StableSurgeHook.t.sol
+++ b/pkg/pool-hooks/test/foundry/StableSurgeHook.t.sol
@@ -247,7 +247,7 @@ contract StableSurgeHookTest is BaseVaultTest, StableSurgeHookDeployer {
         amountGivenScaled18 = bound(amountGivenScaled18, 1e18, poolInitAmount / 2);
         SwapKind kind = SwapKind(bound(kindRaw, 0, 1));
 
-        vault.manuallySetSwapFee(pool, bound(swapFeePercentageRaw, 0, 1e16));
+        vault.manualUnsafeSetStaticSwapFeePercentage(pool, bound(swapFeePercentageRaw, 0, 1e16));
         uint256 swapFeePercentage = vault.getStaticSwapFeePercentage(pool);
 
         BaseVaultTest.Balances memory balancesBefore = getBalances(alice);

--- a/pkg/pool-hooks/test/foundry/StableSurgeHookUnit.t.sol
+++ b/pkg/pool-hooks/test/foundry/StableSurgeHookUnit.t.sol
@@ -190,7 +190,7 @@ contract StableSurgeHookUnitTest is BaseVaultTest, StableSurgeHookDeployer {
 
         // Set a larger static fee percentage.
         uint256 staticFeePercentage = 2e16; // 2%
-        vault.manuallySetSwapFee(pool, staticFeePercentage);
+        vault.manualUnsafeSetStaticSwapFeePercentage(pool, staticFeePercentage);
 
         // Create an unbalanced state to mock an imbalance in the pool. This would normally trigger surge pricing and
         // revert due to a math underflow, but the surge logic is currently blocked because maxSurgeFeePercentage <

--- a/pkg/pool-utils/test/foundry/PoolInfo.t.sol
+++ b/pkg/pool-utils/test/foundry/PoolInfo.t.sol
@@ -161,7 +161,7 @@ contract PoolInfoTest is BaseTest, VaultContractsDeployer {
 
     function testGetStaticSwapFeePercentage() public {
         uint256 expectedSwapFeePercentage = 10e16; // 10%
-        vault.manuallySetSwapFee(address(poolInfo), expectedSwapFeePercentage);
+        vault.manualUnsafeSetStaticSwapFeePercentage(address(poolInfo), expectedSwapFeePercentage);
 
         uint256 swapFeePercentage = poolInfo.getStaticSwapFeePercentage();
         assertEq(swapFeePercentage, expectedSwapFeePercentage, "Incorrect swap fee percentage");

--- a/pkg/pool-weighted/test/foundry/WeightedPoolLimits.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedPoolLimits.t.sol
@@ -298,7 +298,7 @@ contract WeightedPoolLimitsTest is BaseVaultTest, WeightedPoolContractsDeployer 
 
     function _testSwap() public {
         // Set swap fee to zero for this test.
-        vault.manuallySetSwapFee(pool, 0);
+        vault.manualUnsafeSetStaticSwapFeePercentage(pool, 0);
         startingBalances[daiIdx] = dai.balanceOf(bob);
         startingBalances[usdcIdx] = usdc.balanceOf(bob);
 

--- a/pkg/vault/contracts/test/VaultExtensionMock.sol
+++ b/pkg/vault/contracts/test/VaultExtensionMock.sol
@@ -25,10 +25,6 @@ contract VaultExtensionMock is IVaultExtensionMock, VaultExtension {
         return keccak256(input);
     }
 
-    function manuallySetSwapFee(address pool, uint256 newSwapFee) external {
-        _poolConfigBits[pool] = _poolConfigBits[pool].setStaticSwapFeePercentage(newSwapFee);
-    }
-
     function manualRegisterPoolReentrancy(
         address pool,
         TokenConfig[] memory tokenConfig,

--- a/pkg/vault/test/foundry/Fungibility.t.sol
+++ b/pkg/vault/test/foundry/Fungibility.t.sol
@@ -16,7 +16,7 @@ contract FungibilityTest is BaseVaultTest {
         super.setUp();
 
         // Sets swap fee to 0, so we measure the real amount of minted BPTs.
-        vault.manuallySetSwapFee(pool, 0);
+        vault.manualUnsafeSetStaticSwapFeePercentage(pool, 0);
     }
 
     function testFungibilityAddUnbalanced__Fuzz(uint256 proportion) public {

--- a/pkg/vault/test/foundry/LiquidityApproximation.t.sol
+++ b/pkg/vault/test/foundry/LiquidityApproximation.t.sol
@@ -412,8 +412,8 @@ contract LiquidityApproximationTest is BaseVaultTest {
     // Utils
 
     function assertLiquidityOperationNoSwapFee() internal {
-        vault.manuallySetSwapFee(liquidityPool, 0);
-        vault.manuallySetSwapFee(swapPool, 0);
+        vault.manualUnsafeSetStaticSwapFeePercentage(liquidityPool, 0);
+        vault.manualUnsafeSetStaticSwapFeePercentage(swapPool, 0);
 
         // Alice and Bob have no BPT tokens.
         assertEq(IERC20(swapPool).balanceOf(alice), 0, "Alice should have 0 BPT");

--- a/pkg/vault/test/foundry/fuzz/AddAndRemoveLiquidity.medusa.sol
+++ b/pkg/vault/test/foundry/fuzz/AddAndRemoveLiquidity.medusa.sol
@@ -37,7 +37,7 @@ contract AddAndRemoveLiquidityMedusaTest is BaseMedusaTest {
         initialRate = vault.getBptRate(address(pool));
         // Set swap fee percentage to 0, which is the worst scenario since there's no LP fees. Circumvent minimum swap
         // fees, for testing purposes.
-        vault.manuallySetSwapFee(address(pool), 0);
+        vault.manualUnsafeSetStaticSwapFeePercentage(address(pool), 0);
     }
 
     /*******************************************************************************

--- a/pkg/vault/test/foundry/fuzz/Swap.medusa.sol
+++ b/pkg/vault/test/foundry/fuzz/Swap.medusa.sol
@@ -25,7 +25,7 @@ contract SwapMedusaTest is BaseMedusaTest {
 
     constructor() BaseMedusaTest() {
         initInvariant = computeInvariant();
-        vault.manuallySetSwapFee(address(pool), 0);
+        vault.manualUnsafeSetStaticSwapFeePercentage(address(pool), 0);
 
         emit Debug("prevInvariant", initInvariant);
     }

--- a/pkg/vault/test/foundry/utils/BasePoolTest.sol
+++ b/pkg/vault/test/foundry/utils/BasePoolTest.sol
@@ -196,7 +196,7 @@ abstract contract BasePoolTest is BaseVaultTest {
 
     function testSwap() public virtual {
         if (!isTestSwapFeeEnabled) {
-            vault.manuallySetSwapFee(pool, 0);
+            vault.manualUnsafeSetStaticSwapFeePercentage(pool, 0);
         }
 
         IERC20 tokenIn = poolTokens[tokenIndexIn];

--- a/pkg/vault/test/foundry/utils/BaseVaultTest.sol
+++ b/pkg/vault/test/foundry/utils/BaseVaultTest.sol
@@ -309,7 +309,7 @@ abstract contract BaseVaultTest is VaultContractsDeployer, VaultStorage, BaseTes
     }
 
     function _setSwapFeePercentage(address setPool, uint256 percentage) internal {
-        vault.manuallySetSwapFee(setPool, percentage);
+        vault.manualUnsafeSetStaticSwapFeePercentage(setPool, percentage);
     }
 
     function getBalances(address user) internal view returns (Balances memory balances) {


### PR DESCRIPTION
# Description

Small fix to reduce redundancy and confusion around manual static swap fee setter.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- N/A Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A