### PR TITLE
LBP migration edits

### DIFF
--- a/pkg/interfaces/contracts/pool-weighted/ILBPMigrationRouter.sol
+++ b/pkg/interfaces/contracts/pool-weighted/ILBPMigrationRouter.sol
@@ -5,8 +5,8 @@ pragma solidity ^0.8.24;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { PoolRoleAccounts } from "../vault/VaultTypes.sol";
-import { ILBPool } from "./ILBPool.sol";
 import { IWeightedPool } from "./IWeightedPool.sol";
+import { ILBPool } from "./ILBPool.sol";
 
 /// @notice Interface for migrating liquidity from an LBP to a new Weighted Pool with custom parameters.
 interface ILBPMigrationRouter {
@@ -18,22 +18,19 @@ interface ILBPMigrationRouter {
      */
     event PoolMigrated(ILBPool indexed lbp, IWeightedPool weightedPool, uint256 bptAmountOut);
 
-    /**
-     * @notice A contract returned from the Balancer Contract Registry is not active.
-     * @param contractName The name of the contract that is not active
-     */
-    error ContractIsNotActiveInRegistry(string contractName);
+    /// @notice The Balancer Contract Registry did not return an active address for the "WeightedPool" alias.
+    error NoRegisteredWeightedPoolFactory();
 
     /**
      * @notice `migrateLiquidity` was called before the sale completed.
-     * @param lbp The Liquidity Bootstrapping Pool with unfinalized weights
+     * @param lbp The address of the Liquidity Bootstrapping Pool
      */
-    error LBPWeightsNotFinalized(ILBPool lbp);
+    error RemovingLiquidityNotAllowed(ILBPool lbp);
 
     /// @notice The caller is not the owner of the LBP.
     error SenderIsNotLBPOwner();
 
-    /// @notice Pool have incorrect migration router.
+    /// @notice Pool has an incorrect migration router.
     error IncorrectMigrationRouter(address currentRouter);
 
     struct MigrationHookParams {
@@ -43,9 +40,9 @@ interface ILBPMigrationRouter {
         address sender;
         address excessReceiver;
         uint256 lockDuration;
-        uint256 shareToMigrate;
-        uint256 migrationWeight0;
-        uint256 migrationWeight1;
+        uint256 bptPercentageToMigrate;
+        uint256 migrationWeightProjectToken;
+        uint256 migrationWeightReserveToken;
     }
 
     struct WeightedPoolParams {

--- a/pkg/pool-weighted/contracts/lbp/Timelocker.sol
+++ b/pkg/pool-weighted/contracts/lbp/Timelocker.sol
@@ -2,57 +2,30 @@
 
 pragma solidity ^0.8.24;
 
-import { Multicall } from "@openzeppelin/contracts/utils/Multicall.sol";
 import { ERC6909Metadata } from "@openzeppelin/contracts/token/ERC6909/extensions/draft-ERC6909Metadata.sol";
-import { ERC6909 } from "@openzeppelin/contracts/token/ERC6909/draft-ERC6909.sol";
-import { ERC6909ContentURI } from "@openzeppelin/contracts/token/ERC6909/extensions/draft-ERC6909ContentURI.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import { IERC6909 } from "@openzeppelin/contracts/interfaces/draft-IERC6909.sol";
-import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-
-import { IWeightedPool } from "@balancer-labs/v3-interfaces/contracts/pool-weighted/IWeightedPool.sol";
-import { ILBPool, LBPoolImmutableData } from "@balancer-labs/v3-interfaces/contracts/pool-weighted/ILBPool.sol";
-import {
-    TokenConfig,
-    RemoveLiquidityParams,
-    RemoveLiquidityKind
-} from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
-
-import { VaultGuard } from "@balancer-labs/v3-vault/contracts/VaultGuard.sol";
-import { Version } from "@balancer-labs/v3-solidity-utils/contracts/helpers/Version.sol";
-import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
-import {
-    ReentrancyGuardTransient
-} from "@balancer-labs/v3-solidity-utils/contracts/openzeppelin/ReentrancyGuardTransient.sol";
-import {
-    BalancerContractRegistry,
-    ContractType
-} from "@balancer-labs/v3-standalone-utils/contracts/BalancerContractRegistry.sol";
-
-import { WeightedPoolFactory } from "../WeightedPoolFactory.sol";
-
-import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import { ERC6909 } from "@openzeppelin/contracts/token/ERC6909/draft-ERC6909.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Multicall } from "@openzeppelin/contracts/utils/Multicall.sol";
 
 contract Timelocker is ERC6909, ERC6909Metadata, Multicall {
     using SafeERC20 for IERC20;
 
     /**
-     * @dev Emitted when the unlock timestamp is set for a locked amount.
-     * @param id The ID of the locked tokens, which is derived from the token address
+     * @notice Emitted when the unlock timestamp is set for a locked amount.
+     * @param bptAddress The address of the
      */
-    event SetUnlockTimestamp(uint256 indexed id, uint256 unlockTimestamp);
+    event BPTTimelockSet(IERC20 indexed bptAddress, uint256 unlockTimestamp);
 
     /**
-     * @dev Amount is not unlocked yet.
-     * @param unlockTimestamp The timestamp when the locked amount can be unlocked
+     * @notice The caller has a locked BPT balance, but is trying to burn it before the timelock expired.
+     * @param unlockTimestamp The timestamp when the locked amount can be burned
      */
-    error AmountNotUnlockedYet(uint256 unlockTimestamp);
+    error BPTStillLocked(uint256 unlockTimestamp);
 
-    /// @dev The amount to burn is not locked.
-    error NoLockedAmount();
+    /// @notice The caller has no balance of the locked BPT.
+    error NoLockedBPT();
 
     mapping(uint256 => uint256) internal _unlockTimestamps;
 
@@ -63,13 +36,13 @@ contract Timelocker is ERC6909, ERC6909Metadata, Multicall {
     function burn(uint256 id) public {
         uint256 amount = balanceOf(msg.sender, id);
         if (amount == 0) {
-            revert NoLockedAmount();
+            revert NoLockedBPT();
         }
 
         uint256 unlockTimestamp = _unlockTimestamps[id];
         // solhint-disable-next-line not-rely-on-time
         if (block.timestamp < unlockTimestamp) {
-            revert AmountNotUnlockedYet(unlockTimestamp);
+            revert BPTStillLocked(unlockTimestamp);
         }
 
         _burn(msg.sender, id, amount);
@@ -89,8 +62,9 @@ contract Timelocker is ERC6909, ERC6909Metadata, Multicall {
 
     /**
      * @notice Get the unlock timestamp for a given locked token ID.
+     * @dev The owner can withdraw the underlying BPT at any time after this timestamp.
      * @param id The ID of the locked tokens, which is derived from the token address
-     * @return unlockTimestamp The timestamp when the locked amount can be unlocked
+     * @return unlockTimestamp The timestamp when the locked BPT can be withdrawn
      */
     function getUnlockTimestamp(uint256 id) external view returns (uint256) {
         return _unlockTimestamps[id];
@@ -112,6 +86,6 @@ contract Timelocker is ERC6909, ERC6909Metadata, Multicall {
 
         _mint(owner, id, amount);
 
-        emit SetUnlockTimestamp(id, unlockTimestamp);
+        emit BPTTimelockSet(token, unlockTimestamp);
     }
 }

--- a/pkg/pool-weighted/contracts/test/LBPMigrationRouterMock.sol
+++ b/pkg/pool-weighted/contracts/test/LBPMigrationRouterMock.sol
@@ -3,7 +3,9 @@
 pragma solidity ^0.8.24;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 import { ILBPool } from "@balancer-labs/v3-interfaces/contracts/pool-weighted/ILBPool.sol";
+
 import { BalancerContractRegistry } from "@balancer-labs/v3-standalone-utils/contracts/BalancerContractRegistry.sol";
 
 import { LBPMigrationRouter } from "../../contracts/lbp/LBPMigrationRouter.sol";
@@ -18,12 +20,19 @@ contract LBPMigrationRouterMock is LBPMigrationRouter {
 
     function manualComputeExactAmountsIn(
         ILBPool lbp,
-        uint256 shareToMigrate,
-        uint256 migrationWeight0,
-        uint256 migrationWeight1,
+        uint256 bptPercentageToMigrate,
+        uint256 migrationWeightProjectToken,
+        uint256 migrationWeightReserveToken,
         uint256[] memory removeAmountsOut
     ) external view returns (uint256[] memory exactAmountsIn) {
-        return _computeExactAmountsIn(lbp, shareToMigrate, migrationWeight0, migrationWeight1, removeAmountsOut);
+        return
+            _computeExactAmountsIn(
+                lbp,
+                bptPercentageToMigrate,
+                migrationWeightProjectToken,
+                migrationWeightReserveToken,
+                removeAmountsOut
+            );
     }
 
     function manualLockAmount(IERC20 token, address owner, uint256 amount, uint256 duration) external {

--- a/pkg/pool-weighted/test/foundry/LBMigrationPool.t.sol
+++ b/pkg/pool-weighted/test/foundry/LBMigrationPool.t.sol
@@ -10,7 +10,7 @@ import { ERC20TestToken } from "@balancer-labs/v3-solidity-utils/contracts/test/
 
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
-import { ILBPool } from "@balancer-labs/v3-interfaces/contracts/pool-weighted/ILBPool.sol";
+import { ILBPool, LBPoolImmutableData } from "@balancer-labs/v3-interfaces/contracts/pool-weighted/ILBPool.sol";
 import { IWeightedPool } from "@balancer-labs/v3-interfaces/contracts/pool-weighted/IWeightedPool.sol";
 import { ILBPMigrationRouter } from "@balancer-labs/v3-interfaces/contracts/pool-weighted/ILBPMigrationRouter.sol";
 import { ContractType } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IBalancerContractRegistry.sol";
@@ -40,8 +40,8 @@ contract LBPMigrationRouterTest is BaseLBPTest {
     uint256 constant DELTA = 1e7;
     uint256 constant DEFAULT_BPT_LOCK_DURATION = 10 days;
     uint256 constant DEFAULT_SHARE_TO_MIGRATE = 70e16; // 70% of the pool
-    uint256 constant DEFAULT_WEIGHT0 = 30e16; // 30% for project token
-    uint256 constant DEFAULT_WEIGHT1 = 70e16; // 70% for reserve token
+    uint256 constant DEFAULT_WEIGHT_PROJECT_TOKEN = 30e16; // 30% for project token
+    uint256 constant DEFAULT_WEIGHT_RESERVE_TOKEN = 70e16; // 70% for reserve token
 
     string constant POOL_NAME = "Weighted Pool";
     string constant POOL_SYMBOL = "WP";
@@ -53,9 +53,7 @@ contract LBPMigrationRouterTest is BaseLBPTest {
         vm.prank(admin);
         balancerContractRegistry.deprecateBalancerContract(address(weightedPoolFactory));
 
-        vm.expectRevert(
-            abi.encodeWithSelector(ILBPMigrationRouter.ContractIsNotActiveInRegistry.selector, "WeightedPool")
-        );
+        vm.expectRevert(ILBPMigrationRouter.NoRegisteredWeightedPoolFactory.selector);
         new LBPMigrationRouter(balancerContractRegistry, VERSION);
     }
 
@@ -102,7 +100,7 @@ contract LBPMigrationRouterTest is BaseLBPTest {
     }
 
     function testUnlockAmountRevertsIfAmountIsZero() external {
-        vm.expectRevert(Timelocker.NoLockedAmount.selector);
+        vm.expectRevert(Timelocker.NoLockedBPT.selector);
         migrationRouter.burn(0);
     }
 
@@ -112,24 +110,33 @@ contract LBPMigrationRouterTest is BaseLBPTest {
         uint256 unlockTimestamp = block.timestamp + DEFAULT_BPT_LOCK_DURATION;
         migrationRouter.manualLockAmount(pool, alice, 1e10, DEFAULT_BPT_LOCK_DURATION);
 
-        vm.expectRevert(abi.encodePacked(Timelocker.AmountNotUnlockedYet.selector, unlockTimestamp));
+        vm.expectRevert(abi.encodePacked(Timelocker.BPTStillLocked.selector, unlockTimestamp));
         vm.prank(alice);
         migrationRouter.burn(id);
     }
 
-    function testMigrateLiquidity_Fuzz(uint256 weight0, uint256 shareToMigrate) external {
-        weight0 = bound(weight0, 10e16, 90e16);
-        uint256 weight1 = FixedPoint.ONE - weight0;
-        shareToMigrate = bound(shareToMigrate, 10e16, 100e16);
+    function testMigrateLiquidity_Fuzz(uint256 weightProjectToken, uint256 bptPercentageToMigrate) external {
+        weightProjectToken = bound(weightProjectToken, 10e16, 90e16);
+        uint256 weightReserveToken = FixedPoint.ONE - weightProjectToken;
+        bptPercentageToMigrate = bound(bptPercentageToMigrate, 10e16, 100e16);
 
-        (pool, ) = _createLBPoolWithMigration(DEFAULT_BPT_LOCK_DURATION, shareToMigrate, weight0, weight1);
+        (pool, ) = _createLBPoolWithMigration(
+            DEFAULT_BPT_LOCK_DURATION,
+            bptPercentageToMigrate,
+            weightProjectToken,
+            weightReserveToken
+        );
         initPool();
 
         vm.startPrank(bob);
 
-        uint256[] memory weights = [weight0, weight1].toMemoryArray();
+        LBPoolImmutableData memory data = ILBPool(pool).getLBPoolImmutableData();
+        uint256[] memory weights = new uint256[](2);
 
-        vm.warp(ILBPool(pool).getLBPoolImmutableData().endTime + 1);
+        weights[data.projectTokenIndex] = weightProjectToken;
+        weights[data.reserveTokenIndex] = weightReserveToken;
+
+        vm.warp(data.endTime + 1);
 
         uint256 lbpBPTBalanceBefore = IERC20(pool).balanceOf(bob);
         IERC20(pool).approve(address(migrationRouter), lbpBPTBalanceBefore);
@@ -140,7 +147,7 @@ contract LBPMigrationRouterTest is BaseLBPTest {
         PoolRoleAccounts memory poolRoleAccounts = PoolRoleAccounts({
             pauseManager: makeAddr("pauseManager"),
             swapFeeManager: makeAddr("swapFeeManager"),
-            poolCreator: address(0)
+            poolCreator: ZERO_ADDRESS
         });
 
         (IWeightedPool weightedPool, uint256 bptAmountOut) = migrationRouter.migrateLiquidity(
@@ -151,10 +158,10 @@ contract LBPMigrationRouterTest is BaseLBPTest {
                 symbol: POOL_SYMBOL,
                 roleAccounts: poolRoleAccounts,
                 swapFeePercentage: DEFAULT_SWAP_FEE_PERCENTAGE,
-                poolHooksContract: address(0),
+                poolHooksContract: ZERO_ADDRESS,
                 enableDonation: false,
                 disableUnbalancedLiquidity: false,
-                salt: bytes32(0)
+                salt: ZERO_BYTES32
             })
         );
 
@@ -192,7 +199,7 @@ contract LBPMigrationRouterTest is BaseLBPTest {
 
             assertEq(
                 vault.getHooksConfig(address(weightedPool)).hooksContract,
-                address(0),
+                ZERO_ADDRESS,
                 "Pool hooks contract should be zero address"
             );
 
@@ -204,13 +211,13 @@ contract LBPMigrationRouterTest is BaseLBPTest {
 
         // Check the liquidity migration result
         {
-            uint256 _shareToMigrate = shareToMigrate;
+            uint256 _bptPercentageToMigrate = bptPercentageToMigrate;
             uint256[] memory lbpWeights = ILBPool(pool).getLBPoolDynamicData().normalizedWeights;
             uint256[] memory expectedBalances = _calculateExactAmountsIn(
                 lbpWeights,
                 lbpBalancesBefore,
                 weights,
-                _shareToMigrate
+                _bptPercentageToMigrate
             );
 
             // Check that the weighted pool balance is correct
@@ -283,18 +290,18 @@ contract LBPMigrationRouterTest is BaseLBPTest {
         }
     }
 
-    function testMigrateLiquidityRevertsIfLBPWeightsNotFinalized() external {
+    function testMigrateLiquidityRevertsIfLBPSaleOngoing() external {
         PoolRoleAccounts memory poolRoleAccounts;
 
         (pool, ) = _createLBPoolWithMigration(
             DEFAULT_BPT_LOCK_DURATION,
             DEFAULT_SHARE_TO_MIGRATE,
-            DEFAULT_WEIGHT0,
-            DEFAULT_WEIGHT1
+            DEFAULT_WEIGHT_PROJECT_TOKEN,
+            DEFAULT_WEIGHT_RESERVE_TOKEN
         );
         initPool();
 
-        vm.expectRevert(abi.encodeWithSelector(ILBPMigrationRouter.LBPWeightsNotFinalized.selector, pool));
+        vm.expectRevert(abi.encodeWithSelector(ILBPMigrationRouter.RemovingLiquidityNotAllowed.selector, pool));
         vm.prank(bob);
         migrationRouter.migrateLiquidity(
             ILBPool(pool),
@@ -304,10 +311,10 @@ contract LBPMigrationRouterTest is BaseLBPTest {
                 symbol: POOL_SYMBOL,
                 roleAccounts: poolRoleAccounts,
                 swapFeePercentage: DEFAULT_SWAP_FEE_PERCENTAGE,
-                poolHooksContract: address(0),
+                poolHooksContract: ZERO_ADDRESS,
                 enableDonation: true,
                 disableUnbalancedLiquidity: true,
-                salt: bytes32(0)
+                salt: ZERO_BYTES32
             })
         );
     }
@@ -315,7 +322,7 @@ contract LBPMigrationRouterTest is BaseLBPTest {
     function testMigrationLiquidityRevertsIfMigrationNotSetup() external {
         PoolRoleAccounts memory poolRoleAccounts;
 
-        vm.expectRevert(abi.encodeWithSelector(ILBPMigrationRouter.IncorrectMigrationRouter.selector, address(0)));
+        vm.expectRevert(abi.encodeWithSelector(ILBPMigrationRouter.IncorrectMigrationRouter.selector, ZERO_ADDRESS));
         vm.prank(bob);
         migrationRouter.migrateLiquidity(
             ILBPool(pool),
@@ -325,10 +332,10 @@ contract LBPMigrationRouterTest is BaseLBPTest {
                 symbol: POOL_SYMBOL,
                 roleAccounts: poolRoleAccounts,
                 swapFeePercentage: DEFAULT_SWAP_FEE_PERCENTAGE,
-                poolHooksContract: address(0),
+                poolHooksContract: ZERO_ADDRESS,
                 enableDonation: true,
                 disableUnbalancedLiquidity: true,
-                salt: bytes32(0)
+                salt: ZERO_BYTES32
             })
         );
     }
@@ -348,10 +355,10 @@ contract LBPMigrationRouterTest is BaseLBPTest {
                 symbol: POOL_SYMBOL,
                 roleAccounts: poolRoleAccounts,
                 swapFeePercentage: DEFAULT_SWAP_FEE_PERCENTAGE,
-                poolHooksContract: address(0),
+                poolHooksContract: ZERO_ADDRESS,
                 enableDonation: true,
                 disableUnbalancedLiquidity: true,
-                salt: bytes32(0)
+                salt: ZERO_BYTES32
             })
         );
     }
@@ -362,20 +369,24 @@ contract LBPMigrationRouterTest is BaseLBPTest {
         uint256[] memory weights,
         uint256[] memory balances,
         uint256[] memory newWeights,
-        uint256 shareToMigrate
-    ) internal pure returns (uint256[] memory exactAmountsIn) {
-        uint256 price = (balances[0] * weights[1]).divDown(balances[1] * weights[0]);
+        uint256 bptPercentageToMigrate
+    ) internal view returns (uint256[] memory exactAmountsIn) {
+        uint256 price = (balances[projectIdx] * weights[reserveIdx]).divDown(
+            balances[reserveIdx] * weights[projectIdx]
+        );
 
-        uint256 b0 = price.mulDown(balances[1]).mulDown(newWeights[0]).divDown(newWeights[1]);
-        uint256 b1 = balances[1];
+        uint256 projectAmountOut = price.mulDown(balances[reserveIdx]).mulDown(newWeights[projectIdx]).divDown(
+            newWeights[reserveIdx]
+        );
+        uint256 reserveAmountOut = balances[reserveIdx];
 
-        if (b0 > balances[0]) {
-            b0 = balances[0];
-            b1 = (balances[0] * newWeights[1]).divDown(price * newWeights[0]);
+        if (projectAmountOut > balances[projectIdx]) {
+            projectAmountOut = balances[projectIdx];
+            reserveAmountOut = (balances[projectIdx] * newWeights[reserveIdx]).divDown(price * newWeights[projectIdx]);
         }
 
         exactAmountsIn = new uint256[](TOKEN_COUNT);
-        exactAmountsIn[0] = b0.mulDown(shareToMigrate);
-        exactAmountsIn[1] = b1.mulDown(shareToMigrate);
+        exactAmountsIn[projectIdx] = projectAmountOut.mulDown(bptPercentageToMigrate);
+        exactAmountsIn[reserveIdx] = reserveAmountOut.mulDown(bptPercentageToMigrate);
     }
 }

--- a/pkg/pool-weighted/test/foundry/LBPool.t.sol
+++ b/pkg/pool-weighted/test/foundry/LBPool.t.sol
@@ -231,40 +231,45 @@ contract LBPoolTest is BaseLBPTest {
         (
             address migrationRouter,
             uint256 bptLockDuration,
-            uint256 shareToMigrate,
-            uint256 migrationWeight0,
-            uint256 migrationWeight1
+            uint256 bptPercentageToMigrate,
+            uint256 migrationWeightProjectToken,
+            uint256 migrationWeightReserveToken
         ) = LBPool(pool).getMigrationParams();
 
-        assertEq(migrationRouter, address(0), "Migration router should be zero address");
+        assertEq(migrationRouter, ZERO_ADDRESS, "Migration router should be zero address");
         assertEq(bptLockDuration, 0, "BPT lock duration should be zero");
-        assertEq(shareToMigrate, 0, "Share to migrate should be zero");
-        assertEq(migrationWeight0, 0, "Migration weight 0 should be zero");
-        assertEq(migrationWeight1, 0, "Migration weight 1 should be zero");
+        assertEq(bptPercentageToMigrate, 0, "Share to migrate should be zero");
+        assertEq(migrationWeightProjectToken, 0, "Migration weight of project token should be zero");
+        assertEq(migrationWeightReserveToken, 0, "Migration weight of reserve token should be zero");
     }
 
     function testGetMigrationParamsWithMigration() public {
         uint256 initBptLockDuration = 30 days;
-        uint256 initShareToMigrate = 50e16; // 50%
-        uint256 initNewWeight0 = 60e16; // 60%
-        uint256 initNewWeight1 = 40e16; // 40%
+        uint256 initBptPercentageToMigrate = 50e16; // 50%
+        uint256 initNewWeightProjectToken = 60e16; // 60%
+        uint256 initNewWeightReserveToken = 40e16; // 40%
 
-        (pool, ) = _createLBPoolWithMigration(initBptLockDuration, initShareToMigrate, initNewWeight0, initNewWeight1);
+        (pool, ) = _createLBPoolWithMigration(
+            initBptLockDuration,
+            initBptPercentageToMigrate,
+            initNewWeightProjectToken,
+            initNewWeightReserveToken
+        );
         initPool();
 
         (
             address migrationRouter,
             uint256 bptLockDuration,
-            uint256 shareToMigrate,
-            uint256 migrationWeight0,
-            uint256 migrationWeight1
+            uint256 bptPercentageToMigrate,
+            uint256 migrationWeight,
+            uint256 migrationWeightReserveToken
         ) = LBPool(pool).getMigrationParams();
 
         assertEq(migrationRouter, address(migrationRouter), "Migration router mismatch");
         assertEq(bptLockDuration, initBptLockDuration, "BPT lock duration mismatch");
-        assertEq(shareToMigrate, initShareToMigrate, "Share to migrate mismatch");
-        assertEq(migrationWeight0, initNewWeight0, "New weight0 mismatch");
-        assertEq(migrationWeight1, initNewWeight1, "New weight1 mismatch");
+        assertEq(bptPercentageToMigrate, initBptPercentageToMigrate, "Share to migrate mismatch");
+        assertEq(migrationWeight, initNewWeightProjectToken, "New project token weight mismatch");
+        assertEq(migrationWeightReserveToken, initNewWeightReserveToken, "New reserve token weight mismatch");
     }
 
     function testGetProjectToken() public view {
@@ -744,8 +749,8 @@ contract LBPoolTest is BaseLBPTest {
         vm.prank(address(vault));
         vm.expectRevert(LBPool.RemovingLiquidityNotAllowed.selector);
         LBPool(pool).onBeforeRemoveLiquidity(
-            address(0),
-            address(0),
+            ZERO_ADDRESS,
+            ZERO_ADDRESS,
             RemoveLiquidityKind.PROPORTIONAL,
             0,
             new uint256[](0),
@@ -760,8 +765,8 @@ contract LBPoolTest is BaseLBPTest {
 
         vm.prank(address(vault));
         bool success = LBPool(pool).onBeforeRemoveLiquidity(
-            address(0),
-            address(0),
+            ZERO_ADDRESS,
+            ZERO_ADDRESS,
             RemoveLiquidityKind.PROPORTIONAL,
             0,
             new uint256[](0),
@@ -811,7 +816,7 @@ contract LBPoolTest is BaseLBPTest {
         vm.prank(address(vault));
         bool success = LBPool(pool).onBeforeRemoveLiquidity(
             address(router),
-            address(0),
+            ZERO_ADDRESS,
             RemoveLiquidityKind.PROPORTIONAL,
             0,
             new uint256[](0),
@@ -837,7 +842,7 @@ contract LBPoolTest is BaseLBPTest {
         vm.prank(address(vault));
         bool success = LBPool(pool).onBeforeRemoveLiquidity(
             address(migrationRouter),
-            address(0),
+            ZERO_ADDRESS,
             RemoveLiquidityKind.PROPORTIONAL,
             0,
             new uint256[](0),
@@ -863,7 +868,7 @@ contract LBPoolTest is BaseLBPTest {
         vm.prank(address(vault));
         bool success = LBPool(pool).onBeforeRemoveLiquidity(
             address(router),
-            address(0),
+            ZERO_ADDRESS,
             RemoveLiquidityKind.PROPORTIONAL,
             0,
             new uint256[](0),

--- a/pkg/pool-weighted/test/foundry/utils/BaseLBPTest.sol
+++ b/pkg/pool-weighted/test/foundry/utils/BaseLBPTest.sol
@@ -147,9 +147,9 @@ contract BaseLBPTest is BaseVaultTest, LBPoolContractsDeployer, WeightedPoolCont
 
     function _createLBPoolWithMigration(
         uint256 bptLockDuration,
-        uint256 shareToMigrate,
-        uint256 migrationWeight0,
-        uint256 migrationWeight1
+        uint256 bptPercentageToMigrate,
+        uint256 migrationWeightProjectToken,
+        uint256 migrationWeightReserveToken
     ) internal returns (address newPool, bytes memory poolArgs) {
         string memory name = "LBPool";
         string memory symbol = "LBP";
@@ -174,9 +174,9 @@ contract BaseLBPTest is BaseVaultTest, LBPoolContractsDeployer, WeightedPoolCont
             swapFee,
             bytes32(_saltCounter++),
             bptLockDuration,
-            shareToMigrate,
-            migrationWeight0,
-            migrationWeight1
+            bptPercentageToMigrate,
+            migrationWeightProjectToken,
+            migrationWeightReserveToken
         );
 
         poolArgs = abi.encode(name, symbol, lbpParams, vault, address(router), address(migrationRouter), poolVersion);


### PR DESCRIPTION
# Description

The review of #1404 got a bit out of hand :)

It was easier to just make the changes, as many were outside the diff. No semantic changes, just some cleanup/docs/renames. This can be merged into #1404.

// This really doesn't need to be generalized; it's used for one purpose, so can be specific
ContractIsNotActiveInRegistry(string contractName) -> NoRegisteredWeightedPoolFactory();

// Finalized sounds like V1 (at least to those who go back that far); I reused the name of the underlying LBPool error
LBPWeightsNotFinalized -> RemovingLiquidityNotAllowed

// "share" isn't wrong, but perhaps bptPercentage is clearer
shareToMigrate -> bptPercentageToMigrate

// Big one responsible for a lot of the diff: as in ReCLAMM, using 0/1 is confusing, especially when we have two well-defined tokens (project and reserve). Using the names also makes things like price calculations easier to follow.

Timelocker introduces a lot of new OpenZeppelin libraries. It would be helpful to document what they are, why they're used, etc.

Most of the imports were unused, and there were some additional renames. "Amount" isn't really involved in the error; the issue is the timelock expiration, so renamed to focus on that. Events have the verb at the end, and using a regular address for the BPT is clearer than a numerical value (even though they're the same).

SetUnlockTimestamp -> BPTTimelockSet (and use address in the event for clarity)
AmountNotUnlockedYet -> BPTStillLocked
NoLockedAmount -> NoLockedBPT

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
