### PR TITLE
Adjust e2e swap tests to allow fuzz params to edit limits

### DIFF
--- a/pkg/pool-gyro/test/foundry/E2eSwap2CLP.t.sol
+++ b/pkg/pool-gyro/test/foundry/E2eSwap2CLP.t.sol
@@ -87,7 +87,13 @@ contract E2eSwapGyro2CLPTest is E2eSwapTest, Gyro2ClpPoolDeployer {
         maxSwapAmountTokenB = poolInitAmountTokenB.mulDown(50e16);
     }
 
-    function fuzzPoolParams(uint256[POOL_SPECIFIC_PARAMS_SIZE] memory params) internal override {
+    function fuzzPoolParams(
+        uint256[POOL_SPECIFIC_PARAMS_SIZE] memory params
+    )
+        internal
+        override
+        returns (bool overrideSwapLimits, uint256 maxAmountInSwapExactIn, uint256 maxAmountOutSwapExactOut)
+    {
         uint256 sqrtAlpha = params[0];
         sqrtAlpha = bound(sqrtAlpha, _MINIMUM_SQRT_ALPHA, _MAXIMUM_SQRT_BETA - _MINIMUM_DIFF_ALPHA_BETA);
 
@@ -95,5 +101,6 @@ contract E2eSwapGyro2CLPTest is E2eSwapTest, Gyro2ClpPoolDeployer {
         sqrtBeta = bound(sqrtBeta, sqrtAlpha + _MINIMUM_DIFF_ALPHA_BETA, _MAXIMUM_SQRT_BETA);
 
         Gyro2CLPPoolMock(pool).setSqrtParams(sqrtAlpha, sqrtBeta);
+        return (false, 0, 0);
     }
 }

--- a/pkg/pool-gyro/test/foundry/E2eSwap2CLP.t.sol
+++ b/pkg/pool-gyro/test/foundry/E2eSwap2CLP.t.sol
@@ -89,11 +89,7 @@ contract E2eSwapGyro2CLPTest is E2eSwapTest, Gyro2ClpPoolDeployer {
 
     function fuzzPoolParams(
         uint256[POOL_SPECIFIC_PARAMS_SIZE] memory params
-    )
-        internal
-        override
-        returns (bool overrideSwapLimits, uint256 maxAmountInSwapExactIn, uint256 maxAmountOutSwapExactOut)
-    {
+    ) internal override returns (bool overrideSwapLimits) {
         uint256 sqrtAlpha = params[0];
         sqrtAlpha = bound(sqrtAlpha, _MINIMUM_SQRT_ALPHA, _MAXIMUM_SQRT_BETA - _MINIMUM_DIFF_ALPHA_BETA);
 
@@ -101,6 +97,6 @@ contract E2eSwapGyro2CLPTest is E2eSwapTest, Gyro2ClpPoolDeployer {
         sqrtBeta = bound(sqrtBeta, sqrtAlpha + _MINIMUM_DIFF_ALPHA_BETA, _MAXIMUM_SQRT_BETA);
 
         Gyro2CLPPoolMock(pool).setSqrtParams(sqrtAlpha, sqrtBeta);
-        return (false, 0, 0);
+        return false;
     }
 }

--- a/pkg/pool-stable/test/foundry/E2eSwap.t.sol
+++ b/pkg/pool-stable/test/foundry/E2eSwap.t.sol
@@ -145,7 +145,7 @@ contract E2eSwapStableTest is E2eSwapTest, StablePoolContractsDeployer {
         uint256 newAmplificationParameter = bound(params[0], StableMath.MIN_AMP, StableMath.MAX_AMP);
 
         _setAmplificationParameter(pool, newAmplificationParameter);
-        return (false, 0, 0);
+        return false;
     }
 
     function _setAmplificationParameter(address pool, uint256 newAmplificationParameter) private {

--- a/pkg/pool-stable/test/foundry/E2eSwap.t.sol
+++ b/pkg/pool-stable/test/foundry/E2eSwap.t.sol
@@ -134,11 +134,18 @@ contract E2eSwapStableTest is E2eSwapTest, StablePoolContractsDeployer {
         );
     }
 
-    function fuzzPoolParams(uint256[POOL_SPECIFIC_PARAMS_SIZE] memory params) internal override {
+    function fuzzPoolParams(
+        uint256[POOL_SPECIFIC_PARAMS_SIZE] memory params
+    )
+        internal
+        override
+        returns (bool overrideSwapLimits, uint256 maxAmountInSwapExactIn, uint256 maxAmountOutSwapExactOut)
+    {
         // Vary amplification parameter from 1 to 5000.
         uint256 newAmplificationParameter = bound(params[0], StableMath.MIN_AMP, StableMath.MAX_AMP);
 
         _setAmplificationParameter(pool, newAmplificationParameter);
+        return (false, 0, 0);
     }
 
     function _setAmplificationParameter(address pool, uint256 newAmplificationParameter) private {

--- a/pkg/pool-stable/test/foundry/E2eSwap.t.sol
+++ b/pkg/pool-stable/test/foundry/E2eSwap.t.sol
@@ -136,11 +136,7 @@ contract E2eSwapStableTest is E2eSwapTest, StablePoolContractsDeployer {
 
     function fuzzPoolParams(
         uint256[POOL_SPECIFIC_PARAMS_SIZE] memory params
-    )
-        internal
-        override
-        returns (bool overrideSwapLimits, uint256 maxAmountInSwapExactIn, uint256 maxAmountOutSwapExactOut)
-    {
+    ) internal override returns (bool overrideSwapLimits) {
         // Vary amplification parameter from 1 to 5000.
         uint256 newAmplificationParameter = bound(params[0], StableMath.MIN_AMP, StableMath.MAX_AMP);
 

--- a/pkg/pool-weighted/test/foundry/E2eSwap.t.sol
+++ b/pkg/pool-weighted/test/foundry/E2eSwap.t.sol
@@ -65,7 +65,13 @@ contract E2eSwapWeightedTest is E2eSwapTest, WeightedPoolContractsDeployer {
         maxSwapAmountTokenB = poolInitAmountTokenB / 10;
     }
 
-    function fuzzPoolParams(uint256[POOL_SPECIFIC_PARAMS_SIZE] memory params) internal override {
+    function fuzzPoolParams(
+        uint256[POOL_SPECIFIC_PARAMS_SIZE] memory params
+    )
+        internal
+        override
+        returns (bool overrideSwapLimits, uint256 maxAmountInSwapExactIn, uint256 maxAmountOutSwapExactOut)
+    {
         uint256 weightTokenA = params[0];
         weightTokenA = bound(weightTokenA, 0.1e16, 99.9e16);
 
@@ -77,6 +83,10 @@ contract E2eSwapWeightedTest is E2eSwapTest, WeightedPoolContractsDeployer {
         // `testExactInRepeatExactOutVariableFeesSpecific__Fuzz`. The farther the weights are from 50/50, the bigger
         // the error.
         exactInOutDecimalsErrorMultiplier = 2000;
+
+        overrideSwapLimits = true;
+        maxAmountInSwapExactIn = maxSwapAmountTokenA;
+        maxAmountOutSwapExactOut = maxSwapAmountTokenB;
     }
 
     function _setMinAndMaxSwapAmountExactIn(uint256[] memory poolBalancesRaw) private {

--- a/pkg/pool-weighted/test/foundry/E2eSwap.t.sol
+++ b/pkg/pool-weighted/test/foundry/E2eSwap.t.sol
@@ -67,11 +67,7 @@ contract E2eSwapWeightedTest is E2eSwapTest, WeightedPoolContractsDeployer {
 
     function fuzzPoolParams(
         uint256[POOL_SPECIFIC_PARAMS_SIZE] memory params
-    )
-        internal
-        override
-        returns (bool overrideSwapLimits, uint256 maxAmountInSwapExactIn, uint256 maxAmountOutSwapExactOut)
-    {
+    ) internal override returns (bool overrideSwapLimits) {
         uint256 weightTokenA = params[0];
         weightTokenA = bound(weightTokenA, 0.1e16, 99.9e16);
 
@@ -85,8 +81,6 @@ contract E2eSwapWeightedTest is E2eSwapTest, WeightedPoolContractsDeployer {
         exactInOutDecimalsErrorMultiplier = 2000;
 
         overrideSwapLimits = true;
-        maxAmountInSwapExactIn = maxSwapAmountTokenA;
-        maxAmountOutSwapExactOut = maxSwapAmountTokenB;
     }
 
     function _setMinAndMaxSwapAmountExactIn(uint256[] memory poolBalancesRaw) private {

--- a/pkg/vault/test/foundry/E2eSwap.t.sol
+++ b/pkg/vault/test/foundry/E2eSwap.t.sol
@@ -195,7 +195,13 @@ contract E2eSwapTest is BaseVaultTest {
      * @notice Fuzz specific pool parameters.
      * @dev Override this function to fuzz test parameters that are specific to a kind of pool.
      */
-    function fuzzPoolParams(uint256[POOL_SPECIFIC_PARAMS_SIZE] memory params) internal virtual {
+    function fuzzPoolParams(
+        uint256[POOL_SPECIFIC_PARAMS_SIZE] memory params
+    )
+        internal
+        virtual
+        returns (bool overrideSwapLimits, uint256 maxAmountInSwapExactIn, uint256 minAmountOutSwapExactOut)
+    {
         // solhint-disable-previous-line no-empty-blocks
     }
 
@@ -612,10 +618,6 @@ contract E2eSwapTest is BaseVaultTest {
             _setTokenDecimalsInPool();
         }
 
-        if (testLocals.shouldFuzzPoolParams) {
-            fuzzPoolParams(testLocals.poolParams);
-        }
-
         uint256 maxAmountIn = maxSwapAmountTokenA;
         if (testLocals.shouldTestLiquidity) {
             testLocals.liquidityTokenA = bound(
@@ -630,6 +632,13 @@ contract E2eSwapTest is BaseVaultTest {
             );
 
             maxAmountIn = _setPoolBalancesAndGetAmountIn(testLocals.liquidityTokenA, testLocals.liquidityTokenB);
+        }
+
+        if (testLocals.shouldFuzzPoolParams) {
+            (bool shouldOverrideSwapLimits, uint256 maxSwapAmountInExactIn, ) = fuzzPoolParams(testLocals.poolParams);
+            if (shouldOverrideSwapLimits) {
+                maxAmountIn = maxSwapAmountInExactIn;
+            }
         }
 
         if (testLocals.shouldTestSwapAmount) {
@@ -731,10 +740,6 @@ contract E2eSwapTest is BaseVaultTest {
             _setTokenDecimalsInPool();
         }
 
-        if (testLocals.shouldFuzzPoolParams) {
-            fuzzPoolParams(testLocals.poolParams);
-        }
-
         uint256 maxAmountOut = maxSwapAmountTokenB;
         if (testLocals.shouldTestLiquidity) {
             testLocals.liquidityTokenA = bound(
@@ -749,6 +754,13 @@ contract E2eSwapTest is BaseVaultTest {
             );
 
             maxAmountOut = _setPoolBalancesAndGetAmountOut(testLocals.liquidityTokenA, testLocals.liquidityTokenB);
+        }
+
+        if (testLocals.shouldFuzzPoolParams) {
+            (bool shouldOverrideSwapLimits, , uint256 maxSwapAmountOutExactOut) = fuzzPoolParams(testLocals.poolParams);
+            if (shouldOverrideSwapLimits) {
+                maxAmountOut = maxSwapAmountOutExactOut;
+            }
         }
 
         if (testLocals.shouldTestSwapAmount) {

--- a/pkg/vault/test/foundry/E2eSwap.t.sol
+++ b/pkg/vault/test/foundry/E2eSwap.t.sol
@@ -194,14 +194,15 @@ contract E2eSwapTest is BaseVaultTest {
     /**
      * @notice Fuzz specific pool parameters.
      * @dev Override this function to fuzz test parameters that are specific to a kind of pool.
+     * This function is executed after setting pool balances. Some pools may require different swap limits based on
+     * the chosen parameters for the pool state.
+     * Set `minSwapAmountTokenA`, `maxSwapAmountTokenA`, `minSwapAmountTokenB` and `maxSwapAmountTokenB` to the values
+     * that are expected to be used in the pool, and return `true` to signal that these values shall be used as
+     * limits whenever needed.
      */
     function fuzzPoolParams(
         uint256[POOL_SPECIFIC_PARAMS_SIZE] memory params
-    )
-        internal
-        virtual
-        returns (bool overrideSwapLimits, uint256 maxAmountInSwapExactIn, uint256 minAmountOutSwapExactOut)
-    {
+    ) internal virtual returns (bool overrideSwapLimits) {
         // solhint-disable-previous-line no-empty-blocks
     }
 
@@ -635,9 +636,9 @@ contract E2eSwapTest is BaseVaultTest {
         }
 
         if (testLocals.shouldFuzzPoolParams) {
-            (bool shouldOverrideSwapLimits, uint256 maxSwapAmountInExactIn, ) = fuzzPoolParams(testLocals.poolParams);
+            bool shouldOverrideSwapLimits = fuzzPoolParams(testLocals.poolParams);
             if (shouldOverrideSwapLimits) {
-                maxAmountIn = maxSwapAmountInExactIn;
+                maxAmountIn = maxSwapAmountTokenA;
             }
         }
 
@@ -757,9 +758,9 @@ contract E2eSwapTest is BaseVaultTest {
         }
 
         if (testLocals.shouldFuzzPoolParams) {
-            (bool shouldOverrideSwapLimits, , uint256 maxSwapAmountOutExactOut) = fuzzPoolParams(testLocals.poolParams);
+            bool shouldOverrideSwapLimits = fuzzPoolParams(testLocals.poolParams);
             if (shouldOverrideSwapLimits) {
-                maxAmountOut = maxSwapAmountOutExactOut;
+                maxAmountOut = maxSwapAmountTokenB;
             }
         }
 


### PR DESCRIPTION
# Description

For e2e swap tests, in some cases `fuzzSwapParams` might edit balances or parameters that affect swap limits.
`testDoUndoExactInBase` and `testDoUndoExactOutBase` currently force the balances and the maximum amounts after fuzzing pool params, which is not ideal. 

For Reclamm in particular, virtual balances (i.e. pool state) are tied to pool balances, so if the test forces pool balances without considering virtual balances, something will go out of sync. This change allows keeping pool state aligned with fuzzed pool balances by changing the order of execution and allowing overrides.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A