### PR TITLE
Allow overriding non-specific e2e tests, 0 min trade amount.

### DIFF
--- a/pkg/vault/test/foundry/E2eSwap.t.sol
+++ b/pkg/vault/test/foundry/E2eSwap.t.sol
@@ -59,8 +59,8 @@ contract E2eSwapTest is BaseVaultTest {
     uint256 internal constant POOL_SPECIFIC_PARAMS_SIZE = 5;
 
     function setUp() public virtual override {
-        // We will use min trade amount in this test.
-        vaultMockMinTradeAmount = PRODUCTION_MIN_TRADE_AMOUNT;
+        // We'll do best effort to be around the minimum trade amount, but things should work nonetheless.
+        vaultMockMinTradeAmount = 0;
 
         BaseVaultTest.setUp();
 
@@ -207,7 +207,7 @@ contract E2eSwapTest is BaseVaultTest {
         // solhint-disable-previous-line no-empty-blocks
     }
 
-    function testDoUndoExactInSwapAmount__Fuzz(uint256 exactAmountIn) public {
+    function testDoUndoExactInSwapAmount__Fuzz(uint256 exactAmountIn) public virtual {
         DoUndoLocals memory testLocals;
         testLocals.shouldTestSwapAmount = true;
 
@@ -237,7 +237,7 @@ contract E2eSwapTest is BaseVaultTest {
         testDoUndoExactInBase(exactAmountIn, testLocals);
     }
 
-    function testDoUndoExactInFees__Fuzz(uint256 poolSwapFeePercentage) public {
+    function testDoUndoExactInFees__Fuzz(uint256 poolSwapFeePercentage) public virtual {
         DoUndoLocals memory testLocals;
         testLocals.shouldTestFee = true;
         testLocals.poolSwapFeePercentage = poolSwapFeePercentage;
@@ -332,7 +332,7 @@ contract E2eSwapTest is BaseVaultTest {
         testDoUndoExactInBase(exactAmountIn, testLocals);
     }
 
-    function testDoUndoExactOutSwapAmount__Fuzz(uint256 exactAmountOut) public {
+    function testDoUndoExactOutSwapAmount__Fuzz(uint256 exactAmountOut) public virtual {
         DoUndoLocals memory testLocals;
         testLocals.shouldTestSwapAmount = true;
 
@@ -362,7 +362,7 @@ contract E2eSwapTest is BaseVaultTest {
         testDoUndoExactOutBase(exactAmountOut, testLocals);
     }
 
-    function testDoUndoExactOutFees__Fuzz(uint256 poolSwapFeePercentage) public {
+    function testDoUndoExactOutFees__Fuzz(uint256 poolSwapFeePercentage) public virtual {
         DoUndoLocals memory testLocals;
         testLocals.shouldTestFee = true;
         testLocals.poolSwapFeePercentage = poolSwapFeePercentage;


### PR DESCRIPTION
# Description

When applying e2e tests for different pool types, computing limits is challenging.
Moreover, the standard test that doesn't fuzz pool parameters might not use the correct limits for every pool type.

This PR allows pool-specific tests to skip those tests that don't fuzz pool parameters. 
Also sets the min trade amount to 0 (things should work, this was always just an extra protection).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A