### PR TITLE
Add token getter for weighted pool oracle

### DIFF
--- a/pkg/interfaces/contracts/standalone-utils/IWeightedLPOracle.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IWeightedLPOracle.sol
@@ -23,25 +23,25 @@ interface IWeightedLPOracle {
 
     /**
      * @notice Gets the list of feeds used by the oracle.
-     * @return An array of AggregatorV3Interface instances representing the feeds.
+     * @return An array of AggregatorV3Interface instances representing the feeds
      */
     function getFeeds() external view returns (AggregatorV3Interface[] memory);
 
     /**
      * @notice Gets the decimal scaling factors for each feed token.
-     * @return An array of scaling factors corresponding to each feed.
+     * @return An array of scaling factors corresponding to each feed
      */
     function getFeedTokenDecimalScalingFactors() external view returns (uint256[] memory);
 
     /**
      * @notice Gets the current weights of the tokens in the pool.
-     * @return An array of weights corresponding to each token in the pool.
+     * @return An array of weights corresponding to each token in the pool
      */
     function getWeights() external view returns (uint256[] memory);
 
     /**
      * @notice Gets the tokens in the pool.
-     * @return An array of addresses corresponding to each token in the pool.
+     * @return An array of token addresses, sorted in token registration order
      */
-    function getTokens() external view returns (IERC20[] memory);
+    function getPoolTokens() external view returns (IERC20[] memory);
 }

--- a/pkg/interfaces/contracts/standalone-utils/IWeightedLPOracle.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IWeightedLPOracle.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.24;
 
 import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IWeightedLPOracle {
     /**
@@ -37,4 +38,10 @@ interface IWeightedLPOracle {
      * @return An array of weights corresponding to each token in the pool.
      */
     function getWeights() external view returns (uint256[] memory);
+
+    /**
+     * @notice Gets the tokens in the pool.
+     * @return An array of addresses corresponding to each token in the pool.
+     */
+    function getTokens() external view returns (IERC20[] memory);
 }

--- a/pkg/standalone-utils/contracts/WeightedLPOracle.sol
+++ b/pkg/standalone-utils/contracts/WeightedLPOracle.sol
@@ -276,7 +276,7 @@ contract WeightedLPOracle is IWeightedLPOracle, AggregatorV3Interface {
     }
 
     /// @inheritdoc IWeightedLPOracle
-    function getTokens() external view returns (IERC20[] memory) {
+    function getPoolTokens() external view returns (IERC20[] memory) {
         return _vault.getPoolTokens(address(pool));
     }
 

--- a/pkg/standalone-utils/contracts/WeightedLPOracle.sol
+++ b/pkg/standalone-utils/contracts/WeightedLPOracle.sol
@@ -275,6 +275,11 @@ contract WeightedLPOracle is IWeightedLPOracle, AggregatorV3Interface {
         return _getWeights(_totalTokens);
     }
 
+    /// @inheritdoc IWeightedLPOracle
+    function getTokens() external view returns (IERC20[] memory) {
+        return _vault.getPoolTokens(address(pool));
+    }
+
     function _computeFeedTokenDecimalScalingFactor(AggregatorV3Interface feed) internal view returns (uint256) {
         uint256 feedDecimals = feed.decimals();
 

--- a/pkg/standalone-utils/test/foundry/WeightedLPOracle.t.sol
+++ b/pkg/standalone-utils/test/foundry/WeightedLPOracle.t.sol
@@ -227,13 +227,13 @@ contract WeightedLPOracleTest is BaseVaultTest, WeightedPoolContractsDeployer {
      * forge-config: default.fuzz.runs = 10
      * forge-config: intense.fuzz.runs = 50
      */
-    function testGetTokens(uint256 totalTokens) public {
+    function testGetPoolTokens(uint256 totalTokens) public {
         totalTokens = bound(totalTokens, MIN_TOKENS, MAX_TOKENS);
 
         (IWeightedPool pool, ) = createAndInitPool(totalTokens);
         (WeightedLPOracleMock oracle, ) = deployOracle(pool);
 
-        IERC20[] memory returnedTokens = oracle.getTokens();
+        IERC20[] memory returnedTokens = oracle.getPoolTokens();
         IERC20[] memory registeredTokens = vault.getPoolTokens(address(pool));
 
         assertEq(returnedTokens.length, registeredTokens.length, "Tokens length does not match");

--- a/pkg/standalone-utils/test/foundry/WeightedLPOracle.t.sol
+++ b/pkg/standalone-utils/test/foundry/WeightedLPOracle.t.sol
@@ -162,6 +162,10 @@ contract WeightedLPOracleTest is BaseVaultTest, WeightedPoolContractsDeployer {
         assertEq(oracle.description(), "WEIGHTED-TEST/USD", "Description does not match");
     }
 
+    /**
+     * forge-config: default.fuzz.runs = 10
+     * forge-config: intense.fuzz.runs = 50
+     */
     function testGetFeeds__Fuzz(uint256 totalTokens) public {
         totalTokens = bound(totalTokens, MIN_TOKENS, MAX_TOKENS);
 
@@ -178,6 +182,10 @@ contract WeightedLPOracleTest is BaseVaultTest, WeightedPoolContractsDeployer {
         }
     }
 
+    /**
+     * forge-config: default.fuzz.runs = 10
+     * forge-config: intense.fuzz.runs = 50
+     */
     function testGetFeedTokenDecimalScalingFactors__Fuzz(uint256 totalTokens) public {
         totalTokens = bound(totalTokens, MIN_TOKENS, MAX_TOKENS);
 
@@ -196,6 +204,10 @@ contract WeightedLPOracleTest is BaseVaultTest, WeightedPoolContractsDeployer {
         }
     }
 
+    /**
+     * forge-config: default.fuzz.runs = 10
+     * forge-config: intense.fuzz.runs = 50
+     */
     function testCalculateFeedTokenDecimalScalingFactor__Fuzz(uint256 totalTokens) public {
         totalTokens = bound(totalTokens, MIN_TOKENS, MAX_TOKENS);
 
@@ -211,6 +223,29 @@ contract WeightedLPOracleTest is BaseVaultTest, WeightedPoolContractsDeployer {
         }
     }
 
+    /**
+     * forge-config: default.fuzz.runs = 10
+     * forge-config: intense.fuzz.runs = 50
+     */
+    function testGetTokens(uint256 totalTokens) public {
+        totalTokens = bound(totalTokens, MIN_TOKENS, MAX_TOKENS);
+
+        (IWeightedPool pool, ) = createAndInitPool(totalTokens);
+        (WeightedLPOracleMock oracle, ) = deployOracle(pool);
+
+        IERC20[] memory returnedTokens = oracle.getTokens();
+        IERC20[] memory registeredTokens = vault.getPoolTokens(address(pool));
+
+        assertEq(returnedTokens.length, registeredTokens.length, "Tokens length does not match");
+        for (uint256 i = 0; i < returnedTokens.length; i++) {
+            assertEq(address(returnedTokens[i]), address(registeredTokens[i]), "Tokens does not match");
+        }
+    }
+
+    /**
+     * forge-config: default.fuzz.runs = 10
+     * forge-config: intense.fuzz.runs = 50
+     */
     function testGetWeights__Fuzz(uint256 totalTokens) public {
         totalTokens = bound(totalTokens, MIN_TOKENS, MAX_TOKENS);
 


### PR DESCRIPTION
# Description

Convenience getter for pool tokens.
We already have a separate feed getter, and it's usually best to just return plain arrays instead of arrays with structs (token, feed).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #1403 