### PR TITLE
Add minAmountOut for unwrapping in ERC4626CowBurner

### DIFF
--- a/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
+++ b/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
@@ -66,11 +66,12 @@ contract ERC4626CowSwapFeeBurner is CowSwapFeeBurner {
         uint256 minTargetTokenAmountOut = uint128(encodedMinAmountsOut >> 128);
         uint256 minERC4626AmountOut = uint128(encodedMinAmountsOut & type(uint128).max);
 
+        IERC4626 erc4626Token = IERC4626(address(feeToken));
+        // Redeem and overwrite inputs with new asset and unwrapped amount.
+        feeToken = IERC20(erc4626Token.asset());
+
         uint256 feeTokenBalanceBefore = feeToken.balanceOf(address(this));
 
-        // Redeem and overwrite inputs with new asset and unwrapped amount.
-        IERC4626 erc4626Token = IERC4626(address(feeToken));
-        feeToken = IERC20(erc4626Token.asset());
         exactFeeTokenAmountIn = erc4626Token.redeem(exactFeeTokenAmountIn, address(this), address(this));
 
         uint256 feeTokenBalanceAfter = feeToken.balanceOf(address(this));

--- a/pkg/standalone-utils/test/foundry/ERC4626CowSwapFeeBurner.t.sol
+++ b/pkg/standalone-utils/test/foundry/ERC4626CowSwapFeeBurner.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IERC1271 } from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -91,7 +92,15 @@ contract ERC4626CowSwapFeeBurnerTest is BaseVaultTest {
         emit IProtocolFeeBurner.ProtocolFeeBurned(address(0), dai, assetsAmount, usdc, MIN_TARGET_TOKEN_AMOUNT, alice);
 
         vm.prank(admin);
-        cowSwapFeeBurner.burn(address(0), waDAI, TEST_BURN_AMOUNT, usdc, MIN_TARGET_TOKEN_AMOUNT, alice, orderDeadline);
+        cowSwapFeeBurner.burn(
+            address(0),
+            waDAI,
+            TEST_BURN_AMOUNT,
+            usdc,
+            _encodeMinAmountsOut(MIN_TARGET_TOKEN_AMOUNT, 0),
+            alice,
+            orderDeadline
+        );
 
         assertEq(
             waDAI.balanceOf(admin),
@@ -155,7 +164,15 @@ contract ERC4626CowSwapFeeBurnerTest is BaseVaultTest {
         // Target token is now DAI, which is waDAI.asset().
         // Deadline doesn't matter in this case, as settlement is instant.
         vm.prank(admin);
-        cowSwapFeeBurner.burn(address(0), waDAI, TEST_BURN_AMOUNT, dai, assetsAmount, alice, 0);
+        cowSwapFeeBurner.burn(
+            address(0),
+            waDAI,
+            TEST_BURN_AMOUNT,
+            dai,
+            _encodeMinAmountsOut(assetsAmount, 0),
+            alice,
+            0
+        );
 
         assertEq(
             waDAI.balanceOf(admin),
@@ -200,7 +217,81 @@ contract ERC4626CowSwapFeeBurnerTest is BaseVaultTest {
         );
         // Target token is now DAI, which is waDAI.asset().
         vm.prank(admin);
-        cowSwapFeeBurner.burn(address(0), waDAI, TEST_BURN_AMOUNT, dai, assetsAmount + 1, alice, orderDeadline);
+        cowSwapFeeBurner.burn(
+            address(0),
+            waDAI,
+            TEST_BURN_AMOUNT,
+            dai,
+            _encodeMinAmountsOut(assetsAmount + 1, 0),
+            alice,
+            orderDeadline
+        );
+    }
+
+    function testBurnFeeTokenIfUnwrappedTokenBelowMin() public {
+        // Admin will call `burn` acting as the fee sweeper. The burner will pull tokens from them.
+        vm.prank(admin);
+        waDAI.approve(address(cowSwapFeeBurner), TEST_BURN_AMOUNT);
+
+        uint256 assetsAmount = waDAI.previewRedeem(TEST_BURN_AMOUNT);
+        require(assetsAmount != TEST_BURN_AMOUNT, "No point testing when rate is 1:1");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IProtocolFeeBurner.AmountOutBelowMin.selector, dai, assetsAmount, type(uint128).max)
+        );
+        // Target token is now DAI, which is waDAI.asset().
+        vm.prank(admin);
+        cowSwapFeeBurner.burn(
+            address(0),
+            waDAI,
+            TEST_BURN_AMOUNT,
+            dai,
+            _encodeMinAmountsOut(MIN_TARGET_TOKEN_AMOUNT, type(uint128).max),
+            alice,
+            orderDeadline
+        );
+    }
+
+    function testBurnFeeTokenIfRealUnwrappedTokenBelowMin() public {
+        // Admin will call `burn` acting as the fee sweeper. The burner will pull tokens from them.
+        vm.prank(admin);
+        waDAI.approve(address(cowSwapFeeBurner), TEST_BURN_AMOUNT);
+
+        uint256 assetsAmount = waDAI.previewRedeem(TEST_BURN_AMOUNT);
+        require(assetsAmount != TEST_BURN_AMOUNT, "No point testing when rate is 1:1");
+
+        vm.mockCall(
+            address(waDAI),
+            abi.encodeWithSelector(
+                IERC4626.redeem.selector,
+                TEST_BURN_AMOUNT,
+                address(cowSwapFeeBurner),
+                address(cowSwapFeeBurner)
+            ),
+            abi.encode(type(uint128).max)
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IProtocolFeeBurner.AmountOutBelowMin.selector, dai, 0, type(uint128).max)
+        );
+        // Target token is now DAI, which is waDAI.asset().
+        vm.prank(admin);
+        cowSwapFeeBurner.burn(
+            address(0),
+            waDAI,
+            TEST_BURN_AMOUNT,
+            dai,
+            _encodeMinAmountsOut(MIN_TARGET_TOKEN_AMOUNT, type(uint128).max),
+            alice,
+            orderDeadline
+        );
+    }
+
+    function _encodeMinAmountsOut(
+        uint256 minTargetTokenAmountOut,
+        uint256 minERC4626AmountOut
+    ) internal pure returns (uint256) {
+        return (minTargetTokenAmountOut << 128) | minERC4626AmountOut;
     }
 
     function _mockComposableCowCreate(IERC20 sellToken) internal {


### PR DESCRIPTION
# Description

This PR adds support for using minAmountOut when unwrapping ERC4626 tokens in ERC4626CowBurner. The issue is that ERC4626 can have different implementations and may sometimes don't return tokens. For example, we encountered this problem with rstETH. As a temporary solution to this issue, we decided to use a single variable for two values in order to avoid changing the interface.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #1386

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
