### PR TITLE
Remove `authenticate` from weighted LP oracle factory

### DIFF
--- a/pkg/standalone-utils/contracts/WeightedLPOracleFactory.sol
+++ b/pkg/standalone-utils/contracts/WeightedLPOracleFactory.sol
@@ -30,7 +30,7 @@ contract WeightedLPOracleFactory is IWeightedLPOracleFactory, SingletonAuthentic
     function create(
         IWeightedPool pool,
         AggregatorV3Interface[] memory feeds
-    ) external authenticate returns (IWeightedLPOracle oracle) {
+    ) external returns (IWeightedLPOracle oracle) {
         if (_oracles[pool] != IWeightedLPOracle(address(0))) {
             revert OracleAlreadyExists();
         }

--- a/pkg/standalone-utils/test/foundry/WeightedLPOracleFactory.t.sol
+++ b/pkg/standalone-utils/test/foundry/WeightedLPOracleFactory.t.sol
@@ -40,8 +40,6 @@ contract WeightedLPOracleFactoryTest is BaseVaultTest, WeightedPoolContractsDepl
         BaseVaultTest.setUp();
         _weightedLPOracleFactory = new WeightedLPOracleFactory(vault, ORACLE_VERSION);
 
-        authorizer.grantRole(_weightedLPOracleFactory.getActionId(IWeightedLPOracleFactory.create.selector), admin);
-
         _weightedPoolFactory = deployWeightedPoolFactory(IVault(address(vault)), 365 days, "Factory v1", "Pool v1");
     }
 
@@ -101,13 +99,11 @@ contract WeightedLPOracleFactoryTest is BaseVaultTest, WeightedPoolContractsDepl
         AggregatorV3Interface[] memory feeds = createFeeds(pool);
 
         uint256 snapshot = vm.snapshot();
-        vm.prank(admin);
         IWeightedLPOracle oracle = _weightedLPOracleFactory.create(pool, feeds);
         vm.revertTo(snapshot);
 
         vm.expectEmit();
         emit IWeightedLPOracleFactory.WeightedLPOracleCreated(pool, oracle);
-        vm.prank(admin);
         _weightedLPOracleFactory.create(pool, feeds);
 
         assertEq(address(oracle), address(_weightedLPOracleFactory.getOracle(pool)), "Oracle address mismatch");
@@ -118,11 +114,9 @@ contract WeightedLPOracleFactoryTest is BaseVaultTest, WeightedPoolContractsDepl
         IWeightedPool pool = createAndInitPool();
         AggregatorV3Interface[] memory feeds = createFeeds(pool);
 
-        vm.prank(admin);
         _weightedLPOracleFactory.create(pool, feeds);
 
         vm.expectRevert(IWeightedLPOracleFactory.OracleAlreadyExists.selector);
-        vm.prank(admin);
         _weightedLPOracleFactory.create(pool, feeds);
     }
 }


### PR DESCRIPTION
# Description

Same concept as pool factories: creating one should be permissionless; up to the user of the oracle to check whether it's wired up properly.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A