### PR TITLE
Alternate ERC4626 cow burner fix

### DIFF
--- a/pkg/interfaces/contracts/standalone-utils/ICowSwapFeeBurner.sol
+++ b/pkg/interfaces/contracts/standalone-utils/ICowSwapFeeBurner.sol
@@ -11,10 +11,10 @@ import { IProtocolFeeBurner } from "./IProtocolFeeBurner.sol";
 
 interface ICowSwapFeeBurner is IERC1271, IProtocolFeeBurner, ICowConditionalOrder, ICowConditionalOrderGenerator {
     enum OrderStatus {
-        Nonexistent,
-        Active,
-        Filled,
-        Failed
+        Nonexistent, // No order exists (initialized state)
+        Active,      // Order created, waiting for execution
+        Filled,      // Order successfully executed
+        Failed       // Order failed (deadline passed)
     }
 
     /// @notice The fee protocol is invalid.

--- a/pkg/interfaces/contracts/standalone-utils/ICowSwapFeeBurner.sol
+++ b/pkg/interfaces/contracts/standalone-utils/ICowSwapFeeBurner.sol
@@ -68,6 +68,9 @@ interface ICowSwapFeeBurner is IERC1271, IProtocolFeeBurner, ICowConditionalOrde
 
     /**
      * @notice Get the status of the order at the sell token.
+     * @dev Cow does not provide an interface to query the status directly. We must infer it from the order fields
+     * and token balance.
+     *
      * @param tokenIn The token used to identify the order
      * @return orderStatus The status of the order for the given token
      */

--- a/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
+++ b/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
@@ -73,6 +73,14 @@ contract ERC4626CowSwapFeeBurner is CowSwapFeeBurner {
 
         uint256 feeTokenBalanceBefore = underlyingToken.balanceOf(address(this));
 
+        ShortOrder memory order = _orders[feeToken];
+
+        // Check the status before unwrapping; if it's filled, the balance should be zero at this point.
+        _updateOrderStatus(order, OrderStatus.Active);
+
+        // Update the status in storage. When checked below in `_burn`, it will be a no-op, as it's already active.
+        _orders[feeToken] = order;
+
         erc4626Token.redeem(exactFeeTokenAmountIn, address(this), address(this));
 
         uint256 feeTokenBalanceAfter = underlyingToken.balanceOf(address(this));

--- a/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
+++ b/pkg/standalone-utils/contracts/ERC4626CowSwapFeeBurner.sol
@@ -71,15 +71,12 @@ contract ERC4626CowSwapFeeBurner is CowSwapFeeBurner {
             bytes32(encodedMinAmountsOut)
         );
 
-        uint256 feeTokenBalanceBefore = underlyingToken.balanceOf(address(this));
-
-        ShortOrder memory order = _orders[feeToken];
+        ShortOrder memory order = _orders[underlyingToken];
 
         // Check the status before unwrapping; if it's filled, the balance should be zero at this point.
-        _updateOrderStatus(order, OrderStatus.Active);
+        _updateOrderStatus(order, underlyingToken, OrderStatus.Active);
 
-        // Update the status in storage. When checked below in `_burn`, it will be a no-op, as it's already active.
-        _orders[feeToken] = order;
+        uint256 feeTokenBalanceBefore = underlyingToken.balanceOf(address(this));
 
         erc4626Token.redeem(exactFeeTokenAmountIn, address(this), address(this));
 


### PR DESCRIPTION
# Description

Alternate approach to the ERC4626 cow burner fix that uses an explicit state machine to validate transitions. Though it is based on main, tests copied from #1388 pass in this PR.

Essentially, we store the OrderStatus in the ShortOrder, call `_refreshOrderStatus` to update it in memory from the state, and `_updateOrderStatus` updates it from the desired user action, validating that it's a valid state transition.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
