### PR TITLE
Remove redundant argument from fee percentage provider

### DIFF
--- a/pkg/standalone-utils/contracts/ProtocolFeePercentagesProvider.sol
+++ b/pkg/standalone-utils/contracts/ProtocolFeePercentagesProvider.sol
@@ -46,14 +46,8 @@ contract ProtocolFeePercentagesProvider is IProtocolFeePercentagesProvider, Sing
     // Factory address => FactoryProtocolFees
     mapping(IBasePoolFactory => FactoryProtocolFees) private _factoryDefaultFeePercentages;
 
-    constructor(
-        IVault vault,
-        IProtocolFeeController protocolFeeController,
-        IBalancerContractRegistry trustedContractRegistry
-    ) SingletonAuthentication(vault) {
-        if (protocolFeeController.vault() != vault) {
-            revert WrongProtocolFeeControllerDeployment();
-        }
+    constructor(IVault vault, IBalancerContractRegistry trustedContractRegistry) SingletonAuthentication(vault) {
+        IProtocolFeeController protocolFeeController = vault.getProtocolFeeController();
 
         _protocolFeeController = protocolFeeController;
         _trustedContractRegistry = trustedContractRegistry;

--- a/pkg/standalone-utils/test/foundry/ProtocolFeePercentagesProvider.t.sol
+++ b/pkg/standalone-utils/test/foundry/ProtocolFeePercentagesProvider.t.sol
@@ -42,7 +42,7 @@ contract ProtocolFeePercentagesProviderTest is BaseVaultTest {
         BaseVaultTest.setUp();
 
         trustedContractRegistry = new BalancerContractRegistry(vault);
-        percentagesProvider = new ProtocolFeePercentagesProvider(vault, feeController, trustedContractRegistry);
+        percentagesProvider = new ProtocolFeePercentagesProvider(vault, trustedContractRegistry);
 
         // Mark the poolFactory as trusted, so that operations on it won't fail.
         authorizer.grantRole(
@@ -68,11 +68,6 @@ contract ProtocolFeePercentagesProviderTest is BaseVaultTest {
 
         pools = new address[](1);
         pools[0] = pool;
-    }
-
-    function testInvalidConstruction() public {
-        vm.expectRevert(IProtocolFeePercentagesProvider.WrongProtocolFeeControllerDeployment.selector);
-        new ProtocolFeePercentagesProvider(IVault(INVALID_ADDRESS), feeController, trustedContractRegistry);
     }
 
     function testGetProtocolFeeController() public view {


### PR DESCRIPTION
# Description

It's just easier to grab the fee controller from the vault directly; might save some headaches in the deployment scripts.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- N/A Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A