### PR TITLE
Add ERC4626 cow burner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,20 @@ jobs:
       - name: Test
         run: yarn workspace @balancer-labs/v3-solidity-utils test:hardhat
 
+  test-forge-standalone-utils:
+    runs-on: ubuntu-latest
+    needs: lint-and-build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up environment
+        uses: ./.github/actions/setup
+      - uses: actions/download-artifact@v4
+        with:
+          name: built-contracts
+          path: pkg/
+      - name: Test
+        run: yarn workspace @balancer-labs/v3-standalone-utils test:forge
+
   test-forge-solidity-utils:
     runs-on: ubuntu-latest
     needs: lint-and-build

--- a/pkg/interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol
@@ -36,7 +36,7 @@ interface IProtocolFeeBurner {
 
     /**
      * @notice Swap an exact amount of `feeToken` for the `targetToken`, and send proceeds to the `recipient`.
-     * @dev Assumes the sweeper has transferred the tokens to the burner prior to the call.
+     * @dev Assumes the sweeper has granted allowance for the fee tokens to the burner prior to the call.
      * @param pool The pool the fees came from (only used for documentation in the event)
      * @param feeToken The token collected from the pool
      * @param exactFeeTokenAmountIn The number of fee tokens collected

--- a/pkg/standalone-utils/contracts/CowSwapFeeBurner.sol
+++ b/pkg/standalone-utils/contracts/CowSwapFeeBurner.sol
@@ -20,6 +20,9 @@ import {
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 
 import { Version } from "@balancer-labs/v3-solidity-utils/contracts/helpers/Version.sol";
+import {
+    ReentrancyGuardTransient
+} from "@balancer-labs/v3-solidity-utils/contracts/openzeppelin/ReentrancyGuardTransient.sol";
 import { SingletonAuthentication } from "@balancer-labs/v3-vault/contracts/SingletonAuthentication.sol";
 
 // solhint-disable not-rely-on-time
@@ -30,7 +33,7 @@ import { SingletonAuthentication } from "@balancer-labs/v3-vault/contracts/Singl
  * @dev The Cow Watchtower (https://github.com/cowprotocol/watch-tower) must be running for the burner to function.
  * Only one order per token is allowed at a time.
  */
-contract CowSwapFeeBurner is ICowSwapFeeBurner, SingletonAuthentication, Version {
+contract CowSwapFeeBurner is ICowSwapFeeBurner, SingletonAuthentication, ReentrancyGuardTransient, Version {
     using SafeERC20 for IERC20;
 
     struct ShortOrder {
@@ -129,19 +132,41 @@ contract CowSwapFeeBurner is ICowSwapFeeBurner, SingletonAuthentication, Version
     function burn(
         address pool,
         IERC20 feeToken,
-        uint256 feeTokenAmount,
+        uint256 exactFeeTokenAmountIn,
         IERC20 targetToken,
-        uint256 minAmountOut,
+        uint256 minTargetTokenAmountOut,
         address recipient,
         uint256 deadline
-    ) external authenticate {
+    ) external authenticate nonReentrant virtual {
+        _burn(
+            pool,
+            feeToken,
+            exactFeeTokenAmountIn,
+            targetToken,
+            minTargetTokenAmountOut,
+            recipient,
+            deadline,
+            true // pullFeeToken
+        );
+    }
+
+    function _burn(
+        address pool,
+        IERC20 feeToken,
+        uint256 feeTokenAmount,
+        IERC20 targetToken,
+        uint256 minTargetTokenAmountOut,
+        address recipient,
+        uint256 deadline,
+        bool pullFeeToken
+    ) internal {
         if (targetToken == feeToken) {
             revert InvalidOrderParameters("Fee token and target token are the same");
         } else if (feeTokenAmount == 0) {
             revert InvalidOrderParameters("Fee token amount is zero");
         }
 
-        _checkMinAmountOut(minAmountOut);
+        _checkMinAmountOut(minTargetTokenAmountOut);
         _checkDeadline(deadline);
 
         (OrderStatus status, ) = _getOrderStatusAndBalance(feeToken);
@@ -149,7 +174,9 @@ contract CowSwapFeeBurner is ICowSwapFeeBurner, SingletonAuthentication, Version
             revert OrderHasUnexpectedStatus(status);
         }
 
-        feeToken.safeTransferFrom(msg.sender, address(this), feeTokenAmount);
+        if (pullFeeToken) {
+            feeToken.safeTransferFrom(msg.sender, address(this), feeTokenAmount);
+        }
 
         _createCowOrder(feeToken);
 
@@ -158,11 +185,11 @@ contract CowSwapFeeBurner is ICowSwapFeeBurner, SingletonAuthentication, Version
         _orders[feeToken] = ShortOrder({
             tokenOut: targetToken,
             receiver: recipient,
-            minAmountOut: minAmountOut,
+            minAmountOut: minTargetTokenAmountOut,
             deadline: uint32(deadline)
         });
 
-        emit ProtocolFeeBurned(pool, feeToken, feeTokenAmount, targetToken, minAmountOut, recipient);
+        emit ProtocolFeeBurned(pool, feeToken, feeTokenAmount, targetToken, minTargetTokenAmountOut, recipient);   
     }
 
     /***************************************************************************

--- a/pkg/standalone-utils/contracts/CowSwapFeeBurner.sol
+++ b/pkg/standalone-utils/contracts/CowSwapFeeBurner.sol
@@ -137,7 +137,7 @@ contract CowSwapFeeBurner is ICowSwapFeeBurner, SingletonAuthentication, Reentra
         uint256 minTargetTokenAmountOut,
         address recipient,
         uint256 deadline
-    ) external authenticate nonReentrant virtual {
+    ) external virtual authenticate nonReentrant {
         _burn(
             pool,
             feeToken,
@@ -189,7 +189,7 @@ contract CowSwapFeeBurner is ICowSwapFeeBurner, SingletonAuthentication, Reentra
             deadline: uint32(deadline)
         });
 
-        emit ProtocolFeeBurned(pool, feeToken, feeTokenAmount, targetToken, minTargetTokenAmountOut, recipient);   
+        emit ProtocolFeeBurned(pool, feeToken, feeTokenAmount, targetToken, minTargetTokenAmountOut, recipient);
     }
 
     /***************************************************************************

--- a/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
+++ b/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
@@ -53,13 +53,13 @@ contract ERC4626CowSwapFeeBurner is CowSwapFeeBurner {
 
     /**
      * @notice Treats `feeToken` as an ERC4626, redeems `exactFeeTokenAmountIn`, swaps the underlying asset for
-     * `targetToken`, and send proceeds to the `recipient`.
+     * `targetToken`, and sends the proceeds to the `recipient`.
      * @dev Assumes the sweeper has granted allowance for the fee tokens to the burner prior to the call.
      * @param pool The pool the fees came from (only used for documentation in the event)
      * @param feeToken The token collected from the pool
      * @param exactFeeTokenAmountIn The number of fee tokens collected
-     * @param targetToken The desired target token (token out of the swap)
-     * @param minTargetTokenAmountOut The minimum amount out for the swap
+     * @param targetToken The desired target token (`tokenOut` of the swap)
+     * @param minTargetTokenAmountOut The minimum `amountOut` for the swap
      * @param recipient The recipient of the swap proceeds
      * @param deadline Deadline for the burn operation (i.e., swap), after which it will revert
      */

--- a/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
+++ b/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
@@ -71,7 +71,7 @@ contract ERC4626CowSwapFeeBurner is CowSwapFeeBurner {
         uint256 minTargetTokenAmountOut,
         address recipient,
         uint256 deadline
-    ) external onlyProtocolFeeSweeper nonReentrant override {
+    ) external override onlyProtocolFeeSweeper nonReentrant {
         // In this case we first pull the wrapped token, unwrap, and then proceed to burn by creating an order for
         // the underlying token.
         feeToken.safeTransferFrom(msg.sender, address(this), exactFeeTokenAmountIn);

--- a/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
+++ b/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IComposableCow } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IComposableCow.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+
+import {
+    ReentrancyGuardTransient
+} from "@balancer-labs/v3-solidity-utils/contracts/openzeppelin/ReentrancyGuardTransient.sol";
+
+import { CowSwapFeeBurner } from "./CowSwapFeeBurner.sol";
+
+/**
+ * @title ERC4626CowSwapFeeBurner
+ * @notice A contract that burns ERC4626 protocol fee tokens using CowSwap, previously redeeming underlying assets.
+ * @dev The Cow Watchtower (https://github.com/cowprotocol/watch-tower) must be running for the burner to function.
+ * Only one order per token is allowed at a time.
+ */
+contract ERC4626CowSwapFeeBurner is CowSwapFeeBurner {
+    using SafeERC20 for IERC20;
+
+    constructor(
+        IVault vault,
+        IComposableCow composableCow,
+        address vaultRelayer,
+        bytes32 appData,
+        string memory version
+    ) CowSwapFeeBurner(vault, composableCow, vaultRelayer, appData, version) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    /**
+     * @notice Treats `feeToken` as an ERC4626, redeems `exactFeeTokenAmountIn`, swaps the underlying asset for
+     * `targetToken`, and send proceeds to the `recipient`.
+     * @dev Assumes the sweeper has granted allowance for the fee tokens to the burner prior to the call.
+     * @param pool The pool the fees came from (only used for documentation in the event)
+     * @param feeToken The token collected from the pool
+     * @param exactFeeTokenAmountIn The number of fee tokens collected
+     * @param targetToken The desired target token (token out of the swap)
+     * @param minTargetTokenAmountOut The minimum amount out for the swap
+     * @param recipient The recipient of the swap proceeds
+     * @param deadline Deadline for the burn operation (i.e., swap), after which it will revert
+     */
+    function burn(
+        address pool,
+        IERC20 feeToken,
+        uint256 exactFeeTokenAmountIn,
+        IERC20 targetToken,
+        uint256 minTargetTokenAmountOut,
+        address recipient,
+        uint256 deadline
+    ) external authenticate nonReentrant override {
+        // In this case we first pull the wrapped token, unwrap, and then proceed to burn by creating an order for
+        // the underlying token.
+        feeToken.safeTransferFrom(msg.sender, address(this), exactFeeTokenAmountIn);
+
+        // Redeem and overwrite inputs with new asset and unwrapped amount.
+        IERC4626 erc4626Token = IERC4626(address(feeToken));
+        feeToken = IERC20(erc4626Token.asset());
+        exactFeeTokenAmountIn = erc4626Token.redeem(exactFeeTokenAmountIn, address(this), address(this));
+
+        // This case is not handled by the internal `_burn` function, but it's valid: we can consider that the token
+        // has already been converted to the correct token, so we just forward the result.
+        if (feeToken == targetToken) {
+            // We apply the slippage check, but not deadline as the order settlement is instant in this case.
+            if (exactFeeTokenAmountIn < minTargetTokenAmountOut) {
+                revert AmountOutBelowMin(targetToken, exactFeeTokenAmountIn, minTargetTokenAmountOut);
+            }
+            feeToken.safeTransfer(recipient, exactFeeTokenAmountIn);
+        }
+
+        _burn(
+            pool,
+            feeToken,
+            exactFeeTokenAmountIn,
+            targetToken,
+            minTargetTokenAmountOut,
+            recipient,
+            deadline,
+            false // pullToken
+        );
+    }
+}

--- a/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
+++ b/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
@@ -82,13 +82,15 @@ contract ERC4626CowSwapFeeBurner is CowSwapFeeBurner {
         exactFeeTokenAmountIn = erc4626Token.redeem(exactFeeTokenAmountIn, address(this), address(this));
 
         // This case is not handled by the internal `_burn` function, but it's valid: we can consider that the token
-        // has already been converted to the correct token, so we just forward the result.
+        // has already been converted to the correct token, so we just forward the result and finish.
         if (feeToken == targetToken) {
             // We apply the slippage check, but not deadline as the order settlement is instant in this case.
             if (exactFeeTokenAmountIn < minTargetTokenAmountOut) {
                 revert AmountOutBelowMin(targetToken, exactFeeTokenAmountIn, minTargetTokenAmountOut);
             }
+
             feeToken.safeTransfer(recipient, exactFeeTokenAmountIn);
+            return;
         }
 
         _burn(

--- a/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
+++ b/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
@@ -90,18 +90,17 @@ contract ERC4626CowSwapFeeBurner is CowSwapFeeBurner {
             }
 
             feeToken.safeTransfer(recipient, exactFeeTokenAmountIn);
-            return;
+        } else {
+            _burn(
+                pool,
+                feeToken,
+                exactFeeTokenAmountIn,
+                targetToken,
+                minTargetTokenAmountOut,
+                recipient,
+                deadline,
+                false // pullToken
+            );
         }
-
-        _burn(
-            pool,
-            feeToken,
-            exactFeeTokenAmountIn,
-            targetToken,
-            minTargetTokenAmountOut,
-            recipient,
-            deadline,
-            false // pullToken
-        );
     }
 }

--- a/pkg/standalone-utils/test/foundry/ERC4626CowSwapFeeBurner.t.sol
+++ b/pkg/standalone-utils/test/foundry/ERC4626CowSwapFeeBurner.t.sol
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import { IERC1271 } from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IProtocolFeeSweeper } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IProtocolFeeSweeper.sol";
+import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
+import { IVersion } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IVersion.sol";
+import { IProtocolFeeBurner } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IProtocolFeeBurner.sol";
+import { ICowSwapFeeBurner } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/ICowSwapFeeBurner.sol";
+import { IProtocolFeeController } from "@balancer-labs/v3-interfaces/contracts/vault/IProtocolFeeController.sol";
+import { IComposableCow } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IComposableCow.sol";
+import {
+    ICowConditionalOrderGenerator
+} from "@balancer-labs/v3-interfaces/contracts/standalone-utils/ICowConditionalOrderGenerator.sol";
+import {
+    ICowConditionalOrder,
+    GPv2Order
+} from "@balancer-labs/v3-interfaces/contracts/standalone-utils/ICowConditionalOrder.sol";
+
+import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVaultTest.sol";
+
+import { ProtocolFeeSweeper } from "../../contracts/ProtocolFeeSweeper.sol";
+import { CowSwapFeeBurner } from "../../contracts/CowSwapFeeBurner.sol";
+import { ERC4626CowSwapFeeBurner } from "../../contracts/ERC4626CowSwapFeeBurner.sol";
+
+contract ERC4626CowSwapFeeBurnerTest is BaseVaultTest {
+    using SafeERC20 for IERC20;
+
+    bytes32 internal immutable SELL_KIND = keccak256("sell");
+    bytes32 internal immutable TOKEN_BALANCE = keccak256("erc20");
+    bytes32 immutable APP_DATA_HASH = keccak256("appData");
+
+    uint256 constant TEST_BURN_AMOUNT = 1e18;
+    uint256 constant MIN_TARGET_TOKEN_AMOUNT = 1e18;
+    uint256 constant ORDER_LIFETIME = 1 days;
+    string constant VERSION = "v1";
+
+    uint256 internal orderDeadline;
+
+    IAuthentication internal cowSwapFeeBurnerAuth;
+    IAuthentication internal feeSweeperAuth;
+
+    address internal composableCowMock = address(bytes20(bytes32("composableCowMock")));
+    address internal vaultRelayerMock = address(bytes20(bytes32("vaultRelayerMock")));
+    address internal feeRecipient;
+
+    ICowSwapFeeBurner internal cowSwapFeeBurner;
+    IProtocolFeeSweeper internal feeSweeper;
+
+    function setUp() public override {
+        BaseVaultTest.setUp();
+
+        orderDeadline = block.timestamp + ORDER_LIFETIME;
+
+        (feeRecipient, ) = makeAddrAndKey("feeRecipient");
+
+        // Only fee sweeper can call `burn`, so for simplicity we just make the admin the fee sweeper for the purpose
+        // of this test.
+        cowSwapFeeBurner = new ERC4626CowSwapFeeBurner(
+            IProtocolFeeSweeper(admin),
+            vault,
+            IComposableCow(composableCowMock),
+            vaultRelayerMock,
+            APP_DATA_HASH,
+            VERSION
+        );
+    }
+
+    function testBurn() public {
+        // Admin will call `burn` acting as the fee sweeper. The burner will pull tokens from them.
+        vm.prank(admin);
+        waDAI.approve(address(cowSwapFeeBurner), TEST_BURN_AMOUNT);
+
+        uint256 cowSwapFeeBurnerWaDaiBalanceBefore = waDAI.balanceOf(address(cowSwapFeeBurner));
+        uint256 cowSwapFeeBurnerDaiBalanceBefore = dai.balanceOf(address(cowSwapFeeBurner));
+        uint256 callerWaDaiBalanceBefore = waDAI.balanceOf(address(admin));
+
+        vm.expectRevert(abi.encodeWithSelector(ICowConditionalOrder.OrderNotValid.selector, "Order does not exist"));
+        cowSwapFeeBurner.getOrder(dai);
+
+        _mockComposableCowCreate(dai);
+
+        uint256 assetsAmount = waDAI.previewRedeem(TEST_BURN_AMOUNT);
+        require(assetsAmount != TEST_BURN_AMOUNT, "No point testing when rate is 1:1");
+
+        vm.expectEmit();
+        emit IProtocolFeeBurner.ProtocolFeeBurned(address(0), dai, assetsAmount, usdc, MIN_TARGET_TOKEN_AMOUNT, alice);
+
+        vm.prank(admin);
+        cowSwapFeeBurner.burn(address(0), waDAI, TEST_BURN_AMOUNT, usdc, MIN_TARGET_TOKEN_AMOUNT, alice, orderDeadline);
+
+        assertEq(
+            waDAI.balanceOf(admin),
+            callerWaDaiBalanceBefore - TEST_BURN_AMOUNT,
+            "caller should have sent the fee to the burner"
+        );
+
+        assertEq(
+            waDAI.balanceOf(address(cowSwapFeeBurner)),
+            cowSwapFeeBurnerWaDaiBalanceBefore,
+            "cowSwapFeeBurner should have received _and redeemed_ the fee"
+        );
+
+        assertEq(
+            dai.balanceOf(address(cowSwapFeeBurner)),
+            cowSwapFeeBurnerDaiBalanceBefore + assetsAmount,
+            "cowSwapFeeBurner should have received the fee"
+        );
+
+        assertEq(waDAI.allowance(admin, address(cowSwapFeeBurner)), 0, "Hanging allowance between caller and burner");
+
+        assertEq(
+            dai.allowance(address(cowSwapFeeBurner), vaultRelayerMock),
+            assetsAmount,
+            "vaultRelayer should have been approved to transfer the fee"
+        );
+
+        GPv2Order memory order = cowSwapFeeBurner.getOrder(dai);
+        GPv2Order memory expectedOrder = GPv2Order({
+            sellToken: IERC20(address(dai)),
+            buyToken: IERC20(address(usdc)),
+            receiver: alice,
+            sellAmount: assetsAmount,
+            buyAmount: MIN_TARGET_TOKEN_AMOUNT,
+            validTo: uint32(orderDeadline),
+            appData: APP_DATA_HASH,
+            feeAmount: 0,
+            kind: SELL_KIND,
+            partiallyFillable: true,
+            sellTokenBalance: TOKEN_BALANCE,
+            buyTokenBalance: TOKEN_BALANCE
+        });
+
+        assertEq(keccak256(abi.encode(order)), keccak256(abi.encode(expectedOrder)), "Order has incorrect values");
+    }
+
+    /// @dev No order is created in this case; tokens are forwarded to the receiver directly.
+    function testBurnFeeTokenIsTargetToken() public {
+        // Admin will call `burn` acting as the fee sweeper. The burner will pull tokens from them.
+        vm.prank(admin);
+        waDAI.approve(address(cowSwapFeeBurner), TEST_BURN_AMOUNT);
+
+        uint256 cowSwapFeeBurnerWaDaiBalanceBefore = waDAI.balanceOf(address(cowSwapFeeBurner));
+        uint256 cowSwapFeeBurnerDaiBalanceBefore = dai.balanceOf(address(cowSwapFeeBurner));
+        uint256 callerWaDaiBalanceBefore = waDAI.balanceOf(address(admin));
+        uint256 receiverDaiBalanceBefore = dai.balanceOf(alice);
+
+        uint256 assetsAmount = waDAI.previewRedeem(TEST_BURN_AMOUNT);
+        require(assetsAmount != TEST_BURN_AMOUNT, "No point testing when rate is 1:1");
+
+        // Target token is now DAI, which is waDAI.asset().
+        // Deadline doesn't matter in this case, as settlement is instant.
+        vm.prank(admin);
+        cowSwapFeeBurner.burn(address(0), waDAI, TEST_BURN_AMOUNT, dai, assetsAmount, alice, 0);
+
+        assertEq(
+            waDAI.balanceOf(admin),
+            callerWaDaiBalanceBefore - TEST_BURN_AMOUNT,
+            "caller should have sent the fee to the burner"
+        );
+
+        assertEq(
+            waDAI.balanceOf(address(cowSwapFeeBurner)),
+            cowSwapFeeBurnerWaDaiBalanceBefore,
+            "cowSwapFeeBurner should have received _and redeemed_ the fee"
+        );
+
+        assertEq(
+            dai.balanceOf(address(cowSwapFeeBurner)),
+            cowSwapFeeBurnerDaiBalanceBefore,
+            "cowSwapFeeBurner should have received _and forwarded_ the asset"
+        );
+
+        assertEq(waDAI.allowance(admin, address(cowSwapFeeBurner)), 0, "Hanging allowance between caller and burner");
+
+        assertEq(
+            dai.balanceOf(alice),
+            receiverDaiBalanceBefore + assetsAmount,
+            "Receiver should have gotten the redeemed assets directly"
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(ICowConditionalOrder.OrderNotValid.selector, "Order does not exist"));
+        cowSwapFeeBurner.getOrder(dai);
+    }
+
+    function testBurnFeeTokenIsTargetTokenBelowMin() public {
+        // Admin will call `burn` acting as the fee sweeper. The burner will pull tokens from them.
+        vm.prank(admin);
+        waDAI.approve(address(cowSwapFeeBurner), TEST_BURN_AMOUNT);
+
+        uint256 assetsAmount = waDAI.previewRedeem(TEST_BURN_AMOUNT);
+        require(assetsAmount != TEST_BURN_AMOUNT, "No point testing when rate is 1:1");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IProtocolFeeBurner.AmountOutBelowMin.selector, dai, assetsAmount, assetsAmount + 1)
+        );
+        // Target token is now DAI, which is waDAI.asset().
+        vm.prank(admin);
+        cowSwapFeeBurner.burn(address(0), waDAI, TEST_BURN_AMOUNT, dai, assetsAmount + 1, alice, orderDeadline);
+    }
+
+    function _mockComposableCowCreate(IERC20 sellToken) internal {
+        vm.mockCall(
+            composableCowMock,
+            abi.encodeWithSelector(
+                IComposableCow.create.selector,
+                ICowConditionalOrder.ConditionalOrderParams({
+                    handler: ICowConditionalOrder(cowSwapFeeBurner),
+                    salt: bytes32(0),
+                    staticData: abi.encode(sellToken)
+                }),
+                true
+            ),
+            new bytes(0)
+        );
+    }
+}


### PR DESCRIPTION
# Description

An alternative approach to #1365.
This is not my personal preferred approach from an architecture's standpoint, but it's easier to wire up governance-wise and we might be able to use it in the meantime.

Instead of unwrapping at the sweeper, we can deploy a new cow burner that unwraps before posting the order.
It has a few caveats: it must pull the tokens from the sweeper before creating the order and handle a few edge cases. But other than that it's rather reasonable.

Tests pending.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A