### PR TITLE
Fix ERC4626 cow status bug

### DIFF
--- a/pkg/standalone-utils/contracts/CowSwapFeeBurner.sol
+++ b/pkg/standalone-utils/contracts/CowSwapFeeBurner.sol
@@ -342,7 +342,7 @@ contract CowSwapFeeBurner is ICowSwapFeeBurner, ReentrancyGuardTransient, Versio
             return (OrderStatus.Nonexistent, 0);
         }
 
-        // We return the balance to the state before we received tokens for the new order
+        // We return the balance to the state before we received tokens for the new order.
         uint256 balance = tokenIn.balanceOf(address(this)) - balanceDelta;
         if (balance == 0) {
             // If no tokens remain, we assume the order was fully executed

--- a/pkg/standalone-utils/contracts/CowSwapFeeBurner.sol
+++ b/pkg/standalone-utils/contracts/CowSwapFeeBurner.sol
@@ -172,7 +172,6 @@ contract CowSwapFeeBurner is ICowSwapFeeBurner, ReentrancyGuardTransient, Versio
             minTargetTokenAmountOut,
             recipient,
             deadline,
-            0, // balanceDelta
             true // pullFeeToken
         );
     }
@@ -185,7 +184,6 @@ contract CowSwapFeeBurner is ICowSwapFeeBurner, ReentrancyGuardTransient, Versio
         uint256 minTargetTokenAmountOut,
         address recipient,
         uint256 deadline,
-        uint256 balanceDelta,
         bool pullFeeToken
     ) internal {
         if (targetToken == feeToken) {
@@ -197,13 +195,13 @@ contract CowSwapFeeBurner is ICowSwapFeeBurner, ReentrancyGuardTransient, Versio
         _checkMinAmountOut(minTargetTokenAmountOut);
         _checkDeadline(deadline);
 
-        (OrderStatus status, ) = _getOrderStatusAndBalance(feeToken, balanceDelta);
-        if (status != OrderStatus.Nonexistent && status != OrderStatus.Filled) {
-            revert OrderHasUnexpectedStatus(status);
-        }
-
         if (pullFeeToken) {
             feeToken.safeTransferFrom(msg.sender, address(this), feeTokenAmount);
+        }
+
+        (OrderStatus status, ) = _getOrderStatusAndBalance(feeToken, feeTokenAmount);
+        if (status != OrderStatus.Nonexistent && status != OrderStatus.Filled) {
+            revert OrderHasUnexpectedStatus(status);
         }
 
         _createCowOrder(feeToken);

--- a/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
+++ b/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
@@ -99,7 +99,6 @@ contract ERC4626CowSwapFeeBurner is CowSwapFeeBurner {
                 minTargetTokenAmountOut,
                 recipient,
                 deadline,
-                exactFeeTokenAmountIn, // balanceDelta
                 false // pullToken
             );
         }

--- a/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
+++ b/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
@@ -83,6 +83,7 @@ contract ERC4626CowSwapFeeBurner is CowSwapFeeBurner {
                 minTargetTokenAmountOut,
                 recipient,
                 deadline,
+                exactFeeTokenAmountIn, // balanceDelta
                 false // pullToken
             );
         }

--- a/pkg/standalone-utils/test/foundry/ERC4626CowSwapFeeBurner.t.sol
+++ b/pkg/standalone-utils/test/foundry/ERC4626CowSwapFeeBurner.t.sol
@@ -71,6 +71,21 @@ contract ERC4626CowSwapFeeBurnerTest is BaseVaultTest {
     }
 
     function testBurn() public {
+        vm.expectRevert(abi.encodeWithSelector(ICowConditionalOrder.OrderNotValid.selector, "Order does not exist"));
+        cowSwapFeeBurner.getOrder(dai);
+
+        _testBurn();
+    }
+
+    function testBurnDouble() public {
+        vm.expectRevert(abi.encodeWithSelector(ICowConditionalOrder.OrderNotValid.selector, "Order does not exist"));
+        cowSwapFeeBurner.getOrder(dai);
+
+        _testBurn();
+        _testBurn();
+    }
+
+    function _testBurn() public {
         // Admin will call `burn` acting as the fee sweeper. The burner will pull tokens from them.
         vm.prank(admin);
         waDAI.approve(address(cowSwapFeeBurner), TEST_BURN_AMOUNT);
@@ -78,9 +93,6 @@ contract ERC4626CowSwapFeeBurnerTest is BaseVaultTest {
         uint256 cowSwapFeeBurnerWaDaiBalanceBefore = waDAI.balanceOf(address(cowSwapFeeBurner));
         uint256 cowSwapFeeBurnerDaiBalanceBefore = dai.balanceOf(address(cowSwapFeeBurner));
         uint256 callerWaDaiBalanceBefore = waDAI.balanceOf(address(admin));
-
-        vm.expectRevert(abi.encodeWithSelector(ICowConditionalOrder.OrderNotValid.selector, "Order does not exist"));
-        cowSwapFeeBurner.getOrder(dai);
 
         _mockComposableCowCreate(dai);
 


### PR DESCRIPTION
# Description

This PR fixes a bug where creating a second order for the same token after completing the first one results in a status error. The issue is that when the token is unwrapped, the status method still considers the balance to be present.

The problem with ERC4626CowBurner was that the tokens were unpacked before calling the burn method. Because of that, the balance on the contract was not zero anymore. This caused a status error: instead of getting Filled, we got Failed, since the deadline had already passed.

This fix solves the issue — it basically resets the balance back to what it was before the unpacking, so the status is calculated correctly.



<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
