### PR TITLE
Refactor LBP

### DIFF
--- a/pkg/interfaces/contracts/pool-weighted/ILBPMigrationRouter.sol
+++ b/pkg/interfaces/contracts/pool-weighted/ILBPMigrationRouter.sol
@@ -24,8 +24,12 @@ interface ILBPMigrationRouter {
     /// @notice The caller is not the owner of the LBP.
     error SenderIsNotLBPOwner();
 
-    /// @notice Pool has an incorrect migration router.
-    error IncorrectMigrationRouter(address currentRouter);
+    /**
+     * @notice A router called `migrate` on a pool that was not the one specified on deployment.
+     * @param expectedRouter The migration router address set by the pool on deployment
+     * @param actualRouter The address of the router that tried to migrate it
+     */
+    error IncorrectMigrationRouter(address expectedRouter, address actualRouter);
 
     struct MigrationHookParams {
         ILBPool lbp;
@@ -33,7 +37,7 @@ interface ILBPMigrationRouter {
         IERC20[] tokens;
         address sender;
         address excessReceiver;
-        uint256 lockDuration;
+        uint256 bptLockDuration;
         uint256 bptPercentageToMigrate;
         uint256 migrationWeightProjectToken;
         uint256 migrationWeightReserveToken;

--- a/pkg/interfaces/contracts/pool-weighted/ILBPool.sol
+++ b/pkg/interfaces/contracts/pool-weighted/ILBPool.sol
@@ -59,6 +59,12 @@ struct LBPoolImmutableData {
     uint256 projectTokenIndex;
     uint256 reserveTokenIndex;
     bool isProjectTokenSwapInBlocked;
+    // Migration parameters (if migrationRouter == address(0), the pool does not support migration).
+    address migrationRouter;
+    uint256 bptLockDuration;
+    uint256 bptPercentageToMigrate;
+    uint256 migrationWeightProjectToken;
+    uint256 migrationWeightReserveToken;
 }
 
 /**

--- a/pkg/pool-weighted/contracts/lbp/BPTTimeLocker.sol
+++ b/pkg/pool-weighted/contracts/lbp/BPTTimeLocker.sol
@@ -9,6 +9,18 @@ import { ERC6909 } from "@openzeppelin/contracts/token/ERC6909/draft-ERC6909.sol
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Multicall } from "@openzeppelin/contracts/utils/Multicall.sol";
 
+/**
+ * @notice Timelock for WeightedPool BPT created during an LBP migration.
+ * @dev The migration router creates and initializes a new weighted pool upon completion of an LBP sale, sending the
+ * BPT to this contract, and calls `_lockBPT` with an amount and lock duration (read from immutable LBP parameters)
+ * to mint an amount of fungible ERC6909 tokens to the caller corresponding to the BPT amount, with an id that is the
+ * numeric equivalent of the BPT address. After the timelock expires, a "lock token" holder can call `withdrawBPT` to
+ * burn them and recover the original BPT.
+ *
+ * This contract uses ERC-6909, a token standard that allows a single smart contract to manage multiple fungible and
+ * non-fungible tokens efficiently. ERC6909Metadata is an extension similar to ERC20Metadata that supports name,
+ * symbol, and decimals.
+ */
 contract BPTTimeLocker is ERC6909, ERC6909Metadata, Multicall {
     using SafeERC20 for IERC20;
 

--- a/pkg/pool-weighted/contracts/lbp/LBPool.sol
+++ b/pkg/pool-weighted/contracts/lbp/LBPool.sol
@@ -180,33 +180,6 @@ contract LBPool is ILBPool, WeightedPool, Ownable2Step, BaseHooks {
         return _trustedRouter;
     }
 
-    /**
-     * @notice Returns the migration parameters, which are used to migrate liquidity.
-     * @dev The migration parameters are set at deployment and cannot be changed later.
-     * @return migrationRouter The address of the migration router allowed to migrate this LBP
-     * @return lockDuration The duration for which the BPTs will be locked after migration
-     * @return bptPercentageToMigrate The percentage of the BPT to migrate from the LBP to the new weighted pool
-     * @return weightProjectToken The weight of the project token in the new weighted pool
-     * @return weightReserveToken The weight of the reserve token in the new weighted pool
-     */
-    function getMigrationParams()
-        external
-        view
-        returns (
-            address migrationRouter,
-            uint256 lockDuration,
-            uint256 bptPercentageToMigrate,
-            uint256 weightProjectToken,
-            uint256 weightReserveToken
-        )
-    {
-        migrationRouter = _migrationRouter;
-        lockDuration = _lockDurationAfterMigration;
-        bptPercentageToMigrate = _bptPercentageToMigrate;
-        weightProjectToken = _migrationWeightProjectToken;
-        weightReserveToken = _migrationWeightReserveToken;
-    }
-
     /// @inheritdoc ILBPool
     function getProjectToken() external view returns (IERC20) {
         return _projectToken;
@@ -323,6 +296,13 @@ contract LBPool is ILBPool, WeightedPool, Ownable2Step, BaseHooks {
         data.endWeights = new uint256[](_TWO_TOKENS);
         data.endWeights[_projectTokenIndex] = _projectTokenEndWeight;
         data.endWeights[_reserveTokenIndex] = _reserveTokenEndWeight;
+
+        // Migration-related params, non-zero if the pool supports migration.
+        data.migrationRouter = _migrationRouter;
+        data.bptLockDuration = _lockDurationAfterMigration;
+        data.bptPercentageToMigrate = _bptPercentageToMigrate;
+        data.migrationWeightProjectToken = _migrationWeightProjectToken;
+        data.migrationWeightReserveToken = _migrationWeightReserveToken;
     }
 
     /*******************************************************************************

--- a/pkg/pool-weighted/test/foundry/LBPMigrationRouter.t.sol
+++ b/pkg/pool-weighted/test/foundry/LBPMigrationRouter.t.sol
@@ -369,7 +369,9 @@ contract LBPMigrationRouterTest is BaseLBPTest {
     function testMigrationLiquidityRevertsIfMigrationNotSetup() external {
         PoolRoleAccounts memory poolRoleAccounts;
 
-        vm.expectRevert(abi.encodeWithSelector(ILBPMigrationRouter.IncorrectMigrationRouter.selector, ZERO_ADDRESS));
+        vm.expectRevert(
+            abi.encodeWithSelector(ILBPMigrationRouter.IncorrectMigrationRouter.selector, ZERO_ADDRESS, migrationRouter)
+        );
         vm.prank(bob);
         migrationRouter.migrateLiquidity(
             ILBPool(pool),

--- a/pkg/pool-weighted/test/foundry/LBPool.t.sol
+++ b/pkg/pool-weighted/test/foundry/LBPool.t.sol
@@ -228,19 +228,13 @@ contract LBPoolTest is BaseLBPTest {
     }
 
     function testGetMigrationParams() public view {
-        (
-            address migrationRouter,
-            uint256 bptLockDuration,
-            uint256 bptPercentageToMigrate,
-            uint256 migrationWeightProjectToken,
-            uint256 migrationWeightReserveToken
-        ) = LBPool(pool).getMigrationParams();
+        LBPoolImmutableData memory data = LBPool(pool).getLBPoolImmutableData();
 
-        assertEq(migrationRouter, ZERO_ADDRESS, "Migration router should be zero address");
-        assertEq(bptLockDuration, 0, "BPT lock duration should be zero");
-        assertEq(bptPercentageToMigrate, 0, "Share to migrate should be zero");
-        assertEq(migrationWeightProjectToken, 0, "Migration weight of project token should be zero");
-        assertEq(migrationWeightReserveToken, 0, "Migration weight of reserve token should be zero");
+        assertEq(data.migrationRouter, ZERO_ADDRESS, "Migration router should be zero address");
+        assertEq(data.bptLockDuration, 0, "BPT lock duration should be zero");
+        assertEq(data.bptPercentageToMigrate, 0, "Share to migrate should be zero");
+        assertEq(data.migrationWeightProjectToken, 0, "Migration weight of project token should be zero");
+        assertEq(data.migrationWeightReserveToken, 0, "Migration weight of reserve token should be zero");
     }
 
     function testGetMigrationParamsWithMigration() public {
@@ -257,19 +251,13 @@ contract LBPoolTest is BaseLBPTest {
         );
         initPool();
 
-        (
-            address migrationRouter,
-            uint256 bptLockDuration,
-            uint256 bptPercentageToMigrate,
-            uint256 migrationWeight,
-            uint256 migrationWeightReserveToken
-        ) = LBPool(pool).getMigrationParams();
+        LBPoolImmutableData memory data = LBPool(pool).getLBPoolImmutableData();
 
-        assertEq(migrationRouter, address(migrationRouter), "Migration router mismatch");
-        assertEq(bptLockDuration, initBptLockDuration, "BPT lock duration mismatch");
-        assertEq(bptPercentageToMigrate, initBptPercentageToMigrate, "Share to migrate mismatch");
-        assertEq(migrationWeight, initNewWeightProjectToken, "New project token weight mismatch");
-        assertEq(migrationWeightReserveToken, initNewWeightReserveToken, "New reserve token weight mismatch");
+        assertEq(data.migrationRouter, address(migrationRouter), "Migration router mismatch");
+        assertEq(data.bptLockDuration, initBptLockDuration, "BPT lock duration mismatch");
+        assertEq(data.bptPercentageToMigrate, initBptPercentageToMigrate, "Share to migrate mismatch");
+        assertEq(data.migrationWeightProjectToken, initNewWeightProjectToken, "New project token weight mismatch");
+        assertEq(data.migrationWeightReserveToken, initNewWeightReserveToken, "New reserve token weight mismatch");
     }
 
     function testGetProjectToken() public view {


### PR DESCRIPTION
# Description

Built off #1404, the easiest course is again to just make a follow-on PR.

This adds docs, moves the migration params to the existing immutables (in the process resolving some "stack too deep" issues), simplifies a couple calculations, and does some additional validation. It doesn't make sense for the migration percentage to be 0 when we're doing a migration (as that's the same as not doing a migration, and would cause it to fail anyway with zero amounts). And even though we don't have a minimum migration duration, it likewise shouldn't be zero if we're doing a migration. Otherwise there is no benefit to the lock. This is mostly to guard against accidental failure to set initialization parameters (i.e., not overriding their 0 default values). The UI would display the percentage and (more importantly for users) the lock duration.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
