### PR TITLE
Change auth logic in cow burner

### DIFF
--- a/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
+++ b/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
@@ -31,8 +31,9 @@ contract ERC4626CowSwapFeeBurner is CowSwapFeeBurner {
         IComposableCow _composableCow,
         address _vaultRelayer,
         bytes32 _appData,
+        address _initialOwner,
         string memory _version
-    ) CowSwapFeeBurner(_protocolFeeSweeper, _composableCow, _vaultRelayer, _appData, _version) {
+    ) CowSwapFeeBurner(_protocolFeeSweeper, _composableCow, _vaultRelayer, _appData, _initialOwner, _version) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/standalone-utils/test/foundry/CowSwapFeeBurner.t.sol
+++ b/pkg/standalone-utils/test/foundry/CowSwapFeeBurner.t.sol
@@ -61,6 +61,7 @@ contract CowSwapFeeBurnerTest is BaseVaultTest {
             IComposableCow(composableCowMock),
             vaultRelayerMock,
             APP_DATA_HASH,
+            admin,
             VERSION
         );
 
@@ -504,7 +505,15 @@ contract CowSwapFeeBurnerTest is BaseVaultTest {
         cowSwapFeeBurner.supportsInterface(0x62af8dc2);
     }
 
-    function testRetryOrder() public {
+    function testRetryOrderIfSenderIsFeeRecipient() public {
+        _testRetryOrder(alice);
+    }
+
+    function testRetryOrderIfSenderIsOwner() public {
+        _testRetryOrder(admin);
+    }
+
+    function _testRetryOrder(address sender) internal {
         _mockComposableCowCreate(dai);
         _approveForBurner(dai, TEST_BURN_AMOUNT);
 
@@ -522,7 +531,7 @@ contract CowSwapFeeBurnerTest is BaseVaultTest {
         _mockComposableCowCreate(dai);
         vm.expectEmit();
         emit ICowSwapFeeBurner.OrderRetried(dai, halfAmount, newMinAmountOut, newOrderDeadline);
-        vm.prank(alice);
+        vm.prank(sender);
         cowSwapFeeBurner.retryOrder(dai, newMinAmountOut, newOrderDeadline);
 
         GPv2Order memory order = cowSwapFeeBurner.getOrder(dai);
@@ -594,7 +603,15 @@ contract CowSwapFeeBurnerTest is BaseVaultTest {
         cowSwapFeeBurner.retryOrder(dai, MIN_TARGET_TOKEN_AMOUNT, orderDeadline);
     }
 
-    function testCancelOrder() public {
+    function testCancelOrderIfSenderIsFeeRecipient() public {
+        _testCancelOrder(alice);
+    }
+
+    function testCancelOrderIfSenderIsOwner() public {
+        _testCancelOrder(admin);
+    }
+
+    function _testCancelOrder(address sender) internal {
         _mockComposableCowCreate(dai);
         _approveForBurner(dai, TEST_BURN_AMOUNT);
         _burn();
@@ -611,7 +628,7 @@ contract CowSwapFeeBurnerTest is BaseVaultTest {
         vm.expectEmit();
         emit ICowSwapFeeBurner.OrderCanceled(dai, halfAmount, alice);
 
-        vm.prank(alice);
+        vm.prank(sender);
         cowSwapFeeBurner.cancelOrder(dai, alice);
 
         assertEq(
@@ -647,7 +664,15 @@ contract CowSwapFeeBurnerTest is BaseVaultTest {
         cowSwapFeeBurner.cancelOrder(dai, alice);
     }
 
-    function testEmergencyRevertOrder() public {
+    function testEmergencyRevertOrderIfSenderIsFeeRecipient() public {
+        _testEmergencyCancelOrder(alice);
+    }
+
+    function testEmergencyRevertOrderIfSenderIsOwner() public {
+        _testEmergencyCancelOrder(admin);
+    }
+
+    function _testEmergencyCancelOrder(address sender) internal {
         _mockComposableCowCreate(dai);
         _approveForBurner(dai, TEST_BURN_AMOUNT);
 
@@ -664,7 +689,7 @@ contract CowSwapFeeBurnerTest is BaseVaultTest {
         _mockComposableCowCreate(dai);
         vm.expectEmit();
         emit ICowSwapFeeBurner.OrderCanceled(dai, halfAmount, alice);
-        vm.prank(alice);
+        vm.prank(sender);
         cowSwapFeeBurner.emergencyCancelOrder(dai, alice);
 
         assertEq(dai.balanceOf(alice), balanceBefore + halfAmount, "alice should have received the tokens");

--- a/pkg/standalone-utils/test/foundry/ERC4626CowSwapFeeBurner.t.sol
+++ b/pkg/standalone-utils/test/foundry/ERC4626CowSwapFeeBurner.t.sol
@@ -68,6 +68,7 @@ contract ERC4626CowSwapFeeBurnerTest is BaseVaultTest {
             IComposableCow(composableCowMock),
             vaultRelayerMock,
             APP_DATA_HASH,
+            bob,
             VERSION
         );
     }


### PR DESCRIPTION
# Description

This PR changes the authorization system in the Cow Fee Burner. One of the options was to leave the retry and cancel methods without authorization, but the downside of this approach is that it could allow griefing attacks in very rare cases. For example, we might want to call retry, but someone could spam cancel. This is an extremely unlikely scenario, but I’d prefer to avoid it. 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
