### PR TITLE
Restore nested pool functionality to the CompositeLiquidityRouter [old single-PR version]

### DIFF
--- a/pkg/interfaces/contracts/vault/ICompositeLiquidityRouter.sol
+++ b/pkg/interfaces/contracts/vault/ICompositeLiquidityRouter.sol
@@ -171,7 +171,7 @@ interface ICompositeLiquidityRouter {
      * @param minBptAmountOut Expected minimum amount of parent pool tokens to receive
      * @param wethIsEth If true, incoming ETH will be wrapped to WETH and outgoing WETH will be unwrapped to ETH
      * @param userData Additional (optional) data required for the operation
-     * @return bptAmountOut Expected amount of parent pool tokens to receive
+     * @return bptAmountOut Actual amount of parent pool token received
      */
     function addLiquidityUnbalancedNestedPool(
         address parentPool,
@@ -234,7 +234,7 @@ interface ICompositeLiquidityRouter {
      * balances are not settled and the operation reverts. Tokens that repeat must be informed only once.
      * @param sender The sender passed to the operation. It can influence results (e.g., with user-dependent hooks)
      * @param userData Additional (optional) data required for the operation
-     * @return amountsOut Actual amounts of tokens received, parallel to `tokensOut`
+     * @return amountsOut Amounts of tokens expected to be received, parallel to `tokensOut`
      */
     function queryRemoveLiquidityProportionalNestedPool(
         address parentPool,

--- a/pkg/interfaces/contracts/vault/ICompositeLiquidityRouter.sol
+++ b/pkg/interfaces/contracts/vault/ICompositeLiquidityRouter.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.24;
 
 /**
- * @notice The composite liquidity router supports add/remove liquidity operations on ERC4626 pools.
+ * @notice The composite liquidity router supports add/remove liquidity operations on ERC4626 and nested pools.
  * @dev This contract allow interacting with ERC4626 Pools (which contain wrapped ERC4626 tokens) using only underlying
  * standard tokens. For instance, with `addLiquidityUnbalancedToERC4626Pool` it is possible to add liquidity to an
  * ERC4626 Pool with [waDAI, waUSDC], using only DAI, only USDC, or an arbitrary amount of both. If the ERC4626 buffers
@@ -153,4 +153,94 @@ interface ICompositeLiquidityRouter {
         address sender,
         bytes memory userData
     ) external returns (address[] memory tokensOut, uint256[] memory amountsOut);
+
+    /***************************************************************************
+                                   Nested pools
+    ***************************************************************************/
+
+    /**
+     * @notice Adds liquidity unbalanced to a nested pool.
+     * @dev A nested pool is one in which one or more tokens are BPTs from another pool (child pool). Since there are
+     * multiple pools involved, the token order is not given, so the user must specify the preferred order to inform
+     * the token in amounts.
+     *
+     * @param parentPool Address of the highest level pool (which contains BPTs of other pools)
+     * @param tokensIn Input token addresses, sorted by user preference. `tokensIn` array must have all tokens from
+     * child pools and all tokens that are not BPTs from the nested pool (parent pool).
+     * @param exactAmountsIn Amount of each token in, corresponding to `tokensIn`
+     * @param minBptAmountOut Expected minimum amount of parent pool tokens to receive
+     * @param wethIsEth If true, incoming ETH will be wrapped to WETH and outgoing WETH will be unwrapped to ETH
+     * @param userData Additional (optional) data required for the operation
+     * @return bptAmountOut Expected amount of parent pool tokens to receive
+     */
+    function addLiquidityUnbalancedNestedPool(
+        address parentPool,
+        address[] memory tokensIn,
+        uint256[] memory exactAmountsIn,
+        uint256 minBptAmountOut,
+        bool wethIsEth,
+        bytes memory userData
+    ) external payable returns (uint256 bptAmountOut);
+
+    /**
+     * @notice Queries an `addLiquidityUnbalancedNestedPool` operation without actually executing it.
+     * @param parentPool Address of the highest level pool (which contains BPTs of other pools)
+     * @param tokensIn Input token addresses, sorted by user preference. `tokensIn` array must have all tokens from
+     * child pools and all tokens that are not BPTs from the nested pool (parent pool).
+     * @param exactAmountsIn Amount of each token in, corresponding to `tokensIn`
+     * @param sender The sender passed to the operation. It can influence results (e.g., with user-dependent hooks)
+     * @param userData Additional (optional) data required for the operation
+     * @return bptAmountOut Expected amount of parent pool tokens to receive
+     */
+    function queryAddLiquidityUnbalancedNestedPool(
+        address parentPool,
+        address[] memory tokensIn,
+        uint256[] memory exactAmountsIn,
+        address sender,
+        bytes memory userData
+    ) external returns (uint256 bptAmountOut);
+
+    /**
+     * @notice Removes liquidity of a nested pool.
+     * @dev A nested pool is one in which one or more tokens are BPTs from another pool (child pool). Since there are
+     * multiple pools involved, the token order is not given, so the user must specify the preferred order to inform
+     * the token out amounts.
+     *
+     * @param parentPool Address of the highest level pool (which contains BPTs of other pools)
+     * @param exactBptAmountIn Exact amount of `parentPool` tokens provided
+     * @param tokensOut Output token addresses, sorted by user preference. `tokensOut` array must have all tokens from
+     * child pools and all tokens that are not BPTs from the nested pool (parent pool). If not all tokens are informed,
+     * balances are not settled and the operation reverts. Tokens that repeat must be informed only once.
+     * @param minAmountsOut Minimum amounts of each outgoing token, corresponding to `tokensOut`
+     * @param wethIsEth If true, incoming ETH will be wrapped to WETH and outgoing WETH will be unwrapped to ETH
+     * @param userData Additional (optional) data required for the operation
+     * @return amountsOut Actual amounts of tokens received, parallel to `tokensOut`
+     */
+    function removeLiquidityProportionalNestedPool(
+        address parentPool,
+        uint256 exactBptAmountIn,
+        address[] memory tokensOut,
+        uint256[] memory minAmountsOut,
+        bool wethIsEth,
+        bytes memory userData
+    ) external payable returns (uint256[] memory amountsOut);
+
+    /**
+     * @notice Queries an `removeLiquidityProportionalNestedPool` operation without actually executing it.
+     * @param parentPool Address of the highest level pool (which contains BPTs of other pools)
+     * @param exactBptAmountIn Exact amount of `parentPool` tokens provided
+     * @param tokensOut Output token addresses, sorted by user preference. `tokensOut` array must have all tokens from
+     * child pools and all tokens that are not BPTs from the nested pool (parent pool). If not all tokens are informed,
+     * balances are not settled and the operation reverts. Tokens that repeat must be informed only once.
+     * @param sender The sender passed to the operation. It can influence results (e.g., with user-dependent hooks)
+     * @param userData Additional (optional) data required for the operation
+     * @return amountsOut Actual amounts of tokens received, parallel to `tokensOut`
+     */
+    function queryRemoveLiquidityProportionalNestedPool(
+        address parentPool,
+        uint256 exactBptAmountIn,
+        address[] memory tokensOut,
+        address sender,
+        bytes memory userData
+    ) external returns (uint256[] memory amountsOut);
 }

--- a/pkg/interfaces/contracts/vault/ICompositeLiquidityRouter.sol
+++ b/pkg/interfaces/contracts/vault/ICompositeLiquidityRouter.sol
@@ -161,17 +161,15 @@ interface ICompositeLiquidityRouter {
     /**
      * @notice Adds liquidity unbalanced to a nested pool.
      * @dev A nested pool is one in which one or more tokens are BPTs from another pool (child pool). Since there are
-     * multiple pools involved, the token order is not given, so the user must specify the preferred order to inform
-     * the token in amounts.
+     * multiple pools involved, the token order is not well-defined, and must be specified by the caller.
      *
-     * @param parentPool Address of the highest level pool (which contains BPTs of other pools)
-     * @param tokensIn Input token addresses, sorted by user preference. `tokensIn` array must have all tokens from
-     * child pools and all tokens that are not BPTs from the nested pool (parent pool).
-     * @param exactAmountsIn Amount of each token in, corresponding to `tokensIn`
+     * @param parentPool The address of the parent pool (which contains BPTs of other pools)
+     * @param tokensIn An array with all tokens from the child pools, and all non-BPT parent tokens, in arbitrary order
+     * @param exactAmountsIn An array with the amountIn of each token, sorted in the same order as tokensIn
      * @param minBptAmountOut Expected minimum amount of parent pool tokens to receive
      * @param wethIsEth If true, incoming ETH will be wrapped to WETH and outgoing WETH will be unwrapped to ETH
      * @param userData Additional (optional) data required for the operation
-     * @return bptAmountOut Actual amount of parent pool token received
+     * @return bptAmountOut The actual amount of parent pool tokens received
      */
     function addLiquidityUnbalancedNestedPool(
         address parentPool,
@@ -184,13 +182,12 @@ interface ICompositeLiquidityRouter {
 
     /**
      * @notice Queries an `addLiquidityUnbalancedNestedPool` operation without actually executing it.
-     * @param parentPool Address of the highest level pool (which contains BPTs of other pools)
-     * @param tokensIn Input token addresses, sorted by user preference. `tokensIn` array must have all tokens from
-     * child pools and all tokens that are not BPTs from the nested pool (parent pool).
-     * @param exactAmountsIn Amount of each token in, corresponding to `tokensIn`
+     * @param parentPool The address of the parent pool (which contains BPTs of other pools)
+     * @param tokensIn An array with all tokens from the child pools, and all non-BPT parent tokens, in arbitrary order
+     * @param exactAmountsIn An array with the amountIn of each token, sorted in the same order as tokensIn
      * @param sender The sender passed to the operation. It can influence results (e.g., with user-dependent hooks)
      * @param userData Additional (optional) data required for the operation
-     * @return bptAmountOut Expected amount of parent pool tokens to receive
+     * @return bptAmountOut The actual amount of parent pool tokens received
      */
     function queryAddLiquidityUnbalancedNestedPool(
         address parentPool,
@@ -201,20 +198,17 @@ interface ICompositeLiquidityRouter {
     ) external returns (uint256 bptAmountOut);
 
     /**
-     * @notice Removes liquidity of a nested pool.
+     * @notice Removes liquidity from a nested pool.
      * @dev A nested pool is one in which one or more tokens are BPTs from another pool (child pool). Since there are
-     * multiple pools involved, the token order is not given, so the user must specify the preferred order to inform
-     * the token out amounts.
+     * multiple pools involved, the token order is not well-defined, and must be specified by the caller.
      *
-     * @param parentPool Address of the highest level pool (which contains BPTs of other pools)
-     * @param exactBptAmountIn Exact amount of `parentPool` tokens provided
-     * @param tokensOut Output token addresses, sorted by user preference. `tokensOut` array must have all tokens from
-     * child pools and all tokens that are not BPTs from the nested pool (parent pool). If not all tokens are informed,
-     * balances are not settled and the operation reverts. Tokens that repeat must be informed only once.
-     * @param minAmountsOut Minimum amounts of each outgoing token, corresponding to `tokensOut`
+     * @param parentPool The address of the parent pool (which contains BPTs of other pools)
+     * @param exactBptAmountIn The exact amount of `parentPool` tokens provided
+     * @param tokensOut An array with all tokens from the child pools, and all non-BPT parent tokens, in arbitrary order
+     * @param minAmountsOut An array with the minimum amountOut of each token, sorted in the same order as tokensOut
      * @param wethIsEth If true, incoming ETH will be wrapped to WETH and outgoing WETH will be unwrapped to ETH
      * @param userData Additional (optional) data required for the operation
-     * @return amountsOut Actual amounts of tokens received, parallel to `tokensOut`
+     * @return amountsOut An array with the actual amountOut of each token, sorted in the same order as tokensOut
      */
     function removeLiquidityProportionalNestedPool(
         address parentPool,
@@ -227,14 +221,12 @@ interface ICompositeLiquidityRouter {
 
     /**
      * @notice Queries an `removeLiquidityProportionalNestedPool` operation without actually executing it.
-     * @param parentPool Address of the highest level pool (which contains BPTs of other pools)
-     * @param exactBptAmountIn Exact amount of `parentPool` tokens provided
-     * @param tokensOut Output token addresses, sorted by user preference. `tokensOut` array must have all tokens from
-     * child pools and all tokens that are not BPTs from the nested pool (parent pool). If not all tokens are informed,
-     * balances are not settled and the operation reverts. Tokens that repeat must be informed only once.
+     * @param parentPool The address of the parent pool (which contains BPTs of other pools)
+     * @param exactBptAmountIn The exact amount of `parentPool` tokens provided
+     * @param tokensOut An array with all tokens from the child pools, and all non-BPT parent tokens, in arbitrary order
      * @param sender The sender passed to the operation. It can influence results (e.g., with user-dependent hooks)
      * @param userData Additional (optional) data required for the operation
-     * @return amountsOut Amounts of tokens expected to be received, parallel to `tokensOut`
+     * @return amountsOut An array with the expected amountOut of each token, sorted in the same order as tokensOut
      */
     function queryRemoveLiquidityProportionalNestedPool(
         address parentPool,

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -242,11 +242,11 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
         AddLiquidityHookParams calldata params,
         bool[] calldata wrapUnderlying
     ) external nonReentrant onlyVault returns (uint256 bptAmountOut) {
-        IERC20[] memory erc4626PoolTokens = _vault.getPoolTokens(params.pool);
-        uint256 poolTokensLength = erc4626PoolTokens.length;
-
-        // Revert if `poolTokens` length does not match `maxAmountsIn` and `wrapUnderlying`.
-        InputHelpers.ensureInputLengthMatch(poolTokensLength, params.maxAmountsIn.length, wrapUnderlying.length);
+        (IERC20[] memory erc4626PoolTokens, uint256 numTokens) = _validateHookParams(
+            params.pool,
+            params.maxAmountsIn.length,
+            wrapUnderlying.length
+        );
 
         RouterCallParams memory callParams = RouterCallParams({
             sender: params.sender,
@@ -254,8 +254,8 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
             isStaticCall: EVMCallModeHelpers.isStaticCall()
         });
 
-        uint256[] memory amountsIn = new uint256[](poolTokensLength);
-        for (uint256 i = 0; i < poolTokensLength; ++i) {
+        uint256[] memory amountsIn = new uint256[](numTokens);
+        for (uint256 i = 0; i < numTokens; ++i) {
             if (params.maxAmountsIn[i] > 0) {
                 amountsIn[i] = _processTokenIn(
                     address(erc4626PoolTokens[i]),
@@ -286,14 +286,14 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
         AddLiquidityHookParams calldata params,
         bool[] calldata wrapUnderlying
     ) external nonReentrant onlyVault returns (address[] memory tokensIn, uint256[] memory amountsIn) {
-        IERC20[] memory erc4626PoolTokens = _vault.getPoolTokens(params.pool);
-        uint256 poolTokensLength = erc4626PoolTokens.length;
+        (IERC20[] memory erc4626PoolTokens, uint256 numTokens) = _validateHookParams(
+            params.pool,
+            params.maxAmountsIn.length,
+            wrapUnderlying.length
+        );
 
-        // Revert if `poolTokens` length does not match `maxAmountsIn` and `wrapUnderlying`.
-        InputHelpers.ensureInputLengthMatch(poolTokensLength, params.maxAmountsIn.length, wrapUnderlying.length);
-
-        uint256[] memory maxAmounts = new uint256[](poolTokensLength);
-        for (uint256 i = 0; i < poolTokensLength; ++i) {
+        uint256[] memory maxAmounts = new uint256[](numTokens);
+        for (uint256 i = 0; i < numTokens; ++i) {
             maxAmounts[i] = _MAX_AMOUNT;
         }
 
@@ -315,10 +315,10 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
             isStaticCall: EVMCallModeHelpers.isStaticCall()
         });
 
-        tokensIn = new address[](poolTokensLength);
-        amountsIn = new uint256[](poolTokensLength);
+        tokensIn = new address[](numTokens);
+        amountsIn = new uint256[](numTokens);
 
-        for (uint256 i = 0; i < poolTokensLength; ++i) {
+        for (uint256 i = 0; i < numTokens; ++i) {
             (tokensIn[i], amountsIn[i]) = _processTokenInExactOut(
                 address(erc4626PoolTokens[i]),
                 wrappedAmountsIn[i],
@@ -336,18 +336,18 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
         RemoveLiquidityHookParams calldata params,
         bool[] calldata unwrapWrapped
     ) external nonReentrant onlyVault returns (address[] memory tokensOut, uint256[] memory amountsOut) {
-        IERC20[] memory erc4626PoolTokens = _vault.getPoolTokens(params.pool);
-        uint256 poolTokensLength = erc4626PoolTokens.length;
-
-        // Revert if `poolTokens` length does not match `minAmountsOut` and `unwrapWrapped`.
-        InputHelpers.ensureInputLengthMatch(poolTokensLength, params.minAmountsOut.length, unwrapWrapped.length);
+        (IERC20[] memory erc4626PoolTokens, uint256 numTokens) = _validateHookParams(
+            params.pool,
+            params.minAmountsOut.length,
+            unwrapWrapped.length
+        );
 
         (, uint256[] memory wrappedAmountsOut, ) = _vault.removeLiquidity(
             RemoveLiquidityParams({
                 pool: params.pool,
                 from: params.sender,
                 maxBptAmountIn: params.maxBptAmountIn,
-                minAmountsOut: new uint256[](poolTokensLength),
+                minAmountsOut: new uint256[](numTokens),
                 kind: params.kind,
                 userData: params.userData
             })
@@ -359,10 +359,10 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
             isStaticCall: EVMCallModeHelpers.isStaticCall()
         });
 
-        tokensOut = new address[](poolTokensLength);
-        amountsOut = new uint256[](poolTokensLength);
+        tokensOut = new address[](numTokens);
+        amountsOut = new uint256[](numTokens);
 
-        for (uint256 i = 0; i < poolTokensLength; ++i) {
+        for (uint256 i = 0; i < numTokens; ++i) {
             if (wrappedAmountsOut[i] == 0) {
                 tokensOut[i] = address(erc4626PoolTokens[i]);
             } else {
@@ -375,6 +375,17 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                 );
             }
         }
+    }
+
+    function _validateHookParams(
+        address pool,
+        uint256 amountsLength,
+        uint256 wrapLength
+    ) private view returns (IERC20[] memory poolTokens, uint256 numTokens) {
+        poolTokens = _vault.getPoolTokens(pool);
+        numTokens = poolTokens.length;
+
+        InputHelpers.ensureInputLengthMatch(numTokens, amountsLength, wrapLength);
     }
 
     /**
@@ -1008,17 +1019,21 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
     ) private view returns (CompositeTokenInfo memory info) {
         info.token = token;
         info.amount = amount;
+        info.tokenType = _getCompositeTokenType(token);
 
-        if (_vault.isPoolRegistered(token)) {
-            info.tokenType = CompositeTokenType.BPT;
-        } else if (_vault.isERC4626BufferInitialized(IERC4626(token))) {
-            info.tokenType = CompositeTokenType.ERC4626;
-            // Wrap if no wrapped amount specified but underlying is available.
-            info.needToWrap = (amount == 0 &&
+        if (info.tokenType == CompositeTokenType.ERC4626) {
+            info.needToWrap = (amount == 0 && 
                 _currentSwapTokenInAmounts().tGet(_vault.getBufferAsset(IERC4626(token))) > 0);
+        }
+    }
+
+    function _getCompositeTokenType(address token) internal view returns (CompositeTokenType tokenType) {
+        if (_vault.isPoolRegistered(token)) {
+            tokenType = CompositeTokenType.BPT;
+        } else if (_vault.isERC4626BufferInitialized(IERC4626(token))) {
+            tokenType = CompositeTokenType.ERC4626;
         } else {
-            // This clause could be avoided, as the default is ERC20; kept for clarity and enum order-independence.
-            info.tokenType = CompositeTokenType.ERC20;
+            tokenType = CompositeTokenType.ERC20;
         }
     }
 }

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -23,7 +23,7 @@ import {
 import { BatchRouterCommon } from "./BatchRouterCommon.sol";
 
 /**
- * @notice Entrypoint for add/remove liquidity operations on ERC4626 pools.
+ * @notice Entrypoint for add/remove liquidity operations on ERC4626 and nested pools.
  * @dev The external API functions unlock the Vault, which calls back into the corresponding hook functions.
  * These execute the steps needed to add to and remove liquidity from these special types of pools, and settle
  * the operation with the Vault.
@@ -31,6 +31,10 @@ import { BatchRouterCommon } from "./BatchRouterCommon.sol";
 contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommon {
     using TransientEnumerableSet for TransientEnumerableSet.AddressSet;
     using TransientStorageHelpers for *;
+
+    // The level is 1-based, so the outermost pool (level 1) can contain a nested BPT, but any pool tokens in the child
+    // pool (level 2) will not be expanded further, but simply treated as standard tokens.
+    uint256 internal constant _MAX_LEVEL_IN_NESTED_OPERATIONS = 2;
 
     constructor(
         IVault vault,
@@ -563,5 +567,354 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
         address underlyingToken = _vault.getERC4626BufferAsset(wrappedToken);
         _currentSwapTokensOut().add(underlyingToken);
         _currentSwapTokenOutAmounts().tAdd(underlyingToken, underlyingAmountOut);
+    }
+
+    /***************************************************************************
+                                   Nested pools
+    ***************************************************************************/
+
+    /// @inheritdoc ICompositeLiquidityRouter
+    function addLiquidityUnbalancedNestedPool(
+        address parentPool,
+        address[] memory tokensIn,
+        uint256[] memory exactAmountsIn,
+        uint256 minBptAmountOut,
+        bool wethIsEth,
+        bytes memory userData
+    ) external payable saveSender(msg.sender) returns (uint256) {
+        return
+            abi.decode(
+                _vault.unlock(
+                    abi.encodeCall(
+                        CompositeLiquidityRouter.addLiquidityUnbalancedNestedPoolHook,
+                        (
+                            AddLiquidityHookParams({
+                                pool: parentPool,
+                                sender: msg.sender,
+                                maxAmountsIn: exactAmountsIn,
+                                minBptAmountOut: minBptAmountOut,
+                                kind: AddLiquidityKind.UNBALANCED,
+                                wethIsEth: wethIsEth,
+                                userData: userData
+                            }),
+                            tokensIn
+                        )
+                    )
+                ),
+                (uint256)
+            );
+    }
+
+    /// @inheritdoc ICompositeLiquidityRouter
+    function queryAddLiquidityUnbalancedNestedPool(
+        address parentPool,
+        address[] memory tokensIn,
+        uint256[] memory exactAmountsIn,
+        address sender,
+        bytes memory userData
+    ) external saveSender(sender) returns (uint256) {
+        return
+            abi.decode(
+                _vault.quote(
+                    abi.encodeCall(
+                        CompositeLiquidityRouter.addLiquidityUnbalancedNestedPoolHook,
+                        (
+                            AddLiquidityHookParams({
+                                pool: parentPool,
+                                sender: address(this),
+                                maxAmountsIn: exactAmountsIn,
+                                minBptAmountOut: 0,
+                                kind: AddLiquidityKind.UNBALANCED,
+                                wethIsEth: false,
+                                userData: userData
+                            }),
+                            tokensIn
+                        )
+                    )
+                ),
+                (uint256)
+            );
+    }
+
+    function addLiquidityUnbalancedNestedPoolHook(
+        AddLiquidityHookParams calldata params,
+        address[] memory tokensIn
+    ) external nonReentrant onlyVault returns (uint256 exactBptAmountOut) {
+        // Revert if tokensIn length does not match with maxAmountsIn length.
+        InputHelpers.ensureInputLengthMatch(params.maxAmountsIn.length, tokensIn.length);
+
+        bool isStaticCall = EVMCallModeHelpers.isStaticCall();
+
+        // Loads a Set with all amounts to be inserted in the nested pools, so we don't need to iterate in the tokens
+        // array to find the child pool amounts to insert.
+        for (uint256 i = 0; i < tokensIn.length; ++i) {
+            if (params.maxAmountsIn[i] == 0) {
+                continue;
+            }
+
+            _currentSwapTokenInAmounts().tSet(tokensIn[i], params.maxAmountsIn[i]);
+            _currentSwapTokensIn().add(tokensIn[i]);
+        }
+
+        (uint256[] memory amountsIn, ) = _addLiquidity(params.pool, params);
+
+        // Adds liquidity to the parent pool, mints parentPool's BPT to the sender and checks the minimum BPT out.
+        (, exactBptAmountOut, ) = _vault.addLiquidity(
+            AddLiquidityParams({
+                pool: params.pool,
+                to: isStaticCall ? address(this) : params.sender,
+                maxAmountsIn: amountsIn,
+                minBptAmountOut: params.minBptAmountOut,
+                kind: params.kind,
+                userData: params.userData
+            })
+        );
+
+        // Settle the amounts in.
+        if (isStaticCall == false) {
+            _settlePaths(params.sender, params.wethIsEth);
+        }
+    }
+
+    function _addLiquidity(
+        address pool,
+        AddLiquidityHookParams calldata params
+    ) internal returns (uint256[] memory amountsIn, bool allAmountsEmpty) {
+        return _addLiquidityRecursive(pool, params, 1);
+    }
+
+    function _addLiquidityRecursive(
+        address currentPool,
+        AddLiquidityHookParams calldata params,
+        uint256 level
+    ) internal returns (uint256[] memory amountsIn, bool allAmountsEmpty) {
+        allAmountsEmpty = true;
+
+        IERC20[] memory parentPoolTokens = _vault.getPoolTokens(currentPool);
+        amountsIn = new uint256[](parentPoolTokens.length);
+
+        // Iterate over each token of the parent pool. If it's a BPT, add liquidity unbalanced to it.
+        for (uint256 i = 0; i < parentPoolTokens.length; i++) {
+            address childToken = address(parentPoolTokens[i]);
+
+            // NOTE: Recursion involving a pool containing its own BPT is explicitly prohibited by the Vault.
+            // This case is impossible and does not require handling.
+
+            if (_vault.isPoolRegistered(childToken)) {
+                // Token is a BPT, so add liquidity to the child pool.
+
+                if (level > _MAX_LEVEL_IN_NESTED_OPERATIONS) {
+                    // If we have exceeded the maximum level of nested operations,
+                    // the token will be considered a standard ERC20.
+                    if (_settledTokenAmounts().tGet(childToken) == 0) {
+                        amountsIn[i] = _currentSwapTokenInAmounts().tGet(childToken);
+                        _settledTokenAmounts().tSet(childToken, amountsIn[i]);
+                    }
+                    continue;
+                }
+
+                address nextPool = childToken;
+                (uint256[] memory childPoolAmountsIn, bool childPoolAmountsEmpty) = _addLiquidityRecursive(
+                    nextPool,
+                    params,
+                    level + 1
+                );
+
+                if (childPoolAmountsEmpty == false) {
+                    // Add Liquidity will mint childTokens to the Vault, so the insertion of liquidity in the parent
+                    // pool will be a logic insertion, not a token transfer.
+                    (, uint256 exactChildBptAmountOut, ) = _vault.addLiquidity(
+                        AddLiquidityParams({
+                            pool: childToken,
+                            to: address(_vault),
+                            maxAmountsIn: childPoolAmountsIn,
+                            minBptAmountOut: 0,
+                            kind: params.kind,
+                            userData: params.userData
+                        })
+                    );
+
+                    amountsIn[i] = exactChildBptAmountOut;
+
+                    // Since the BPT will be inserted into the parent pool, gets the credit from the inserted BPTs in
+                    // advance.
+                    _vault.settle(IERC20(childToken), exactChildBptAmountOut);
+                }
+            } else if (
+                _vault.isERC4626BufferInitialized(IERC4626(childToken)) &&
+                _currentSwapTokenInAmounts().tGet(childToken) == 0 // wrapped amount in was not specified
+            ) {
+                // The ERC4626 token has a buffer initialized within the Vault. Additionally, since the sender did not
+                // specify an input amount for the wrapped token, the function will wrap the underlying asset and use
+                // the resulting wrapped tokens to add liquidity to the pool.
+                amountsIn[i] = _wrapAndUpdateTokenInAmounts(IERC4626(childToken), params.sender, params.wethIsEth);
+            } else if (_settledTokenAmounts().tGet(childToken) == 0) {
+                // Set this token's amountIn if it's a standard token that was not previously settled.
+                amountsIn[i] = _currentSwapTokenInAmounts().tGet(childToken);
+                _settledTokenAmounts().tSet(childToken, amountsIn[i]);
+            }
+
+            if (amountsIn[i] > 0) {
+                allAmountsEmpty = false;
+            }
+        }
+    }
+
+    /// @inheritdoc ICompositeLiquidityRouter
+    function removeLiquidityProportionalNestedPool(
+        address parentPool,
+        uint256 exactBptAmountIn,
+        address[] memory tokensOut,
+        uint256[] memory minAmountsOut,
+        bool wethIsEth,
+        bytes memory userData
+    ) external payable saveSender(msg.sender) returns (uint256[] memory amountsOut) {
+        (amountsOut) = abi.decode(
+            _vault.unlock(
+                abi.encodeCall(
+                    CompositeLiquidityRouter.removeLiquidityProportionalNestedPoolHook,
+                    (
+                        RemoveLiquidityHookParams({
+                            sender: msg.sender,
+                            pool: parentPool,
+                            minAmountsOut: minAmountsOut,
+                            maxBptAmountIn: exactBptAmountIn,
+                            kind: RemoveLiquidityKind.PROPORTIONAL,
+                            wethIsEth: wethIsEth,
+                            userData: userData
+                        }),
+                        tokensOut
+                    )
+                )
+            ),
+            (uint256[])
+        );
+    }
+
+    /// @inheritdoc ICompositeLiquidityRouter
+    function queryRemoveLiquidityProportionalNestedPool(
+        address parentPool,
+        uint256 exactBptAmountIn,
+        address[] memory tokensOut,
+        address sender,
+        bytes memory userData
+    ) external saveSender(sender) returns (uint256[] memory amountsOut) {
+        (amountsOut) = abi.decode(
+            _vault.quote(
+                abi.encodeCall(
+                    CompositeLiquidityRouter.removeLiquidityProportionalNestedPoolHook,
+                    (
+                        RemoveLiquidityHookParams({
+                            sender: address(this),
+                            pool: parentPool,
+                            minAmountsOut: new uint256[](tokensOut.length),
+                            maxBptAmountIn: exactBptAmountIn,
+                            kind: RemoveLiquidityKind.PROPORTIONAL,
+                            wethIsEth: false,
+                            userData: userData
+                        }),
+                        tokensOut
+                    )
+                )
+            ),
+            (uint256[])
+        );
+    }
+
+    function removeLiquidityProportionalNestedPoolHook(
+        RemoveLiquidityHookParams calldata params,
+        address[] memory tokensOut
+    ) external nonReentrant onlyVault returns (uint256[] memory amountsOut) {
+        IERC20[] memory parentPoolTokens = _vault.getPoolTokens(params.pool);
+
+        bool isStaticCall = EVMCallModeHelpers.isStaticCall();
+
+        // Revert if tokensOut length does not match with minAmountsOut length.
+        InputHelpers.ensureInputLengthMatch(params.minAmountsOut.length, tokensOut.length);
+
+        (, uint256[] memory parentPoolAmountsOut, ) = _vault.removeLiquidity(
+            RemoveLiquidityParams({
+                pool: params.pool,
+                from: params.sender,
+                maxBptAmountIn: params.maxBptAmountIn,
+                minAmountsOut: new uint256[](parentPoolTokens.length),
+                kind: params.kind,
+                userData: params.userData
+            })
+        );
+
+        for (uint256 i = 0; i < parentPoolTokens.length; i++) {
+            address childToken = address(parentPoolTokens[i]);
+
+            if (_vault.isPoolRegistered(childToken)) {
+                // Token is a BPT, so remove liquidity from the child pool.
+
+                // We don't expect the sender to have BPT to burn. So, we flashloan tokens here (which should in
+                // practice just use existing credit).
+                _vault.sendTo(IERC20(childToken), address(this), parentPoolAmountsOut[i]);
+
+                IERC20[] memory childPoolTokens = _vault.getPoolTokens(childToken);
+                // Router is an intermediary in this case. The Vault will burn tokens from the Router, so Router is
+                // both owner and spender (which doesn't need approval).
+                (, uint256[] memory childPoolAmountsOut, ) = _vault.removeLiquidity(
+                    RemoveLiquidityParams({
+                        pool: childToken,
+                        from: address(this),
+                        maxBptAmountIn: parentPoolAmountsOut[i],
+                        minAmountsOut: new uint256[](childPoolTokens.length),
+                        kind: params.kind,
+                        userData: params.userData
+                    })
+                );
+                // Return amounts to user.
+                for (uint256 j = 0; j < childPoolTokens.length; j++) {
+                    address childPoolToken = address(childPoolTokens[j]);
+                    if (_vault.isERC4626BufferInitialized(IERC4626(childPoolToken))) {
+                        // Token is an ERC4626 wrapper, so unwrap it and return the underlying.
+                        _unwrapAndUpdateTokenOutAmounts(IERC4626(childPoolToken), childPoolAmountsOut[j]);
+                    } else {
+                        _currentSwapTokensOut().add(childPoolToken);
+                        _currentSwapTokenOutAmounts().tAdd(childPoolToken, childPoolAmountsOut[j]);
+                    }
+                }
+            } else if (_vault.isERC4626BufferInitialized(IERC4626(childToken))) {
+                // Token is an ERC4626 wrapper, so unwrap it and return the underlying.
+                _unwrapAndUpdateTokenOutAmounts(IERC4626(childToken), parentPoolAmountsOut[i]);
+            } else {
+                // Token is neither a BPT nor ERC4626, so return the amount to the user.
+                _currentSwapTokensOut().add(childToken);
+                _currentSwapTokenOutAmounts().tAdd(childToken, parentPoolAmountsOut[i]);
+            }
+        }
+
+        if (_currentSwapTokensOut().length() != tokensOut.length) {
+            // If tokensOut length does not match with transient tokens out length, the tokensOut array is wrong.
+            revert WrongTokensOut(_currentSwapTokensOut().values(), tokensOut);
+        }
+
+        // The hook writes current swap token and token amounts out.
+        amountsOut = new uint256[](tokensOut.length);
+        // If a certain token index was already iterated on, reverts.
+        bool[] memory checkedTokenIndexes = new bool[](tokensOut.length);
+        for (uint256 i = 0; i < tokensOut.length; ++i) {
+            uint256 tokenIndex = _currentSwapTokensOut().indexOf(tokensOut[i]);
+            if (_currentSwapTokensOut().contains(tokensOut[i]) == false || checkedTokenIndexes[tokenIndex]) {
+                // If tokenOut is not in transient tokens out array or token is repeated, the tokensOut array is wrong.
+                revert WrongTokensOut(_currentSwapTokensOut().values(), tokensOut);
+            }
+
+            // Informs that the token in the transient array index has already been checked.
+            checkedTokenIndexes[tokenIndex] = true;
+
+            amountsOut[i] = _currentSwapTokenOutAmounts().tGet(tokensOut[i]);
+
+            if (amountsOut[i] < params.minAmountsOut[i]) {
+                revert IVaultErrors.AmountOutBelowMin(IERC20(tokensOut[i]), amountsOut[i], params.minAmountsOut[i]);
+            }
+        }
+
+        if (isStaticCall == false) {
+            _settlePaths(params.sender, params.wethIsEth);
+        }
     }
 }

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -276,6 +276,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
             })
         );
 
+        // If there's leftover ETH, send it back to the sender. The router should not keep ETH.
         _returnEth(params.sender);
     }
 
@@ -306,14 +307,27 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
             })
         );
 
-        (tokensIn, amountsIn) = _wrapTokensExactOutIfRequired(
-            params.sender,
-            wrapUnderlying,
-            erc4626PoolTokens,
-            wrappedAmountsIn,
-            params.maxAmountsIn,
-            params.wethIsEth
-        );
+        RouterCallParams memory callParams = RouterCallParams({
+            sender: params.sender,
+            wethIsEth: params.wethIsEth,
+            isStaticCall: EVMCallModeHelpers.isStaticCall()
+        });
+
+        tokensIn = new address[](poolTokensLength);
+        amountsIn = new uint256[](poolTokensLength);
+
+        for (uint256 i = 0; i < poolTokensLength; ++i) {
+            (tokensIn[i], amountsIn[i]) = _processTokenInExactOut(
+                address(erc4626PoolTokens[i]),
+                wrappedAmountsIn[i],
+                wrapUnderlying[i],
+                params.maxAmountsIn[i],
+                callParams
+            );
+        }
+
+        // If there's leftover ETH, send it back to the sender. The router should not keep ETH.
+        _returnEth(params.sender);
     }
 
     function removeLiquidityERC4626PoolProportionalHook(
@@ -359,82 +373,6 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                 );
             }
         }
-    }
-
-    /// @dev Assumes array lengths have been checked externally.
-    function _wrapTokensExactOutIfRequired(
-        address sender,
-        bool[] memory wrapUnderlying,
-        IERC20[] memory erc4626PoolTokens,
-        uint256[] memory wrappedAmountsIn,
-        uint256[] memory maxAmountsIn,
-        bool wethIsEth
-    ) private returns (address[] memory tokensIn, uint256[] memory amountsIn) {
-        uint256 poolTokensLength = erc4626PoolTokens.length;
-        amountsIn = new uint256[](poolTokensLength);
-
-        bool isStaticCall = EVMCallModeHelpers.isStaticCall();
-
-        tokensIn = new address[](poolTokensLength);
-
-        for (uint256 i = 0; i < poolTokensLength; ++i) {
-            // Treat all ERC4626 pool tokens as wrapped. The next step will verify if we can use the wrappedToken as
-            // a valid ERC4626.
-            IERC4626 wrappedToken = IERC4626(address(erc4626PoolTokens[i]));
-            IERC20 underlyingToken = IERC20(_vault.getBufferAsset(wrappedToken));
-
-            // Check whether the caller wants to use the token as an ERC4626 (i.e., wrap/unwrap it), or just use it as
-            // a standard token.
-            if (wrapUnderlying[i]) {
-                if (address(underlyingToken) == address(0)) {
-                    revert IVaultErrors.BufferNotInitialized(wrappedToken);
-                }
-
-                uint256 underlyingAmount;
-                if (wrappedAmountsIn[i] > 0) {
-                    if (isStaticCall == false) {
-                        // The exact amount in is not known, because we have only
-                        // wrappedAmountsIn. Therefore, take the maxAmountsIn. After the wrap operation, the difference
-                        // between the maxAmountsIn and the actual underlying amount is returned to the sender.
-                        _takeTokenIn(sender, underlyingToken, maxAmountsIn[i], wethIsEth);
-                    }
-
-                    // `erc4626BufferWrapOrUnwrap` will fail if the wrappedToken isn't ERC4626-conforming.
-                    (, underlyingAmount, ) = _vault.erc4626BufferWrapOrUnwrap(
-                        BufferWrapOrUnwrapParams({
-                            kind: SwapKind.EXACT_OUT,
-                            direction: WrappingDirection.WRAP,
-                            wrappedToken: wrappedToken,
-                            amountGivenRaw: wrappedAmountsIn[i],
-                            limitRaw: maxAmountsIn[i]
-                        })
-                    );
-                }
-
-                if (isStaticCall == false) {
-                    // The maxAmountsIn of underlying tokens was taken from the user, so the
-                    // difference between maxAmountsIn and exact underlying amount needs to be returned to the sender.
-                    _sendTokenOut(sender, underlyingToken, maxAmountsIn[i] - underlyingAmount, wethIsEth);
-                }
-
-                amountsIn[i] = underlyingAmount;
-                tokensIn[i] = address(underlyingToken);
-            } else {
-                if (isStaticCall == false) {
-                    _takeTokenIn(sender, wrappedToken, wrappedAmountsIn[i], wethIsEth);
-                }
-
-                amountsIn[i] = wrappedAmountsIn[i];
-                tokensIn[i] = address(wrappedToken);
-            }
-
-            if (amountsIn[i] > maxAmountsIn[i]) {
-                revert IVaultErrors.AmountInAboveMax(IERC20(tokensIn[i]), amountsIn[i], maxAmountsIn[i]);
-            }
-        }
-
-        // If there's a leftover of eth, send it back to the sender. The router should not keep ETH.
-        _returnEth(sender);
     }
 
     /**
@@ -880,14 +818,14 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
      * @param amountIn The token amount (or max amount)
      * @param needToWrap Flag indicating whether this token is an ERC4626 to be wrapped
      * @param callParams Common parameters from the main router call
-     * @return processedAmount The final token amount (of the underlying token if wrapped)
+     * @return actualAmountIn The final token amount (of the underlying token if wrapped)
      */
     function _processTokenIn(
         address token,
         uint256 amountIn,
         bool needToWrap,
         RouterCallParams memory callParams
-    ) private returns (uint256 processedAmount) {
+    ) private returns (uint256 actualAmountIn) {
         if (needToWrap) {
             IERC4626 wrappedToken = IERC4626(token);
             IERC20 underlyingToken = IERC20(_vault.getBufferAsset(wrappedToken));
@@ -895,12 +833,12 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
             if (address(underlyingToken) == address(0)) {
                 revert IVaultErrors.BufferNotInitialized(wrappedToken);
             }
-            
+
             if (callParams.isStaticCall == false) {
                 _takeTokenIn(callParams.sender, underlyingToken, amountIn, callParams.wethIsEth);
             }
-            
-            (, , processedAmount) = _vault.erc4626BufferWrapOrUnwrap(
+
+            (, , actualAmountIn) = _vault.erc4626BufferWrapOrUnwrap(
                 BufferWrapOrUnwrapParams({
                     kind: SwapKind.EXACT_IN,
                     direction: WrappingDirection.WRAP,
@@ -910,11 +848,64 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                 })
             );
         } else {
-            processedAmount = amountIn;
+            actualAmountIn = amountIn;
 
             if (callParams.isStaticCall == false) {
                 _takeTokenIn(callParams.sender, IERC20(token), amountIn, callParams.wethIsEth);
             }
+        }
+    }
+
+    function _processTokenInExactOut(
+        address token,
+        uint256 amountIn,
+        bool needToWrap,
+        uint256 maxAmountIn,
+        RouterCallParams memory callParams
+    ) private returns (address tokenIn, uint256 actualAmountIn) {
+        if (needToWrap) {
+            IERC4626 wrappedToken = IERC4626(token);
+            IERC20 underlyingToken = IERC20(_vault.getBufferAsset(wrappedToken));
+
+            if (address(underlyingToken) == address(0)) {
+                revert IVaultErrors.BufferNotInitialized(wrappedToken);
+            }
+
+            if (amountIn > 0) {
+                if (callParams.isStaticCall == false) {
+                    _takeTokenIn(callParams.sender, underlyingToken, maxAmountIn, callParams.wethIsEth);
+                }
+
+                // `erc4626BufferWrapOrUnwrap` will fail if the wrappedToken isn't ERC4626-conforming.
+                (, actualAmountIn, ) = _vault.erc4626BufferWrapOrUnwrap(
+                    BufferWrapOrUnwrapParams({
+                        kind: SwapKind.EXACT_OUT,
+                        direction: WrappingDirection.WRAP,
+                        wrappedToken: wrappedToken,
+                        amountGivenRaw: amountIn,
+                        limitRaw: maxAmountIn
+                    })
+                );
+            }
+
+            if (callParams.isStaticCall == false) {
+                // The maxAmountsIn of underlying tokens was taken from the user, so the difference between
+                // `maxAmountsIn` and the exact underlying amount needs to be returned to the sender.
+                _sendTokenOut(callParams.sender, underlyingToken, maxAmountIn - actualAmountIn, callParams.wethIsEth);
+            }
+
+            tokenIn = address(underlyingToken);
+        } else {
+            if (callParams.isStaticCall == false) {
+                _takeTokenIn(callParams.sender, IERC20(token), amountIn, callParams.wethIsEth);
+            }
+
+            actualAmountIn = amountIn;
+            tokenIn = token;
+        }
+
+        if (actualAmountIn > maxAmountIn) {
+            revert IVaultErrors.AmountInAboveMax(IERC20(token), amountIn, maxAmountIn);
         }
     }
 
@@ -943,7 +934,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
             if (address(underlyingToken) == address(0)) {
                 revert IVaultErrors.BufferNotInitialized(wrappedToken);
             }
-            
+
             (, , actualAmountOut) = _vault.erc4626BufferWrapOrUnwrap(
                 BufferWrapOrUnwrapParams({
                     kind: SwapKind.EXACT_IN,
@@ -954,19 +945,19 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                 })
             );
             tokenOut = address(underlyingToken);
-            
+
             if (callParams.isStaticCall == false) {
                 _sendTokenOut(callParams.sender, underlyingToken, actualAmountOut, callParams.wethIsEth);
             }
         } else {
             actualAmountOut = amountOut;
             tokenOut = token;
-            
+
             if (callParams.isStaticCall == false) {
                 _sendTokenOut(callParams.sender, IERC20(token), actualAmountOut, callParams.wethIsEth);
             }
         }
-        
+
         if (actualAmountOut < minAmountOut) {
             revert IVaultErrors.AmountOutBelowMin(IERC20(tokenOut), actualAmountOut, minAmountOut);
         }

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -238,6 +238,8 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
         );
     }
 
+    // ERC4626 Pool Hooks
+
     function addLiquidityERC4626PoolUnbalancedHook(
         AddLiquidityHookParams calldata params,
         bool[] calldata wrapUnderlying
@@ -377,6 +379,8 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
         }
     }
 
+    // ERC4626 Pool helper functions
+
     function _validateHookParams(
         address pool,
         uint256 amountsLength,
@@ -389,8 +393,12 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
     }
 
     /**
-     * @notice Wraps the underlying tokens specified in the transient set `_currentSwapTokenInAmounts`, and updates
-     * this set with the resulting amount of wrapped tokens from the operation.
+     * @notice Wraps the underlying tokens specified in the transient set `_currentSwapTokenInAmounts`.
+     * @dev Then updates this set with the resulting amount of wrapped tokens from the operation.
+     * @param wrappedToken The token to wrap
+     * @param sender The address of the originator of the transaction
+     * @param wethIsEth Flag indicating whether the user using wrapping ETH
+     * @return wrappedAmountOut The amountOut of wrapped tokens
      */
     function _wrapAndUpdateTokenInAmounts(
         IERC4626 wrappedToken,
@@ -414,375 +422,6 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
         _currentSwapTokensIn().remove(underlyingToken);
         _currentSwapTokenInAmounts().tSet(underlyingToken, 0);
     }
-
-    /***************************************************************************
-                                   Nested pools
-    ***************************************************************************/
-
-    /// @inheritdoc ICompositeLiquidityRouter
-    function addLiquidityUnbalancedNestedPool(
-        address parentPool,
-        address[] memory tokensIn,
-        uint256[] memory exactAmountsIn,
-        uint256 minBptAmountOut,
-        bool wethIsEth,
-        bytes memory userData
-    ) external payable saveSender(msg.sender) returns (uint256) {
-        return
-            abi.decode(
-                _vault.unlock(
-                    abi.encodeCall(
-                        CompositeLiquidityRouter.addLiquidityUnbalancedNestedPoolHook,
-                        (
-                            AddLiquidityHookParams({
-                                pool: parentPool,
-                                sender: msg.sender,
-                                maxAmountsIn: exactAmountsIn,
-                                minBptAmountOut: minBptAmountOut,
-                                kind: AddLiquidityKind.UNBALANCED,
-                                wethIsEth: wethIsEth,
-                                userData: userData
-                            }),
-                            tokensIn
-                        )
-                    )
-                ),
-                (uint256)
-            );
-    }
-
-    /// @inheritdoc ICompositeLiquidityRouter
-    function queryAddLiquidityUnbalancedNestedPool(
-        address parentPool,
-        address[] memory tokensIn,
-        uint256[] memory exactAmountsIn,
-        address sender,
-        bytes memory userData
-    ) external saveSender(sender) returns (uint256) {
-        AddLiquidityHookParams memory params = _buildQueryAddLiquidityParams(
-            parentPool,
-            exactAmountsIn,
-            0,
-            AddLiquidityKind.UNBALANCED,
-            userData
-        );
-
-        return
-            abi.decode(
-                _vault.quote(
-                    abi.encodeCall(CompositeLiquidityRouter.addLiquidityUnbalancedNestedPoolHook, (params, tokensIn))
-                ),
-                (uint256)
-            );
-    }
-
-    function addLiquidityUnbalancedNestedPoolHook(
-        AddLiquidityHookParams calldata params,
-        address[] memory tokensIn
-    ) external nonReentrant onlyVault returns (uint256 exactBptAmountOut) {
-        // Revert if tokensIn length does not match with maxAmountsIn length.
-        InputHelpers.ensureInputLengthMatch(params.maxAmountsIn.length, tokensIn.length);
-
-        bool isStaticCall = EVMCallModeHelpers.isStaticCall();
-
-        // Loads a Set with all amounts to be inserted in the nested pools, so we don't need to iterate over the tokens
-        // array to find the child pool amounts to insert.
-        for (uint256 i = 0; i < tokensIn.length; ++i) {
-            if (params.maxAmountsIn[i] == 0) {
-                continue;
-            }
-
-            _currentSwapTokenInAmounts().tSet(tokensIn[i], params.maxAmountsIn[i]);
-            _currentSwapTokensIn().add(tokensIn[i]);
-        }
-
-        (uint256[] memory amountsIn, ) = _addLiquidity(params.pool, params);
-
-        // Adds liquidity to the parent pool, mints parentPool's BPT to the sender and checks the minimum BPT out.
-        (, exactBptAmountOut, ) = _vault.addLiquidity(
-            AddLiquidityParams({
-                pool: params.pool,
-                to: isStaticCall ? address(this) : params.sender,
-                maxAmountsIn: amountsIn,
-                minBptAmountOut: params.minBptAmountOut,
-                kind: params.kind,
-                userData: params.userData
-            })
-        );
-
-        // Settle the amounts in.
-        if (isStaticCall == false) {
-            _settlePaths(params.sender, params.wethIsEth);
-        }
-    }
-
-    function _addLiquidity(
-        address pool,
-        AddLiquidityHookParams calldata params
-    ) internal returns (uint256[] memory amountsIn, bool allAmountsEmpty) {
-        IERC20[] memory parentPoolTokens = _vault.getPoolTokens(pool);
-        amountsIn = new uint256[](parentPoolTokens.length);
-        allAmountsEmpty = true;
-
-        for (uint256 i = 0; i < parentPoolTokens.length; i++) {
-            address token = address(parentPoolTokens[i]);
-            CompositeTokenInfo memory tokenInfo = _computeCompositeTokenInfo(
-                token,
-                _currentSwapTokenInAmounts().tGet(token)
-            );
-
-            amountsIn[i] = _settledTokenAmounts().tGet(token) > 0
-                ? _settledTokenAmounts().tGet(token)
-                : _processNestedPoolToken(tokenInfo, params);
-
-            if (amountsIn[i] > 0) {
-                allAmountsEmpty = false;
-            }
-        }
-    }
-
-    function _processNestedPoolToken(
-        CompositeTokenInfo memory tokenInfo,
-        AddLiquidityHookParams calldata params
-    ) internal returns (uint256 amountOut) {
-        address token = tokenInfo.token;
-
-        if (tokenInfo.tokenType == CompositeTokenType.BPT) {
-            amountOut = _addLiquidityToChildPool(token, params);
-        } else if (tokenInfo.tokenType == CompositeTokenType.ERC4626 && tokenInfo.needToWrap) {
-            amountOut = _wrapAndUpdateTokenInAmounts(IERC4626(token), params.sender, params.wethIsEth);
-        } else {
-            amountOut = _currentSwapTokenInAmounts().tGet(token);
-        }
-
-        _settledTokenAmounts().tSet(token, amountOut);
-    }
-
-    function _addLiquidityToChildPool(
-        address childPool,
-        AddLiquidityHookParams calldata params
-    ) internal returns (uint256 childBptAmountOut) {
-        IERC20[] memory childPoolTokens = _vault.getPoolTokens(childPool);
-        uint256[] memory childPoolAmountsIn = new uint256[](childPoolTokens.length);
-        bool childPoolAmountsEmpty = true;
-
-        // Process tokens in the child pool (no further nesting allowed).
-        for (uint256 j = 0; j < childPoolTokens.length; j++) {
-            address childPoolToken = address(childPoolTokens[j]);
-
-            CompositeTokenInfo memory tokenInfo = _computeCompositeTokenInfo(
-                childPoolToken,
-                _currentSwapTokenInAmounts().tGet(childPoolToken)
-            );
-
-            if (tokenInfo.tokenType == CompositeTokenType.BPT) {
-                // This would be a second level of nesting, which is not supported. Process as a standard ERC20 token.
-                if (_settledTokenAmounts().tGet(childPoolToken) == 0) {
-                    childPoolAmountsIn[j] = tokenInfo.amount;
-                    _settledTokenAmounts().tSet(childPoolToken, tokenInfo.amount);
-                }
-            } else if (
-                // wrapped amount in was not specified
-                tokenInfo.tokenType == CompositeTokenType.ERC4626 && tokenInfo.amount == 0
-            ) {
-                // Handle ERC4626 token wrapping at child pool level.
-                childPoolAmountsIn[j] = _wrapAndUpdateTokenInAmounts(
-                    IERC4626(childPoolToken),
-                    params.sender,
-                    params.wethIsEth
-                );
-            } else if (_settledTokenAmounts().tGet(childPoolToken) == 0) {
-                // Set this token's amountIn if it's a standard token that was not previously settled.
-                childPoolAmountsIn[j] = tokenInfo.amount;
-                _settledTokenAmounts().tSet(childPoolToken, tokenInfo.amount);
-            }
-
-            if (childPoolAmountsIn[j] > 0) {
-                childPoolAmountsEmpty = false;
-            }
-        }
-
-        if (childPoolAmountsEmpty == false) {
-            // Add Liquidity will mint childTokens to the Vault, so the insertion of liquidity in the parent
-            // pool will be an accounting adjustment, not a token transfer.
-            (, uint256 exactChildBptAmountOut, ) = _vault.addLiquidity(
-                AddLiquidityParams({
-                    pool: childPool,
-                    to: address(_vault),
-                    maxAmountsIn: childPoolAmountsIn,
-                    minBptAmountOut: 0,
-                    kind: params.kind,
-                    userData: params.userData
-                })
-            );
-
-            childBptAmountOut = exactChildBptAmountOut;
-
-            // Since the BPT will be add to the parent pool, get the credit from the inserted BPT in advance.
-            _vault.settle(IERC20(childPool), exactChildBptAmountOut);
-        }
-
-        return childBptAmountOut;
-    }
-
-    /// @inheritdoc ICompositeLiquidityRouter
-    function removeLiquidityProportionalNestedPool(
-        address parentPool,
-        uint256 exactBptAmountIn,
-        address[] memory tokensOut,
-        uint256[] memory minAmountsOut,
-        bool wethIsEth,
-        bytes memory userData
-    ) external payable saveSender(msg.sender) returns (uint256[] memory amountsOut) {
-        (amountsOut) = abi.decode(
-            _vault.unlock(
-                abi.encodeCall(
-                    CompositeLiquidityRouter.removeLiquidityProportionalNestedPoolHook,
-                    (
-                        RemoveLiquidityHookParams({
-                            sender: msg.sender,
-                            pool: parentPool,
-                            minAmountsOut: minAmountsOut,
-                            maxBptAmountIn: exactBptAmountIn,
-                            kind: RemoveLiquidityKind.PROPORTIONAL,
-                            wethIsEth: wethIsEth,
-                            userData: userData
-                        }),
-                        tokensOut
-                    )
-                )
-            ),
-            (uint256[])
-        );
-    }
-
-    /// @inheritdoc ICompositeLiquidityRouter
-    function queryRemoveLiquidityProportionalNestedPool(
-        address parentPool,
-        uint256 exactBptAmountIn,
-        address[] memory tokensOut,
-        address sender,
-        bytes memory userData
-    ) external saveSender(sender) returns (uint256[] memory amountsOut) {
-        RemoveLiquidityHookParams memory params = _buildQueryRemoveLiquidityParams(
-            parentPool,
-            exactBptAmountIn,
-            new uint256[](tokensOut.length),
-            RemoveLiquidityKind.PROPORTIONAL,
-            userData
-        );
-
-        (amountsOut) = abi.decode(
-            _vault.quote(
-                abi.encodeCall(CompositeLiquidityRouter.removeLiquidityProportionalNestedPoolHook, (params, tokensOut))
-            ),
-            (uint256[])
-        );
-    }
-
-    function removeLiquidityProportionalNestedPoolHook(
-        RemoveLiquidityHookParams calldata params,
-        address[] memory tokensOut
-    ) external nonReentrant onlyVault returns (uint256[] memory amountsOut) {
-        IERC20[] memory parentPoolTokens = _vault.getPoolTokens(params.pool);
-
-        bool isStaticCall = EVMCallModeHelpers.isStaticCall();
-
-        // Revert if tokensOut length does not match with minAmountsOut length.
-        InputHelpers.ensureInputLengthMatch(params.minAmountsOut.length, tokensOut.length);
-
-        (, uint256[] memory parentPoolAmountsOut, ) = _vault.removeLiquidity(
-            RemoveLiquidityParams({
-                pool: params.pool,
-                from: params.sender,
-                maxBptAmountIn: params.maxBptAmountIn,
-                minAmountsOut: new uint256[](parentPoolTokens.length),
-                kind: params.kind,
-                userData: params.userData
-            })
-        );
-
-        for (uint256 i = 0; i < parentPoolTokens.length; i++) {
-            address childToken = address(parentPoolTokens[i]);
-            uint256 parentPoolAmountOut = parentPoolAmountsOut[i];
-
-            if (_vault.isPoolRegistered(childToken)) {
-                // Token is a BPT, so remove liquidity from the child pool.
-
-                // We don't expect the sender to have BPT to burn. So, we flashloan tokens here (which should in
-                // practice just use existing credit).
-                _vault.sendTo(IERC20(childToken), address(this), parentPoolAmountsOut[i]);
-
-                IERC20[] memory childPoolTokens = _vault.getPoolTokens(childToken);
-                // Router is an intermediary in this case. The Vault will burn tokens from the Router, so Router is
-                // both owner and spender (which doesn't need approval).
-                (, uint256[] memory childPoolAmountsOut, ) = _vault.removeLiquidity(
-                    RemoveLiquidityParams({
-                        pool: childToken,
-                        from: address(this),
-                        maxBptAmountIn: parentPoolAmountOut,
-                        minAmountsOut: new uint256[](childPoolTokens.length),
-                        kind: params.kind,
-                        userData: params.userData
-                    })
-                );
-                // Return amounts to user.
-                for (uint256 j = 0; j < childPoolTokens.length; j++) {
-                    address childPoolToken = address(childPoolTokens[j]);
-                    uint256 childPoolAmountOut = childPoolAmountsOut[j];
-
-                    if (_vault.isERC4626BufferInitialized(IERC4626(childPoolToken))) {
-                        // Token is an ERC4626 wrapper, so unwrap it and return the underlying.
-                        _executeUnwrapOperation(IERC4626(childPoolToken), childPoolAmountOut);
-                    } else {
-                        _currentSwapTokensOut().add(childPoolToken);
-                        _currentSwapTokenOutAmounts().tAdd(childPoolToken, childPoolAmountOut);
-                    }
-                }
-            } else if (_vault.isERC4626BufferInitialized(IERC4626(childToken))) {
-                // Token is an ERC4626 wrapper, so unwrap it and return the underlying.
-                _executeUnwrapOperation(IERC4626(childToken), parentPoolAmountOut);
-            } else {
-                // Token is neither a BPT nor ERC4626, so return the amount to the user.
-                _currentSwapTokensOut().add(childToken);
-                _currentSwapTokenOutAmounts().tAdd(childToken, parentPoolAmountOut);
-            }
-        }
-
-        if (_currentSwapTokensOut().length() != tokensOut.length) {
-            // If tokensOut length does not match with transient tokens out length, the tokensOut array is wrong.
-            revert WrongTokensOut(_currentSwapTokensOut().values(), tokensOut);
-        }
-
-        // The hook writes current swap token and token amounts out.
-        amountsOut = new uint256[](tokensOut.length);
-        // If a certain token index was already iterated on, reverts.
-        bool[] memory checkedTokenIndexes = new bool[](tokensOut.length);
-        for (uint256 i = 0; i < tokensOut.length; ++i) {
-            uint256 tokenIndex = _currentSwapTokensOut().indexOf(tokensOut[i]);
-            address tokenOut = tokensOut[i];
-
-            if (_currentSwapTokensOut().contains(tokenOut) == false || checkedTokenIndexes[tokenIndex]) {
-                // If tokenOut is not in transient tokens out array or token is repeated, the tokensOut array is wrong.
-                revert WrongTokensOut(_currentSwapTokensOut().values(), tokensOut);
-            }
-
-            // Informs that the token in the transient array index has already been checked.
-            checkedTokenIndexes[tokenIndex] = true;
-
-            amountsOut[i] = _currentSwapTokenOutAmounts().tGet(tokenOut);
-
-            if (amountsOut[i] < params.minAmountsOut[i]) {
-                revert IVaultErrors.AmountOutBelowMin(IERC20(tokenOut), amountsOut[i], params.minAmountsOut[i]);
-            }
-        }
-
-        if (isStaticCall == false) {
-            _settlePaths(params.sender, params.wethIsEth);
-        }
-    }
-
-    // Helper functions
 
     /**
      * @notice Processes a single token for input during add liquidity operations.
@@ -924,71 +563,6 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
         }
     }
 
-    // Construct common parameters for add liquidity operations.
-    function _buildQueryAddLiquidityParams(
-        address pool,
-        uint256[] memory maxAmountsOrExactOut,
-        uint256 minBptOrExactBpt,
-        AddLiquidityKind kind,
-        bytes memory userData
-    ) private view returns (AddLiquidityHookParams memory) {
-        return
-            AddLiquidityHookParams({
-                sender: address(this), // Always use router address for queries
-                pool: pool,
-                maxAmountsIn: kind == AddLiquidityKind.PROPORTIONAL ? _maxTokenLimits(pool) : maxAmountsOrExactOut,
-                minBptAmountOut: kind == AddLiquidityKind.PROPORTIONAL ? minBptOrExactBpt : 0,
-                kind: kind,
-                wethIsEth: false, // Always false for queries
-                userData: userData
-            });
-    }
-
-    // Construct common parameters for remove liquidity operations.
-    function _buildQueryRemoveLiquidityParams(
-        address pool,
-        uint256 exactBptAmountIn,
-        uint256[] memory minAmountsOut,
-        RemoveLiquidityKind kind,
-        bytes memory userData
-    ) private view returns (RemoveLiquidityHookParams memory) {
-        return
-            RemoveLiquidityHookParams({
-                sender: address(this), // Always use router address for queries
-                pool: pool,
-                minAmountsOut: minAmountsOut,
-                maxBptAmountIn: exactBptAmountIn,
-                kind: kind,
-                wethIsEth: false, // Always false for queries
-                userData: userData
-            });
-    }
-
-    // Helper for add liquidity functions; determine the token type to direct execution.
-    function _computeCompositeTokenInfo(
-        address token,
-        uint256 amount
-    ) private view returns (CompositeTokenInfo memory info) {
-        info.token = token;
-        info.amount = amount;
-        info.tokenType = _getCompositeTokenType(token);
-
-        if (info.tokenType == CompositeTokenType.ERC4626) {
-            info.needToWrap = (amount == 0 &&
-                _currentSwapTokenInAmounts().tGet(_vault.getBufferAsset(IERC4626(token))) > 0);
-        }
-    }
-
-    function _getCompositeTokenType(address token) internal view returns (CompositeTokenType tokenType) {
-        if (_vault.isPoolRegistered(token)) {
-            tokenType = CompositeTokenType.BPT;
-        } else if (_vault.isERC4626BufferInitialized(IERC4626(token))) {
-            tokenType = CompositeTokenType.ERC4626;
-        } else {
-            tokenType = CompositeTokenType.ERC20;
-        }
-    }
-
     /**
      * @notice Centralized handler for ERC4626 wrapping operations.
      * @param wrappedToken The ERC4626 token to wrap into
@@ -1050,5 +624,442 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
         address underlyingToken = _vault.getERC4626BufferAsset(wrappedToken);
         _currentSwapTokensOut().add(underlyingToken);
         _currentSwapTokenOutAmounts().tAdd(underlyingToken, underlyingAmount);
+    }
+
+    /***************************************************************************
+                                   Nested pools
+    ***************************************************************************/
+
+    /// @inheritdoc ICompositeLiquidityRouter
+    function addLiquidityUnbalancedNestedPool(
+        address parentPool,
+        address[] memory tokensIn,
+        uint256[] memory exactAmountsIn,
+        uint256 minBptAmountOut,
+        bool wethIsEth,
+        bytes memory userData
+    ) external payable saveSender(msg.sender) returns (uint256) {
+        return
+            abi.decode(
+                _vault.unlock(
+                    abi.encodeCall(
+                        CompositeLiquidityRouter.addLiquidityUnbalancedNestedPoolHook,
+                        (
+                            AddLiquidityHookParams({
+                                pool: parentPool,
+                                sender: msg.sender,
+                                maxAmountsIn: exactAmountsIn,
+                                minBptAmountOut: minBptAmountOut,
+                                kind: AddLiquidityKind.UNBALANCED,
+                                wethIsEth: wethIsEth,
+                                userData: userData
+                            }),
+                            tokensIn
+                        )
+                    )
+                ),
+                (uint256)
+            );
+    }
+
+    /// @inheritdoc ICompositeLiquidityRouter
+    function queryAddLiquidityUnbalancedNestedPool(
+        address parentPool,
+        address[] memory tokensIn,
+        uint256[] memory exactAmountsIn,
+        address sender,
+        bytes memory userData
+    ) external saveSender(sender) returns (uint256) {
+        AddLiquidityHookParams memory params = _buildQueryAddLiquidityParams(
+            parentPool,
+            exactAmountsIn,
+            0,
+            AddLiquidityKind.UNBALANCED,
+            userData
+        );
+
+        return
+            abi.decode(
+                _vault.quote(
+                    abi.encodeCall(CompositeLiquidityRouter.addLiquidityUnbalancedNestedPoolHook, (params, tokensIn))
+                ),
+                (uint256)
+            );
+    }
+
+    /// @inheritdoc ICompositeLiquidityRouter
+    function removeLiquidityProportionalNestedPool(
+        address parentPool,
+        uint256 exactBptAmountIn,
+        address[] memory tokensOut,
+        uint256[] memory minAmountsOut,
+        bool wethIsEth,
+        bytes memory userData
+    ) external payable saveSender(msg.sender) returns (uint256[] memory amountsOut) {
+        (amountsOut) = abi.decode(
+            _vault.unlock(
+                abi.encodeCall(
+                    CompositeLiquidityRouter.removeLiquidityProportionalNestedPoolHook,
+                    (
+                        RemoveLiquidityHookParams({
+                            sender: msg.sender,
+                            pool: parentPool,
+                            minAmountsOut: minAmountsOut,
+                            maxBptAmountIn: exactBptAmountIn,
+                            kind: RemoveLiquidityKind.PROPORTIONAL,
+                            wethIsEth: wethIsEth,
+                            userData: userData
+                        }),
+                        tokensOut
+                    )
+                )
+            ),
+            (uint256[])
+        );
+    }
+
+    /// @inheritdoc ICompositeLiquidityRouter
+    function queryRemoveLiquidityProportionalNestedPool(
+        address parentPool,
+        uint256 exactBptAmountIn,
+        address[] memory tokensOut,
+        address sender,
+        bytes memory userData
+    ) external saveSender(sender) returns (uint256[] memory amountsOut) {
+        RemoveLiquidityHookParams memory params = _buildQueryRemoveLiquidityParams(
+            parentPool,
+            exactBptAmountIn,
+            new uint256[](tokensOut.length),
+            RemoveLiquidityKind.PROPORTIONAL,
+            userData
+        );
+
+        (amountsOut) = abi.decode(
+            _vault.quote(
+                abi.encodeCall(CompositeLiquidityRouter.removeLiquidityProportionalNestedPoolHook, (params, tokensOut))
+            ),
+            (uint256[])
+        );
+    }
+
+    // Nested Pool Hooks
+
+    function removeLiquidityProportionalNestedPoolHook(
+        RemoveLiquidityHookParams calldata params,
+        address[] memory tokensOut
+    ) external nonReentrant onlyVault returns (uint256[] memory amountsOut) {
+        IERC20[] memory parentPoolTokens = _vault.getPoolTokens(params.pool);
+
+        bool isStaticCall = EVMCallModeHelpers.isStaticCall();
+
+        // Revert if tokensOut length does not match with minAmountsOut length.
+        InputHelpers.ensureInputLengthMatch(params.minAmountsOut.length, tokensOut.length);
+
+        (, uint256[] memory parentPoolAmountsOut, ) = _vault.removeLiquidity(
+            RemoveLiquidityParams({
+                pool: params.pool,
+                from: params.sender,
+                maxBptAmountIn: params.maxBptAmountIn,
+                minAmountsOut: new uint256[](parentPoolTokens.length),
+                kind: params.kind,
+                userData: params.userData
+            })
+        );
+
+        for (uint256 i = 0; i < parentPoolTokens.length; i++) {
+            address childToken = address(parentPoolTokens[i]);
+            uint256 parentPoolAmountOut = parentPoolAmountsOut[i];
+
+            if (_vault.isPoolRegistered(childToken)) {
+                // Token is a BPT, so remove liquidity from the child pool.
+
+                // We don't expect the sender to have BPT to burn. So, we flashloan tokens here (which should in
+                // practice just use existing credit).
+                _vault.sendTo(IERC20(childToken), address(this), parentPoolAmountsOut[i]);
+
+                IERC20[] memory childPoolTokens = _vault.getPoolTokens(childToken);
+                // Router is an intermediary in this case. The Vault will burn tokens from the Router, so Router is
+                // both owner and spender (which doesn't need approval).
+                (, uint256[] memory childPoolAmountsOut, ) = _vault.removeLiquidity(
+                    RemoveLiquidityParams({
+                        pool: childToken,
+                        from: address(this),
+                        maxBptAmountIn: parentPoolAmountOut,
+                        minAmountsOut: new uint256[](childPoolTokens.length),
+                        kind: params.kind,
+                        userData: params.userData
+                    })
+                );
+                // Return amounts to user.
+                for (uint256 j = 0; j < childPoolTokens.length; j++) {
+                    address childPoolToken = address(childPoolTokens[j]);
+                    uint256 childPoolAmountOut = childPoolAmountsOut[j];
+
+                    if (_vault.isERC4626BufferInitialized(IERC4626(childPoolToken))) {
+                        // Token is an ERC4626 wrapper, so unwrap it and return the underlying.
+                        _executeUnwrapOperation(IERC4626(childPoolToken), childPoolAmountOut);
+                    } else {
+                        _currentSwapTokensOut().add(childPoolToken);
+                        _currentSwapTokenOutAmounts().tAdd(childPoolToken, childPoolAmountOut);
+                    }
+                }
+            } else if (_vault.isERC4626BufferInitialized(IERC4626(childToken))) {
+                // Token is an ERC4626 wrapper, so unwrap it and return the underlying.
+                _executeUnwrapOperation(IERC4626(childToken), parentPoolAmountOut);
+            } else {
+                // Token is neither a BPT nor ERC4626, so return the amount to the user.
+                _currentSwapTokensOut().add(childToken);
+                _currentSwapTokenOutAmounts().tAdd(childToken, parentPoolAmountOut);
+            }
+        }
+
+        if (_currentSwapTokensOut().length() != tokensOut.length) {
+            // If tokensOut length does not match with transient tokens out length, the tokensOut array is wrong.
+            revert WrongTokensOut(_currentSwapTokensOut().values(), tokensOut);
+        }
+
+        // The hook writes current swap token and token amounts out.
+        amountsOut = new uint256[](tokensOut.length);
+        // If a certain token index was already iterated on, reverts.
+        bool[] memory checkedTokenIndexes = new bool[](tokensOut.length);
+        for (uint256 i = 0; i < tokensOut.length; ++i) {
+            uint256 tokenIndex = _currentSwapTokensOut().indexOf(tokensOut[i]);
+            address tokenOut = tokensOut[i];
+
+            if (_currentSwapTokensOut().contains(tokenOut) == false || checkedTokenIndexes[tokenIndex]) {
+                // If tokenOut is not in transient tokens out array or token is repeated, the tokensOut array is wrong.
+                revert WrongTokensOut(_currentSwapTokensOut().values(), tokensOut);
+            }
+
+            // Informs that the token in the transient array index has already been checked.
+            checkedTokenIndexes[tokenIndex] = true;
+
+            amountsOut[i] = _currentSwapTokenOutAmounts().tGet(tokenOut);
+
+            if (amountsOut[i] < params.minAmountsOut[i]) {
+                revert IVaultErrors.AmountOutBelowMin(IERC20(tokenOut), amountsOut[i], params.minAmountsOut[i]);
+            }
+        }
+
+        if (isStaticCall == false) {
+            _settlePaths(params.sender, params.wethIsEth);
+        }
+    }
+
+    function addLiquidityUnbalancedNestedPoolHook(
+        AddLiquidityHookParams calldata params,
+        address[] memory tokensIn
+    ) external nonReentrant onlyVault returns (uint256 exactBptAmountOut) {
+        // Revert if tokensIn length does not match with maxAmountsIn length.
+        InputHelpers.ensureInputLengthMatch(params.maxAmountsIn.length, tokensIn.length);
+
+        bool isStaticCall = EVMCallModeHelpers.isStaticCall();
+
+        // Loads a Set with all amounts to be inserted in the nested pools, so we don't need to iterate over the tokens
+        // array to find the child pool amounts to insert.
+        for (uint256 i = 0; i < tokensIn.length; ++i) {
+            if (params.maxAmountsIn[i] == 0) {
+                continue;
+            }
+
+            _currentSwapTokenInAmounts().tSet(tokensIn[i], params.maxAmountsIn[i]);
+            _currentSwapTokensIn().add(tokensIn[i]);
+        }
+
+        (uint256[] memory amountsIn, ) = _addLiquidity(params.pool, params);
+
+        // Adds liquidity to the parent pool, mints parentPool's BPT to the sender and checks the minimum BPT out.
+        (, exactBptAmountOut, ) = _vault.addLiquidity(
+            AddLiquidityParams({
+                pool: params.pool,
+                to: isStaticCall ? address(this) : params.sender,
+                maxAmountsIn: amountsIn,
+                minBptAmountOut: params.minBptAmountOut,
+                kind: params.kind,
+                userData: params.userData
+            })
+        );
+
+        // Settle the amounts in.
+        if (isStaticCall == false) {
+            _settlePaths(params.sender, params.wethIsEth);
+        }
+    }
+
+    // Nested Pool helper functions
+
+    function _addLiquidity(
+        address pool,
+        AddLiquidityHookParams calldata params
+    ) internal returns (uint256[] memory amountsIn, bool allAmountsEmpty) {
+        IERC20[] memory parentPoolTokens = _vault.getPoolTokens(pool);
+        amountsIn = new uint256[](parentPoolTokens.length);
+        allAmountsEmpty = true;
+
+        for (uint256 i = 0; i < parentPoolTokens.length; i++) {
+            address token = address(parentPoolTokens[i]);
+            CompositeTokenInfo memory tokenInfo = _computeCompositeTokenInfo(
+                token,
+                _currentSwapTokenInAmounts().tGet(token)
+            );
+
+            amountsIn[i] = _settledTokenAmounts().tGet(token) > 0
+                ? _settledTokenAmounts().tGet(token)
+                : _processNestedPoolToken(tokenInfo, params);
+
+            if (amountsIn[i] > 0) {
+                allAmountsEmpty = false;
+            }
+        }
+    }
+
+    function _processNestedPoolToken(
+        CompositeTokenInfo memory tokenInfo,
+        AddLiquidityHookParams calldata params
+    ) internal returns (uint256 amountOut) {
+        address token = tokenInfo.token;
+
+        if (tokenInfo.tokenType == CompositeTokenType.BPT) {
+            amountOut = _addLiquidityToChildPool(token, params);
+        } else if (tokenInfo.tokenType == CompositeTokenType.ERC4626 && tokenInfo.needToWrap) {
+            amountOut = _wrapAndUpdateTokenInAmounts(IERC4626(token), params.sender, params.wethIsEth);
+        } else {
+            amountOut = _currentSwapTokenInAmounts().tGet(token);
+        }
+
+        _settledTokenAmounts().tSet(token, amountOut);
+    }
+
+    function _addLiquidityToChildPool(
+        address childPool,
+        AddLiquidityHookParams calldata params
+    ) internal returns (uint256 childBptAmountOut) {
+        IERC20[] memory childPoolTokens = _vault.getPoolTokens(childPool);
+        uint256[] memory childPoolAmountsIn = new uint256[](childPoolTokens.length);
+        bool childPoolAmountsEmpty = true;
+
+        // Process tokens in the child pool (no further nesting allowed).
+        for (uint256 j = 0; j < childPoolTokens.length; j++) {
+            address childPoolToken = address(childPoolTokens[j]);
+
+            CompositeTokenInfo memory tokenInfo = _computeCompositeTokenInfo(
+                childPoolToken,
+                _currentSwapTokenInAmounts().tGet(childPoolToken)
+            );
+
+            if (tokenInfo.tokenType == CompositeTokenType.BPT) {
+                // This would be a second level of nesting, which is not supported. Process as a standard ERC20 token.
+                if (_settledTokenAmounts().tGet(childPoolToken) == 0) {
+                    childPoolAmountsIn[j] = tokenInfo.amount;
+                    _settledTokenAmounts().tSet(childPoolToken, tokenInfo.amount);
+                }
+            } else if (
+                // wrapped amount in was not specified
+                tokenInfo.tokenType == CompositeTokenType.ERC4626 && tokenInfo.amount == 0
+            ) {
+                // Handle ERC4626 token wrapping at child pool level.
+                childPoolAmountsIn[j] = _wrapAndUpdateTokenInAmounts(
+                    IERC4626(childPoolToken),
+                    params.sender,
+                    params.wethIsEth
+                );
+            } else if (_settledTokenAmounts().tGet(childPoolToken) == 0) {
+                // Set this token's amountIn if it's a standard token that was not previously settled.
+                childPoolAmountsIn[j] = tokenInfo.amount;
+                _settledTokenAmounts().tSet(childPoolToken, tokenInfo.amount);
+            }
+
+            if (childPoolAmountsIn[j] > 0) {
+                childPoolAmountsEmpty = false;
+            }
+        }
+
+        if (childPoolAmountsEmpty == false) {
+            // Add Liquidity will mint childTokens to the Vault, so the insertion of liquidity in the parent
+            // pool will be an accounting adjustment, not a token transfer.
+            (, uint256 exactChildBptAmountOut, ) = _vault.addLiquidity(
+                AddLiquidityParams({
+                    pool: childPool,
+                    to: address(_vault),
+                    maxAmountsIn: childPoolAmountsIn,
+                    minBptAmountOut: 0,
+                    kind: params.kind,
+                    userData: params.userData
+                })
+            );
+
+            childBptAmountOut = exactChildBptAmountOut;
+
+            // Since the BPT will be add to the parent pool, get the credit from the inserted BPT in advance.
+            _vault.settle(IERC20(childPool), exactChildBptAmountOut);
+        }
+
+        return childBptAmountOut;
+    }
+
+    // Determine the token type to direct execution.
+    function _computeCompositeTokenInfo(
+        address token,
+        uint256 amount
+    ) private view returns (CompositeTokenInfo memory info) {
+        info.token = token;
+        info.amount = amount;
+        info.tokenType = _getCompositeTokenType(token);
+
+        if (info.tokenType == CompositeTokenType.ERC4626) {
+            info.needToWrap = (amount == 0 &&
+                _currentSwapTokenInAmounts().tGet(_vault.getBufferAsset(IERC4626(token))) > 0);
+        }
+    }
+
+    function _getCompositeTokenType(address token) internal view returns (CompositeTokenType tokenType) {
+        if (_vault.isPoolRegistered(token)) {
+            tokenType = CompositeTokenType.BPT;
+        } else if (_vault.isERC4626BufferInitialized(IERC4626(token))) {
+            tokenType = CompositeTokenType.ERC4626;
+        } else {
+            tokenType = CompositeTokenType.ERC20;
+        }
+    }
+
+    // Common helper functions
+
+    function _buildQueryAddLiquidityParams(
+        address pool,
+        uint256[] memory maxAmountsOrExactOut,
+        uint256 minBptOrExactBpt,
+        AddLiquidityKind kind,
+        bytes memory userData
+    ) private view returns (AddLiquidityHookParams memory) {
+        return
+            AddLiquidityHookParams({
+                sender: address(this), // Always use router address for queries
+                pool: pool,
+                maxAmountsIn: kind == AddLiquidityKind.PROPORTIONAL ? _maxTokenLimits(pool) : maxAmountsOrExactOut,
+                minBptAmountOut: kind == AddLiquidityKind.PROPORTIONAL ? minBptOrExactBpt : 0,
+                kind: kind,
+                wethIsEth: false, // Always false for queries
+                userData: userData
+            });
+    }
+
+    // Construct common parameters for remove liquidity operations.
+    function _buildQueryRemoveLiquidityParams(
+        address pool,
+        uint256 exactBptAmountIn,
+        uint256[] memory minAmountsOut,
+        RemoveLiquidityKind kind,
+        bytes memory userData
+    ) private view returns (RemoveLiquidityHookParams memory) {
+        return
+            RemoveLiquidityHookParams({
+                sender: address(this), // Always use router address for queries
+                pool: pool,
+                minAmountsOut: minAmountsOut,
+                maxBptAmountIn: exactBptAmountIn,
+                kind: kind,
+                wethIsEth: false, // Always false for queries
+                userData: userData
+            });
     }
 }

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -222,8 +222,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
         RemoveLiquidityHookParams memory params = _buildQueryRemoveLiquidityParams(
             pool,
             exactBptAmountIn,
-            new uint256[](erc4626PoolTokens.length),
-            RemoveLiquidityKind.PROPORTIONAL,
+            erc4626PoolTokens.length,
             userData
         );
 
@@ -729,8 +728,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
         RemoveLiquidityHookParams memory params = _buildQueryRemoveLiquidityParams(
             parentPool,
             exactBptAmountIn,
-            new uint256[](tokensOut.length),
-            RemoveLiquidityKind.PROPORTIONAL,
+            tokensOut.length,
             userData
         );
 
@@ -1047,17 +1045,16 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
     function _buildQueryRemoveLiquidityParams(
         address pool,
         uint256 exactBptAmountIn,
-        uint256[] memory minAmountsOut,
-        RemoveLiquidityKind kind,
+        uint256 numTokens,
         bytes memory userData
     ) private view returns (RemoveLiquidityHookParams memory) {
         return
             RemoveLiquidityHookParams({
                 sender: address(this), // Always use router address for queries
                 pool: pool,
-                minAmountsOut: minAmountsOut,
+                minAmountsOut: new uint256[](numTokens),
                 maxBptAmountIn: exactBptAmountIn,
-                kind: kind,
+                kind: RemoveLiquidityKind.PROPORTIONAL, // Always proportional for supported use cases
                 wethIsEth: false, // Always false for queries
                 userData: userData
             });

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -32,6 +32,13 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
     using TransientEnumerableSet for TransientEnumerableSet.AddressSet;
     using TransientStorageHelpers for *;
 
+    // Factor out common parameters used in internal functions.
+    struct RouterCallParams {
+        address sender;
+        bool wethIsEth;
+        bool isStaticCall;
+    }
+
     constructor(
         IVault vault,
         IWETH weth,
@@ -239,13 +246,23 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
         // Revert if `poolTokens` length does not match `maxAmountsIn` and `wrapUnderlying`.
         InputHelpers.ensureInputLengthMatch(poolTokensLength, params.maxAmountsIn.length, wrapUnderlying.length);
 
-        uint256[] memory amountsIn = _wrapTokensExactInIfRequired(
-            params.sender,
-            wrapUnderlying,
-            erc4626PoolTokens,
-            params.maxAmountsIn,
-            params.wethIsEth
-        );
+        RouterCallParams memory callParams = RouterCallParams({
+            sender: params.sender,
+            wethIsEth: params.wethIsEth,
+            isStaticCall: EVMCallModeHelpers.isStaticCall()
+        });
+
+        uint256[] memory amountsIn = new uint256[](poolTokensLength);
+        for (uint256 i = 0; i < poolTokensLength; ++i) {
+            if (params.maxAmountsIn[i] > 0) {
+                amountsIn[i] = _processTokenIn(
+                    address(erc4626PoolTokens[i]),
+                    params.maxAmountsIn[i],
+                    wrapUnderlying[i],
+                    callParams
+                );
+            }
+        }
 
         // Add wrapped amounts to the ERC4626 pool.
         (, bptAmountOut, ) = _vault.addLiquidity(
@@ -258,6 +275,8 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
                 userData: params.userData
             })
         );
+
+        _returnEth(params.sender);
     }
 
     function addLiquidityERC4626PoolProportionalHook(
@@ -307,8 +326,6 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
         // Revert if `poolTokens` length does not match `minAmountsOut` and `unwrapWrapped`.
         InputHelpers.ensureInputLengthMatch(poolTokensLength, params.minAmountsOut.length, unwrapWrapped.length);
 
-        amountsOut = new uint256[](poolTokensLength);
-
         (, uint256[] memory wrappedAmountsOut, ) = _vault.removeLiquidity(
             RemoveLiquidityParams({
                 pool: params.pool,
@@ -320,105 +337,28 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
             })
         );
 
-        bool isStaticCall = EVMCallModeHelpers.isStaticCall();
+        RouterCallParams memory callParams = RouterCallParams({
+            sender: params.sender,
+            wethIsEth: params.wethIsEth,
+            isStaticCall: EVMCallModeHelpers.isStaticCall()
+        });
 
         tokensOut = new address[](poolTokensLength);
+        amountsOut = new uint256[](poolTokensLength);
+
         for (uint256 i = 0; i < poolTokensLength; ++i) {
-            IERC4626 wrappedToken = IERC4626(address(erc4626PoolTokens[i]));
-            IERC20 underlyingToken = IERC20(_vault.getBufferAsset(wrappedToken));
-
-            if (unwrapWrapped[i]) {
-                if (address(underlyingToken) == address(0)) {
-                    revert IVaultErrors.BufferNotInitialized(wrappedToken);
-                }
-
-                // `erc4626BufferWrapOrUnwrap` will fail if the wrappedToken is not ERC4626-conforming.
-                (, , amountsOut[i]) = _vault.erc4626BufferWrapOrUnwrap(
-                    BufferWrapOrUnwrapParams({
-                        kind: SwapKind.EXACT_IN,
-                        direction: WrappingDirection.UNWRAP,
-                        wrappedToken: wrappedToken,
-                        amountGivenRaw: wrappedAmountsOut[i],
-                        limitRaw: params.minAmountsOut[i]
-                    })
+            if (wrappedAmountsOut[i] == 0) {
+                tokensOut[i] = address(erc4626PoolTokens[i]);
+            } else {
+                (tokensOut[i], amountsOut[i]) = _processTokenOut(
+                    address(erc4626PoolTokens[i]),
+                    wrappedAmountsOut[i],
+                    unwrapWrapped[i],
+                    params.minAmountsOut[i],
+                    callParams
                 );
-                tokensOut[i] = address(underlyingToken);
-
-                if (isStaticCall == false) {
-                    _sendTokenOut(params.sender, underlyingToken, amountsOut[i], params.wethIsEth);
-                }
-            } else {
-                amountsOut[i] = wrappedAmountsOut[i];
-                tokensOut[i] = address(wrappedToken);
-
-                if (isStaticCall == false) {
-                    _sendTokenOut(params.sender, erc4626PoolTokens[i], amountsOut[i], params.wethIsEth);
-                }
-            }
-
-            if (amountsOut[i] < params.minAmountsOut[i]) {
-                revert IVaultErrors.AmountOutBelowMin(IERC20(tokensOut[i]), amountsOut[i], params.minAmountsOut[i]);
             }
         }
-    }
-
-    /// @dev Assumes array lengths have been checked externally.
-    function _wrapTokensExactInIfRequired(
-        address sender,
-        bool[] memory wrapUnderlying,
-        IERC20[] memory erc4626PoolTokens,
-        uint256[] memory amountsIn,
-        bool wethIsEth
-    ) private returns (uint256[] memory wrappedAmountsIn) {
-        uint256 poolTokensLength = erc4626PoolTokens.length;
-        wrappedAmountsIn = new uint256[](poolTokensLength);
-
-        bool isStaticCall = EVMCallModeHelpers.isStaticCall();
-
-        for (uint256 i = 0; i < poolTokensLength; ++i) {
-            // Treat all ERC4626 pool tokens as wrapped. The next step will verify if we can use the wrappedToken as
-            // a valid ERC4626.
-            IERC4626 wrappedToken = IERC4626(address(erc4626PoolTokens[i]));
-            IERC20 underlyingToken = IERC20(_vault.getBufferAsset(wrappedToken));
-
-            // Check whether the caller wants to use the token as an ERC4626 (i.e., wrap/unwrap it), or just use it as
-            // a standard token.
-            if (wrapUnderlying[i]) {
-                if (address(underlyingToken) == address(0)) {
-                    revert IVaultErrors.BufferNotInitialized(wrappedToken);
-                }
-
-                uint256 wrappedAmount;
-                if (amountsIn[i] > 0) {
-                    if (isStaticCall == false) {
-                        // Take the exact amount in from the sender.
-                        _takeTokenIn(sender, underlyingToken, amountsIn[i], wethIsEth);
-                    }
-
-                    // `erc4626BufferWrapOrUnwrap` will fail if the wrappedToken isn't ERC4626-conforming.
-                    (, , wrappedAmount) = _vault.erc4626BufferWrapOrUnwrap(
-                        BufferWrapOrUnwrapParams({
-                            kind: SwapKind.EXACT_IN,
-                            direction: WrappingDirection.WRAP,
-                            wrappedToken: wrappedToken,
-                            amountGivenRaw: amountsIn[i],
-                            limitRaw: 0
-                        })
-                    );
-                }
-
-                wrappedAmountsIn[i] = wrappedAmount;
-            } else {
-                wrappedAmountsIn[i] = amountsIn[i];
-
-                if (isStaticCall == false) {
-                    _takeTokenIn(sender, wrappedToken, wrappedAmountsIn[i], wethIsEth);
-                }
-            }
-        }
-
-        // If there's a leftover of eth, send it back to the sender. The router should not keep ETH.
-        _returnEth(sender);
     }
 
     /// @dev Assumes array lengths have been checked externally.
@@ -928,6 +868,107 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
 
         if (isStaticCall == false) {
             _settlePaths(params.sender, params.wethIsEth);
+        }
+    }
+
+    // Helper functions
+
+    /**
+     * @notice Processes a single token for input during add liquidity operations.
+     * @dev Handles wrapping and token transfers when not in a query context.
+     * @param token The incoming token
+     * @param amountIn The token amount (or max amount)
+     * @param needToWrap Flag indicating whether this token is an ERC4626 to be wrapped
+     * @param callParams Common parameters from the main router call
+     * @return processedAmount The final token amount (of the underlying token if wrapped)
+     */
+    function _processTokenIn(
+        address token,
+        uint256 amountIn,
+        bool needToWrap,
+        RouterCallParams memory callParams
+    ) private returns (uint256 processedAmount) {
+        if (needToWrap) {
+            IERC4626 wrappedToken = IERC4626(token);
+            IERC20 underlyingToken = IERC20(_vault.getBufferAsset(wrappedToken));
+
+            if (address(underlyingToken) == address(0)) {
+                revert IVaultErrors.BufferNotInitialized(wrappedToken);
+            }
+            
+            if (callParams.isStaticCall == false) {
+                _takeTokenIn(callParams.sender, underlyingToken, amountIn, callParams.wethIsEth);
+            }
+            
+            (, , processedAmount) = _vault.erc4626BufferWrapOrUnwrap(
+                BufferWrapOrUnwrapParams({
+                    kind: SwapKind.EXACT_IN,
+                    direction: WrappingDirection.WRAP,
+                    wrappedToken: wrappedToken,
+                    amountGivenRaw: amountIn,
+                    limitRaw: 0
+                })
+            );
+        } else {
+            processedAmount = amountIn;
+
+            if (callParams.isStaticCall == false) {
+                _takeTokenIn(callParams.sender, IERC20(token), amountIn, callParams.wethIsEth);
+            }
+        }
+    }
+
+    /**
+     * @notice Processes a single token for output during remove liquidity operations.
+     * @dev Handles unwrapping and token transfers when not in a query context.
+     * @param token The outgoing token
+     * @param amountOut The token amount out
+     * @param needToUnwrap Flag indicating whether this token is an ERC4626 to be unwrapped
+     * @param minAmountOut The minimum token amountOut
+     * @param callParams Common parameters from the main router call
+     * @return tokenOut The address of the actual outgoing token (underlying if unwrapped)
+     * @return actualAmountOut The actual amountOut (in underlying token if unwrapped)
+     */
+    function _processTokenOut(
+        address token,
+        uint256 amountOut,
+        bool needToUnwrap,
+        uint256 minAmountOut,
+        RouterCallParams memory callParams
+    ) private returns (address tokenOut, uint256 actualAmountOut) {
+        if (needToUnwrap) {
+            IERC4626 wrappedToken = IERC4626(token);
+            IERC20 underlyingToken = IERC20(_vault.getBufferAsset(wrappedToken));
+
+            if (address(underlyingToken) == address(0)) {
+                revert IVaultErrors.BufferNotInitialized(wrappedToken);
+            }
+            
+            (, , actualAmountOut) = _vault.erc4626BufferWrapOrUnwrap(
+                BufferWrapOrUnwrapParams({
+                    kind: SwapKind.EXACT_IN,
+                    direction: WrappingDirection.UNWRAP,
+                    wrappedToken: wrappedToken,
+                    amountGivenRaw: amountOut,
+                    limitRaw: minAmountOut
+                })
+            );
+            tokenOut = address(underlyingToken);
+            
+            if (callParams.isStaticCall == false) {
+                _sendTokenOut(callParams.sender, underlyingToken, actualAmountOut, callParams.wethIsEth);
+            }
+        } else {
+            actualAmountOut = amountOut;
+            tokenOut = token;
+            
+            if (callParams.isStaticCall == false) {
+                _sendTokenOut(callParams.sender, IERC20(token), actualAmountOut, callParams.wethIsEth);
+            }
+        }
+        
+        if (actualAmountOut < minAmountOut) {
+            revert IVaultErrors.AmountOutBelowMin(IERC20(tokenOut), actualAmountOut, minAmountOut);
         }
     }
 }

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -766,8 +766,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
 
             childBptAmountOut = exactChildBptAmountOut;
 
-            // Since the BPT will be inserted into the parent pool, get the credit from the inserted BPTs in
-            // advance.
+            // Since the BPT will be add to the parent pool, get the credit from the inserted BPT in advance.
             _vault.settle(IERC20(childPool), exactChildBptAmountOut);
         }
 

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	14.249
-InitCode	15.826
+Bytecode	22.371
+InitCode	24.202

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	22.371
-InitCode	24.202
+Bytecode	22.782
+InitCode	24.654

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	23.162
-InitCode	25.048
+Bytecode	23.154
+InitCode	25.040

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	22.727
-InitCode	24.619
+Bytecode	22.425
+InitCode	24.304

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	22.711
-InitCode	24.604
+Bytecode	22.727
+InitCode	24.619

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	23.154
-InitCode	25.040
+Bytecode	22.717
+InitCode	24.609

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	22.732
-InitCode	24.604
+Bytecode	23.162
+InitCode	25.048

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	22.782
-InitCode	24.654
+Bytecode	22.732
+InitCode	24.604

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	22.717
-InitCode	24.609
+Bytecode	22.711
+InitCode	24.604

--- a/pkg/vault/test/foundry/CompositeLiquidityRouterNestedPools.t.sol
+++ b/pkg/vault/test/foundry/CompositeLiquidityRouterNestedPools.t.sol
@@ -1,0 +1,2192 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
+import { ICompositeLiquidityRouter } from "@balancer-labs/v3-interfaces/contracts/vault/ICompositeLiquidityRouter.sol";
+
+import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/test/ArrayHelpers.sol";
+import { CastingHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/CastingHelpers.sol";
+import { ERC20TestToken } from "@balancer-labs/v3-solidity-utils/contracts/test/ERC20TestToken.sol";
+import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
+import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
+
+import { BalancerPoolToken } from "../../contracts/BalancerPoolToken.sol";
+import { BaseERC4626BufferTest } from "./utils/BaseERC4626BufferTest.sol";
+
+contract CompositeLiquidityRouterNestedPoolsTest is BaseERC4626BufferTest {
+    using ArrayHelpers for *;
+    using CastingHelpers for address[];
+    using FixedPoint for uint256;
+
+    address internal parentPool;
+    address internal childPoolA;
+    address internal childPoolB;
+
+    address internal childPoolERC4626;
+    address internal parentPoolWithoutWrapper;
+    address internal parentPoolWithWrapper;
+
+    // Max of 5 wei of error when retrieving tokens from a nested pool.
+    uint256 internal constant MAX_ROUND_ERROR = 5;
+
+    function setUp() public override {
+        BaseERC4626BufferTest.setUp();
+
+        (childPoolA, ) = _createPool([address(usdc), address(weth)].toMemoryArray(), "childPoolA");
+        (childPoolB, ) = _createPool([address(wsteth), address(dai)].toMemoryArray(), "childPoolB");
+        (parentPool, ) = _createPool(
+            [address(childPoolA), address(childPoolB), address(dai)].toMemoryArray(),
+            "parentPool"
+        );
+
+        (childPoolERC4626, ) = _createPool([address(waDAI), address(waWETH)].toMemoryArray(), "childPoolERC4626");
+        (parentPoolWithoutWrapper, ) = _createPool(
+            [address(childPoolERC4626), address(usdc)].toMemoryArray(),
+            "parentPoolWithoutWrapper"
+        );
+        (parentPoolWithWrapper, ) = _createPool(
+            [address(childPoolERC4626), address(waUSDC)].toMemoryArray(),
+            "parentPoolWithWrapper"
+        );
+
+        approveForPool(IERC20(childPoolA));
+        approveForPool(IERC20(childPoolB));
+        approveForPool(IERC20(childPoolERC4626));
+
+        approveForPool(IERC20(parentPool));
+        approveForPool(IERC20(parentPoolWithoutWrapper));
+        approveForPool(IERC20(parentPoolWithWrapper));
+
+        vm.startPrank(lp);
+        uint256 childPoolABptOut = _initPool(childPoolA, [poolInitAmount, poolInitAmount].toMemoryArray(), 0);
+        uint256 childPoolBBptOut = _initPool(childPoolB, [poolInitAmount, poolInitAmount].toMemoryArray(), 0);
+        // Initialize the ERC4626 child pool with 2x poolInitAmount, because we will split the BPT into two pools. So,
+        // it'll be easier to calculate the expectedAmountOut on removeLiquidity.
+        uint256 childPoolERC4626BptOut = _initPool(
+            childPoolERC4626,
+            [2 * poolInitAmount, 2 * poolInitAmount].toMemoryArray(),
+            0
+        );
+
+        _initPoolUnsorted(
+            parentPool,
+            [childPoolA, childPoolB, address(dai)].toMemoryArray(),
+            [childPoolABptOut, childPoolBBptOut, poolInitAmount].toMemoryArray()
+        );
+        _initPoolUnsorted(
+            parentPoolWithoutWrapper,
+            [childPoolERC4626, address(usdc)].toMemoryArray(),
+            [childPoolERC4626BptOut / 2, poolInitAmount].toMemoryArray()
+        );
+        _initPoolUnsorted(
+            parentPoolWithWrapper,
+            [childPoolERC4626, address(waUSDC)].toMemoryArray(),
+            [childPoolERC4626BptOut / 2, poolInitAmount].toMemoryArray()
+        );
+        vm.stopPrank();
+    }
+
+    function _initPoolUnsorted(
+        address poolToInitialize,
+        address[] memory unsortedTokensIn,
+        uint256[] memory unsortedAmountsIn
+    ) private {
+        uint256[] memory tokenIndexes = getSortedIndexes(unsortedTokensIn);
+
+        uint256[] memory sortedAmountsIn = new uint256[](unsortedTokensIn.length);
+        for (uint256 i = 0; i < unsortedTokensIn.length; i++) {
+            sortedAmountsIn[tokenIndexes[i]] = unsortedAmountsIn[i];
+        }
+
+        _initPool(poolToInitialize, sortedAmountsIn, 0);
+    }
+
+    /*******************************************************************************
+                                Add liquidity
+    *******************************************************************************/
+
+    function testAddLiquidityNestedPool__Fuzz(
+        uint256 daiAmount,
+        uint256 usdcAmount,
+        uint256 wethAmount,
+        uint256 wstEthAmount
+    ) public {
+        daiAmount = bound(daiAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        usdcAmount = bound(usdcAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        wethAmount = bound(wethAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        wstEthAmount = bound(wstEthAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        address[] memory tokensIn = new address[](4);
+        tokensIn[vars.daiIdx] = address(dai);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+        tokensIn[vars.wstethIdx] = address(wsteth);
+
+        uint256[] memory amountsIn = new uint256[](4);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+        amountsIn[vars.wstethIdx] = wstEthAmount;
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPool,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 mintedChildPoolABpt = vars.childPoolAAfter.totalSupply - vars.childPoolABefore.totalSupply;
+        uint256 mintedChildPoolBBpt = vars.childPoolBAfter.totalSupply - vars.childPoolBBefore.totalSupply;
+
+        // Check exact BPT out.
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in.
+        uint256 expectedBptOut = daiAmount + usdcAmount + wethAmount + wstEthAmount;
+        assertApproxEqAbs(exactBptOut, expectedBptOut, 10, "Exact BPT amount out is wrong");
+        assertLt(exactBptOut, expectedBptOut, "BPT out rounding direction is wrong");
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai - amountsIn[vars.daiIdx], "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth - amountsIn[vars.wethIdx], "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.wsteth, vars.lpBefore.wsteth - amountsIn[vars.wstethIdx], "LP Wsteth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc - amountsIn[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(vars.lpAfter.childPoolABpt, vars.lpBefore.childPoolABpt, "LP ChildPoolA BPT Balance is wrong");
+        assertEq(vars.lpAfter.childPoolBBpt, vars.lpBefore.childPoolBBpt, "LP ChildPoolB BPT Balance is wrong");
+        assertEq(
+            vars.lpAfter.parentPoolBpt,
+            vars.lpBefore.parentPoolBpt + exactBptOut,
+            "LP ParentPool BPT Balance is wrong"
+        );
+
+        // Check Vault Balances.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai + amountsIn[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth + amountsIn[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(
+            vars.vaultAfter.wsteth,
+            vars.vaultBefore.wsteth + amountsIn[vars.wstethIdx],
+            "Vault Wsteth Balance is wrong"
+        );
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc + amountsIn[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        // Since all Child Pool BPT were allocated in the parent pool, vault is holding all of the minted BPT.
+        assertEq(
+            vars.vaultAfter.childPoolABpt,
+            vars.vaultBefore.childPoolABpt + mintedChildPoolABpt,
+            "Vault ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.vaultAfter.childPoolBBpt,
+            vars.vaultBefore.childPoolBBpt + mintedChildPoolBBpt,
+            "Vault ChildPoolB BPT Balance is wrong"
+        );
+        // Vault's parent pool BPT did not change.
+        assertEq(
+            vars.vaultAfter.parentPoolBpt,
+            vars.vaultBefore.parentPoolBpt,
+            "Vault ParentPool BPT Balance is wrong"
+        );
+
+        // Check ChildPoolA balances.
+        assertEq(
+            vars.childPoolAAfter.weth,
+            vars.childPoolABefore.weth + amountsIn[vars.wethIdx],
+            "ChildPoolA Weth Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolAAfter.usdc,
+            vars.childPoolABefore.usdc + amountsIn[vars.usdcIdx],
+            "ChildPoolA Usdc Balance is wrong"
+        );
+
+        // Check ChildPoolB balances.
+        assertEq(vars.childPoolBAfter.dai, vars.childPoolBBefore.dai, "ChildPoolB Dai Balance is wrong");
+        assertEq(
+            vars.childPoolBAfter.wsteth,
+            vars.childPoolBBefore.wsteth + amountsIn[vars.wstethIdx],
+            "ChildPoolB Wsteth Balance is wrong"
+        );
+
+        // Check ParentPool balances.
+        assertApproxEqAbs(
+            vars.parentPoolAfter.dai,
+            vars.parentPoolBefore.dai + amountsIn[vars.daiIdx],
+            MAX_ROUND_ERROR,
+            "ParentPool Dai Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolABpt,
+            vars.parentPoolBefore.childPoolABpt + mintedChildPoolABpt,
+            "ParentPool ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolBBpt,
+            vars.parentPoolBefore.childPoolBBpt + mintedChildPoolBBpt,
+            "ParentPool ChildPoolB BPT Balance is wrong"
+        );
+    }
+
+    function testAddLiquidityUnbalanceToOneChildNestedPool() public {
+        uint256 usdcAmount = poolInitAmount;
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        address[] memory tokensIn = new address[](1);
+        tokensIn[0] = address(usdc);
+
+        uint256[] memory amountsIn = new uint256[](1);
+        amountsIn[0] = usdcAmount;
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPool,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 mintedChildPoolABpt = vars.childPoolAAfter.totalSupply - vars.childPoolABefore.totalSupply;
+
+        // Check exact BPT out.
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in.
+        uint256 expectedBptOut = usdcAmount;
+        assertApproxEqAbs(exactBptOut, expectedBptOut, 10, "Exact BPT amount out is wrong");
+        assertLt(exactBptOut, expectedBptOut, "BPT out rounding direction is wrong");
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai, "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth, "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.wsteth, vars.lpBefore.wsteth, "LP Wsteth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc - amountsIn[0], "LP Usdc Balance is wrong");
+        assertEq(vars.lpAfter.childPoolABpt, vars.lpBefore.childPoolABpt, "LP ChildPoolA BPT Balance is wrong");
+        assertEq(vars.lpAfter.childPoolBBpt, vars.lpBefore.childPoolBBpt, "LP ChildPoolB BPT Balance is wrong");
+        assertEq(
+            vars.lpAfter.parentPoolBpt,
+            vars.lpBefore.parentPoolBpt + exactBptOut,
+            "LP ParentPool BPT Balance is wrong"
+        );
+
+        // Check Vault Balances.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai, "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth, "Vault Weth Balance is wrong");
+        assertEq(vars.vaultAfter.wsteth, vars.vaultBefore.wsteth, "Vault Wsteth Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc + amountsIn[0], "Vault Usdc Balance is wrong");
+        // Since all Child Pool BPT were allocated in the parent pool, vault is holding all of the minted BPT.
+        assertEq(
+            vars.vaultAfter.childPoolABpt,
+            vars.vaultBefore.childPoolABpt + mintedChildPoolABpt,
+            "Vault ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.vaultAfter.childPoolBBpt,
+            vars.vaultBefore.childPoolBBpt,
+            "Vault ChildPoolB BPT Balance is wrong"
+        );
+        // Vault's parent pool BPT did not change.
+        assertEq(
+            vars.vaultAfter.parentPoolBpt,
+            vars.vaultBefore.parentPoolBpt,
+            "Vault ParentPool BPT Balance is wrong"
+        );
+
+        // Check ChildPoolA balances.
+        assertEq(vars.childPoolAAfter.weth, vars.childPoolABefore.weth, "ChildPoolA Weth Balance is wrong");
+        assertEq(
+            vars.childPoolAAfter.usdc,
+            vars.childPoolABefore.usdc + amountsIn[0],
+            "ChildPoolA Usdc Balance is wrong"
+        );
+
+        // Check ChildPoolB balances.
+        assertApproxEqAbs(
+            vars.childPoolBAfter.dai,
+            vars.childPoolBBefore.dai,
+            MAX_ROUND_ERROR,
+            "ChildPoolB Dai Balance is wrong"
+        );
+        assertEq(vars.childPoolBAfter.wsteth, vars.childPoolBBefore.wsteth, "ChildPoolB Wsteth Balance is wrong");
+
+        // Check ParentPool balances.
+        // The ParentPool's DAI balance does not change since all DAI amount is inserted in the child pool A.
+        assertEq(vars.parentPoolAfter.dai, vars.parentPoolBefore.dai, "ParentPool Dai Balance is wrong");
+        assertEq(
+            vars.parentPoolAfter.childPoolABpt,
+            vars.parentPoolBefore.childPoolABpt + mintedChildPoolABpt,
+            "ParentPool ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolBBpt,
+            vars.parentPoolBefore.childPoolBBpt,
+            "ParentPool ChildPoolB BPT Balance is wrong"
+        );
+    }
+
+    function testAddLiquidityNestedERC4626WithUnderlying__Fuzz(
+        uint256 daiAmount,
+        uint256 usdcAmount,
+        uint256 wethAmount
+    ) public {
+        daiAmount = bound(daiAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        usdcAmount = bound(usdcAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        wethAmount = bound(wethAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.daiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        address[] memory tokensIn = new address[](3);
+        tokensIn[vars.daiIdx] = address(dai);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+
+        uint256[] memory amountsIn = new uint256[](3);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPoolWithoutWrapper,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 mintedChildPoolERC4626Bpt = vars.childPoolERC4626After.totalSupply -
+            vars.childPoolERC4626Before.totalSupply;
+
+        // Check exact BPT out.
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in.
+        uint256 expectedBptOut = _vaultPreviewDeposit(waDAI, daiAmount) + usdcAmount + wethAmount;
+        assertApproxEqAbs(exactBptOut, expectedBptOut, 10, "Exact BPT amount out is wrong");
+        assertLt(exactBptOut, expectedBptOut, "BPT out rounding direction is wrong");
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai - amountsIn[vars.daiIdx], "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth - amountsIn[vars.wethIdx], "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc - amountsIn[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(
+            vars.lpAfter.childPoolERC4626Bpt,
+            vars.lpBefore.childPoolERC4626Bpt,
+            "LP ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.lpAfter.parentPoolWithoutWrapperBpt,
+            vars.lpBefore.parentPoolWithoutWrapperBpt + exactBptOut,
+            "LP ParentPoolWithoutWrapper BPT Balance is wrong"
+        );
+
+        // Check Vault Balances. Since the buffer has enough balance, the Vault only increased its underlying tokens.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai + amountsIn[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.waDAI, vars.vaultBefore.waDAI, "Vault waDai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth + amountsIn[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(vars.vaultAfter.waWETH, vars.vaultBefore.waWETH, "Vault waWETH Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc + amountsIn[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        assertEq(vars.vaultAfter.waUSDC, vars.vaultBefore.waUSDC, "Vault waUsdc Balance is wrong");
+        // Since all Child Pool BPT were allocated in the parent pool, vault is holding all of the minted BPT.
+        assertEq(
+            vars.vaultAfter.childPoolERC4626Bpt,
+            vars.vaultBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "Vault ChildPoolERC4626 BPT Balance is wrong"
+        );
+
+        // Vault's parent pool BPT did not change.
+        assertEq(
+            vars.vaultAfter.parentPoolWithoutWrapperBpt,
+            vars.vaultBefore.parentPoolWithoutWrapperBpt,
+            "Vault ParentPoolWithoutWrapper BPT Balance is wrong"
+        );
+
+        // Check ChildPoolERC4626 balances.
+        assertEq(
+            vars.childPoolERC4626After.waDAI,
+            vars.childPoolERC4626Before.waDAI + _vaultPreviewDeposit(waDAI, amountsIn[vars.daiIdx]),
+            "ChildPoolERC4626 waDAI Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolERC4626After.waWETH,
+            vars.childPoolERC4626Before.waWETH + _vaultPreviewDeposit(waWETH, amountsIn[vars.wethIdx]),
+            "ChildPoolERC4626 waWETH Balance is wrong"
+        );
+
+        // Check ParentPoolWithoutWrapper balances.
+        assertEq(
+            vars.parentPoolWithoutWrapperAfter.childPoolERC4626Bpt,
+            vars.parentPoolWithoutWrapperBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "ParentPoolWithoutWrapper ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolWithoutWrapperAfter.usdc,
+            vars.parentPoolWithoutWrapperBefore.usdc + amountsIn[vars.usdcIdx],
+            "ParentPoolWithoutWrapper USDC Balance is wrong"
+        );
+    }
+
+    function testAddLiquidityNestedERC4626WithEth__Fuzz(
+        uint256 daiAmount,
+        uint256 usdcAmount,
+        uint256 wethAmount,
+        bool forceEthLeftover
+    ) public {
+        daiAmount = bound(daiAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        usdcAmount = bound(usdcAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        wethAmount = bound(wethAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.daiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        address[] memory tokensIn = new address[](3);
+        tokensIn[vars.daiIdx] = address(dai);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+
+        uint256[] memory amountsIn = new uint256[](3);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool{
+            value: wethAmount + (forceEthLeftover ? 1e18 : 0)
+        }(parentPoolWithoutWrapper, tokensIn, amountsIn, minBptOut, true, bytes(""));
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 mintedChildPoolERC4626Bpt = vars.childPoolERC4626After.totalSupply -
+            vars.childPoolERC4626Before.totalSupply;
+
+        // Check exact BPT out.
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in.
+        uint256 expectedBptOut = _vaultPreviewDeposit(waDAI, daiAmount) + usdcAmount + wethAmount;
+        assertApproxEqAbs(exactBptOut, expectedBptOut, 10, "Exact BPT amount out is wrong");
+        assertLt(exactBptOut, expectedBptOut, "BPT out rounding direction is wrong");
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai - amountsIn[vars.daiIdx], "LP Dai Balance is wrong");
+        // LP Weth balance should not change, since ETH was used. Weth and Eth prices are the same.
+        assertEq(vars.lpAfter.eth, vars.lpBefore.eth - amountsIn[vars.wethIdx], "LP Eth Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth, "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc - amountsIn[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(
+            vars.lpAfter.childPoolERC4626Bpt,
+            vars.lpBefore.childPoolERC4626Bpt,
+            "LP ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.lpAfter.parentPoolWithoutWrapperBpt,
+            vars.lpBefore.parentPoolWithoutWrapperBpt + exactBptOut,
+            "LP ParentPoolWithoutWrapper BPT Balance is wrong"
+        );
+
+        // Check Vault Balances. Since the buffer has enough balance, the Vault only increased its underlying tokens.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai + amountsIn[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.waDAI, vars.vaultBefore.waDAI, "Vault waDai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth + amountsIn[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc + amountsIn[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        assertEq(vars.vaultAfter.waUSDC, vars.vaultBefore.waUSDC, "Vault waUsdc Balance is wrong");
+        // Since all Child Pool BPT were allocated in the parent pool, vault is holding all of the minted BPT.
+        assertEq(
+            vars.vaultAfter.childPoolERC4626Bpt,
+            vars.vaultBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "Vault ChildPoolERC4626 BPT Balance is wrong"
+        );
+
+        // Vault's parent pool BPT did not change.
+        assertEq(
+            vars.vaultAfter.parentPoolWithoutWrapperBpt,
+            vars.vaultBefore.parentPoolWithoutWrapperBpt,
+            "Vault ParentPoolWithoutWrapper BPT Balance is wrong"
+        );
+
+        // Check ChildPoolERC4626 balances.
+        assertEq(
+            vars.childPoolERC4626After.waDAI,
+            vars.childPoolERC4626Before.waDAI + _vaultPreviewDeposit(waDAI, amountsIn[vars.daiIdx]),
+            "ChildPoolERC4626 waDAI Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolERC4626After.waWETH,
+            vars.childPoolERC4626Before.waWETH + _vaultPreviewDeposit(waWETH, amountsIn[vars.wethIdx]),
+            "ChildPoolERC4626 waWETH Balance is wrong"
+        );
+
+        // Check ParentPoolWithoutWrapper balances.
+        assertEq(
+            vars.parentPoolWithoutWrapperAfter.childPoolERC4626Bpt,
+            vars.parentPoolWithoutWrapperBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "ParentPoolWithoutWrapper ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolWithoutWrapperAfter.usdc,
+            vars.parentPoolWithoutWrapperBefore.usdc + amountsIn[vars.usdcIdx],
+            "ParentPoolWithoutWrapper USDC Balance is wrong"
+        );
+
+        assertEq(address(compositeLiquidityRouter).balance, 0, "Router has eth balance");
+    }
+
+    function testAddLiquidityNestedERC4626WithWrapped__Fuzz(
+        uint256 waDaiAmount,
+        uint256 usdcAmount,
+        uint256 wethAmount
+    ) public {
+        waDaiAmount = bound(waDaiAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        usdcAmount = bound(usdcAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        wethAmount = bound(wethAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.waDaiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        address[] memory tokensIn = new address[](3);
+        tokensIn[vars.waDaiIdx] = address(waDAI);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+
+        uint256[] memory amountsIn = new uint256[](3);
+        amountsIn[vars.waDaiIdx] = waDaiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPoolWithoutWrapper,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 mintedChildPoolERC4626Bpt = vars.childPoolERC4626After.totalSupply -
+            vars.childPoolERC4626Before.totalSupply;
+
+        // Check exact BPT out.
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in.
+        uint256 expectedBptOut = waDaiAmount + usdcAmount + wethAmount;
+        assertApproxEqAbs(exactBptOut, expectedBptOut, 10, "Exact BPT amount out is wrong");
+        assertLt(exactBptOut, expectedBptOut, "BPT out rounding direction is wrong");
+
+        // Check LP Balances.
+        // Since LP passed the wrapper address as a token in, his DAI balance is not touched.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai, "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.waDAI, vars.lpBefore.waDAI - amountsIn[vars.waDaiIdx], "LP waDAI Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth - amountsIn[vars.wethIdx], "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc - amountsIn[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(
+            vars.lpAfter.childPoolERC4626Bpt,
+            vars.lpBefore.childPoolERC4626Bpt,
+            "LP ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.lpAfter.parentPoolWithoutWrapperBpt,
+            vars.lpBefore.parentPoolWithoutWrapperBpt + exactBptOut,
+            "LP ParentPoolWithoutWrapper BPT Balance is wrong"
+        );
+
+        // Check Vault Balances.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai, "Vault Dai Balance is wrong");
+        assertEq(
+            vars.vaultAfter.waDAI,
+            vars.vaultBefore.waDAI + amountsIn[vars.waDaiIdx],
+            "Vault waDAI Balance is wrong"
+        );
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth + amountsIn[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc + amountsIn[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        // Since all Child Pool BPT were allocated in the parent pool, vault is holding all of the minted BPT.
+        assertEq(
+            vars.vaultAfter.childPoolERC4626Bpt,
+            vars.vaultBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "Vault ChildPoolERC4626 BPT Balance is wrong"
+        );
+
+        // Vault's parent pool BPT did not change.
+        assertEq(
+            vars.vaultAfter.parentPoolWithoutWrapperBpt,
+            vars.vaultBefore.parentPoolWithoutWrapperBpt,
+            "Vault ParentPoolWithoutWrapper BPT Balance is wrong"
+        );
+
+        // Check ChildPoolERC4626 balances.
+        assertEq(
+            vars.childPoolERC4626After.waDAI,
+            vars.childPoolERC4626Before.waDAI + amountsIn[vars.waDaiIdx],
+            "ChildPoolERC4626 waDAI Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolERC4626After.waWETH,
+            vars.childPoolERC4626Before.waWETH + _vaultPreviewDeposit(waWETH, amountsIn[vars.wethIdx]),
+            "ChildPoolERC4626 waWETH Balance is wrong"
+        );
+
+        // Check ParentPoolWithoutWrapper balances.
+        assertEq(
+            vars.parentPoolWithoutWrapperAfter.childPoolERC4626Bpt,
+            vars.parentPoolWithoutWrapperBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "ParentPoolWithoutWrapper ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolWithoutWrapperAfter.usdc,
+            vars.parentPoolWithoutWrapperBefore.usdc + amountsIn[vars.usdcIdx],
+            "ParentPoolWithoutWrapper USDC Balance is wrong"
+        );
+    }
+
+    function testAddLiquidityNestedERC4626InParentWithUnderlying__Fuzz(
+        uint256 daiAmount,
+        uint256 usdcAmount,
+        uint256 wethAmount
+    ) public {
+        daiAmount = bound(daiAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        usdcAmount = bound(usdcAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        wethAmount = bound(wethAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.daiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        address[] memory tokensIn = new address[](3);
+        tokensIn[vars.daiIdx] = address(dai);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+
+        uint256[] memory amountsIn = new uint256[](3);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPoolWithWrapper,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 mintedChildPoolERC4626Bpt = vars.childPoolERC4626After.totalSupply -
+            vars.childPoolERC4626Before.totalSupply;
+
+        // Check exact BPT out.
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in.
+        uint256 expectedBptOut = _vaultPreviewDeposit(waDAI, daiAmount) +
+            _vaultPreviewDeposit(waUSDC, usdcAmount) +
+            _vaultPreviewDeposit(waWETH, wethAmount);
+        assertApproxEqAbs(exactBptOut, expectedBptOut, 10, "Exact BPT amount out is wrong");
+        assertLt(exactBptOut, expectedBptOut, "BPT out rounding direction is wrong");
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai - amountsIn[vars.daiIdx], "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth - amountsIn[vars.wethIdx], "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc - amountsIn[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(
+            vars.lpAfter.childPoolERC4626Bpt,
+            vars.lpBefore.childPoolERC4626Bpt,
+            "LP ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.lpAfter.parentPoolWithWrapperBpt,
+            vars.lpBefore.parentPoolWithWrapperBpt + exactBptOut,
+            "LP ParentPoolWithWrapper BPT Balance is wrong"
+        );
+
+        // Check Vault Balances. Since the buffer has enough balance, the Vault only increased its underlying tokens.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai + amountsIn[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.waDAI, vars.vaultBefore.waDAI, "Vault waDai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth + amountsIn[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(vars.vaultAfter.waWETH, vars.vaultBefore.waWETH, "Vault waWeth Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc + amountsIn[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        assertEq(vars.vaultAfter.waUSDC, vars.vaultBefore.waUSDC, "Vault waUSDC Balance is wrong");
+
+        // Since all Child Pool BPT were allocated in the parent pool, vault is holding all of the minted BPT.
+        assertEq(
+            vars.vaultAfter.childPoolERC4626Bpt,
+            vars.vaultBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "Vault ChildPoolERC4626 BPT Balance is wrong"
+        );
+
+        // Vault's parent pool BPT did not change.
+        assertEq(
+            vars.vaultAfter.parentPoolWithWrapperBpt,
+            vars.vaultBefore.parentPoolWithWrapperBpt,
+            "Vault ParentPoolWithWrapper BPT Balance is wrong"
+        );
+
+        // Check ChildPoolERC4626 balances.
+        assertEq(
+            vars.childPoolERC4626After.waDAI,
+            vars.childPoolERC4626Before.waDAI + _vaultPreviewDeposit(waDAI, amountsIn[vars.daiIdx]),
+            "ChildPoolERC4626 waDAI Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolERC4626After.waWETH,
+            vars.childPoolERC4626Before.waWETH + _vaultPreviewDeposit(waWETH, amountsIn[vars.wethIdx]),
+            "ChildPoolERC4626 waWETH Balance is wrong"
+        );
+
+        // Check ParentPoolWithoutWrapper balances.
+        assertEq(
+            vars.parentPoolWithWrapperAfter.childPoolERC4626Bpt,
+            vars.parentPoolWithWrapperBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "ParentPoolWithWrapper ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolWithWrapperAfter.waUSDC,
+            vars.parentPoolWithWrapperBefore.waUSDC + _vaultPreviewDeposit(waUSDC, amountsIn[vars.usdcIdx]),
+            "ParentPoolWithWrapper waUSDC Balance is wrong"
+        );
+    }
+
+    function testAddLiquidityNestedERC4626InParentWithWrapped__Fuzz(
+        uint256 waDaiAmount,
+        uint256 waUsdcAmount,
+        uint256 waWethAmount
+    ) public {
+        waDaiAmount = bound(waDaiAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        waUsdcAmount = bound(waUsdcAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        waWethAmount = bound(waWethAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.waDaiIdx = 0;
+        vars.waUsdcIdx = 1;
+        vars.waWethIdx = 2;
+
+        address[] memory tokensIn = new address[](3);
+        tokensIn[vars.waDaiIdx] = address(waDAI);
+        tokensIn[vars.waUsdcIdx] = address(waUSDC);
+        tokensIn[vars.waWethIdx] = address(waWETH);
+
+        uint256[] memory amountsIn = new uint256[](3);
+        amountsIn[vars.waDaiIdx] = waDaiAmount;
+        amountsIn[vars.waUsdcIdx] = waUsdcAmount;
+        amountsIn[vars.waWethIdx] = waWethAmount;
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPoolWithWrapper,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 mintedChildPoolERC4626Bpt = vars.childPoolERC4626After.totalSupply -
+            vars.childPoolERC4626Before.totalSupply;
+
+        // Check exact BPT out.
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in.
+        uint256 expectedBptOut = waDaiAmount + waUsdcAmount + waWethAmount;
+        assertApproxEqAbs(exactBptOut, expectedBptOut, 10, "Exact BPT amount out is wrong");
+        assertLt(exactBptOut, expectedBptOut, "BPT out rounding direction is wrong");
+
+        // Check LP Balances.
+        // Since LP passed the wrapper address as a token in, his DAI and USDC balances are not touched.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai, "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc, "LP USDC Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth, "LP WETH Balance is wrong");
+        assertEq(vars.lpAfter.waDAI, vars.lpBefore.waDAI - amountsIn[vars.waDaiIdx], "LP waDAI Balance is wrong");
+        assertEq(vars.lpAfter.waUSDC, vars.lpBefore.waUSDC - amountsIn[vars.waUsdcIdx], "LP waUSDC Balance is wrong");
+        assertEq(vars.lpAfter.waWETH, vars.lpBefore.waWETH - amountsIn[vars.waWethIdx], "LP waWETH Balance is wrong");
+        assertEq(
+            vars.lpAfter.childPoolERC4626Bpt,
+            vars.lpBefore.childPoolERC4626Bpt,
+            "LP ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.lpAfter.parentPoolWithWrapperBpt,
+            vars.lpBefore.parentPoolWithWrapperBpt + exactBptOut,
+            "LP ParentPoolWithWrapper BPT Balance is wrong"
+        );
+
+        // Check Vault Balances.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai, "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc, "Vault USDC Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth, "Vault USDC Balance is wrong");
+        assertEq(
+            vars.vaultAfter.waDAI,
+            vars.vaultBefore.waDAI + amountsIn[vars.waDaiIdx],
+            "Vault waDAI Balance is wrong"
+        );
+        assertEq(
+            vars.vaultAfter.waUSDC,
+            vars.vaultBefore.waUSDC + amountsIn[vars.waUsdcIdx],
+            "Vault waDAI Balance is wrong"
+        );
+        assertEq(
+            vars.vaultAfter.waWETH,
+            vars.vaultBefore.waWETH + amountsIn[vars.waWethIdx],
+            "Vault waWETH Balance is wrong"
+        );
+        // Since all Child Pool BPT were allocated in the parent pool, vault is holding all of the minted BPT.
+        assertEq(
+            vars.vaultAfter.childPoolERC4626Bpt,
+            vars.vaultBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "Vault ChildPoolERC4626 BPT Balance is wrong"
+        );
+
+        // Vault's parent pool BPT did not change.
+        assertEq(
+            vars.vaultAfter.parentPoolWithWrapperBpt,
+            vars.vaultBefore.parentPoolWithWrapperBpt,
+            "Vault ParentPoolWithWrapper BPT Balance is wrong"
+        );
+
+        // Check ChildPoolERC4626 balances.
+        assertEq(
+            vars.childPoolERC4626After.waDAI,
+            vars.childPoolERC4626Before.waDAI + amountsIn[vars.waDaiIdx],
+            "ChildPoolERC4626 waDAI Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolERC4626After.waWETH,
+            vars.childPoolERC4626Before.waWETH + amountsIn[vars.waWethIdx],
+            "ChildPoolERC4626 waWETH Balance is wrong"
+        );
+
+        // Check ParentPoolWithWrapper balances.
+        assertEq(
+            vars.parentPoolWithWrapperAfter.childPoolERC4626Bpt,
+            vars.parentPoolWithWrapperBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "ParentPoolWithWrapper ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolWithWrapperAfter.waUSDC,
+            vars.parentPoolWithWrapperBefore.waUSDC + amountsIn[vars.waUsdcIdx],
+            "ParentPoolWithWrapper waUSDC Balance is wrong"
+        );
+    }
+
+    function testQueryAddLiquidityNestedERC4626__Fuzz(
+        uint256 daiAmount,
+        uint256 usdcAmount,
+        uint256 wethAmount
+    ) public {
+        daiAmount = bound(daiAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        usdcAmount = bound(usdcAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        wethAmount = bound(wethAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.daiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        address[] memory tokensIn = new address[](3);
+        tokensIn[vars.daiIdx] = address(dai);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+
+        uint256[] memory amountsIn = new uint256[](3);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+
+        _prankStaticCall();
+        uint256 queryBptOut = compositeLiquidityRouter.queryAddLiquidityUnbalancedNestedPool(
+            parentPoolWithWrapper,
+            tokensIn,
+            amountsIn,
+            lp,
+            bytes("")
+        );
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPoolWithWrapper,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+
+        // The actual `addLiquidity` changes rates of the wrappers when performing intermediate wrap / unwrap states,
+        // whereas `query` does not. Then, the final steps of the query are computed based off different values
+        // wrt. the actual operation, which in turn produces a different result. In general, the wrappers will round
+        // in their favor, so the query should produce a result that is more favorable to the user than the actual
+        // operation.
+        assertApproxEqAbs(exactBptOut, queryBptOut, 10, "BPT out do not match");
+        assertLt(exactBptOut, queryBptOut, "Wrapper rounding direction is incorrect");
+    }
+
+    function testAddLiquidityNestedPoolMissingToken() public {
+        uint256 daiAmount = poolInitAmount;
+        uint256 usdcAmount = poolInitAmount;
+        uint256 wethAmount = poolInitAmount;
+        // WstETH token won't be added to the Add Liquidity Unbalanced, but the operation should succeed.
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        vars.daiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        address[] memory tokensIn = new address[](3);
+        tokensIn[vars.daiIdx] = address(dai);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+
+        uint256[] memory amountsIn = new uint256[](3);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPool,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 mintedChildPoolABpt = vars.childPoolAAfter.totalSupply - vars.childPoolABefore.totalSupply;
+        uint256 mintedChildPoolBBpt = vars.childPoolBAfter.totalSupply - vars.childPoolBBefore.totalSupply;
+
+        // Check exact BPT out.
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in.
+        uint256 expectedBptOut = daiAmount + usdcAmount + wethAmount;
+        assertApproxEqAbs(exactBptOut, expectedBptOut, 10, "Exact BPT amount out is wrong");
+        assertLt(exactBptOut, expectedBptOut, "BPT out rounding direction is wrong");
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai - amountsIn[vars.daiIdx], "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth - amountsIn[vars.wethIdx], "LP Weth Balance is wrong");
+        // WstETH is the missing token, so its amount does not change.
+        assertEq(vars.lpAfter.wsteth, vars.lpBefore.wsteth, "LP Wsteth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc - amountsIn[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(vars.lpAfter.childPoolABpt, vars.lpBefore.childPoolABpt, "LP ChildPoolA BPT Balance is wrong");
+        assertEq(vars.lpAfter.childPoolBBpt, vars.lpBefore.childPoolBBpt, "LP ChildPoolB BPT Balance is wrong");
+        assertEq(
+            vars.lpAfter.parentPoolBpt,
+            vars.lpBefore.parentPoolBpt + exactBptOut,
+            "LP ParentPool BPT Balance is wrong"
+        );
+
+        // Check Vault Balances.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai + amountsIn[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth + amountsIn[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(vars.vaultAfter.wsteth, vars.vaultBefore.wsteth, "Vault Wsteth Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc + amountsIn[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        // Since all Child Pool BPT were allocated in the parent pool, vault is holding all of the minted BPT.
+        assertEq(
+            vars.vaultAfter.childPoolABpt,
+            vars.vaultBefore.childPoolABpt + mintedChildPoolABpt,
+            "Vault ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.vaultAfter.childPoolBBpt,
+            vars.vaultBefore.childPoolBBpt + mintedChildPoolBBpt,
+            "Vault ChildPoolB BPT Balance is wrong"
+        );
+        // Vault's parent pool BPT did not change.
+        assertEq(
+            vars.vaultAfter.parentPoolBpt,
+            vars.vaultBefore.parentPoolBpt,
+            "Vault ParentPool BPT Balance is wrong"
+        );
+
+        // Check ChildPoolA balances.
+        assertEq(
+            vars.childPoolAAfter.weth,
+            vars.childPoolABefore.weth + amountsIn[vars.wethIdx],
+            "ChildPoolA Weth Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolAAfter.usdc,
+            vars.childPoolABefore.usdc + amountsIn[vars.usdcIdx],
+            "ChildPoolA Usdc Balance is wrong"
+        );
+
+        // Check ChildPoolB balances.
+        assertApproxEqAbs(
+            vars.childPoolBAfter.dai,
+            vars.childPoolBBefore.dai,
+            MAX_ROUND_ERROR,
+            "ChildPoolB Dai Balance is wrong"
+        );
+        assertEq(vars.childPoolBAfter.wsteth, vars.childPoolBBefore.wsteth, "ChildPoolB Wsteth Balance is wrong");
+
+        // Check ParentPool balances.
+        // The ParentPool's DAI balance does not change since all DAI amount is inserted in the child pool A.
+        assertEq(
+            vars.parentPoolAfter.dai,
+            vars.parentPoolBefore.dai + amountsIn[vars.daiIdx],
+            "ParentPool Dai Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolABpt,
+            vars.parentPoolBefore.childPoolABpt + mintedChildPoolABpt,
+            "ParentPool ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolBBpt,
+            vars.parentPoolBefore.childPoolBBpt + mintedChildPoolBBpt,
+            "ParentPool ChildPoolB BPT Balance is wrong"
+        );
+    }
+
+    function testAddLiquidityNestedPoolBptLimit() public {
+        uint256 daiAmount = poolInitAmount;
+        uint256 usdcAmount = poolInitAmount;
+        uint256 wethAmount = poolInitAmount;
+        uint256 wstEthAmount = poolInitAmount;
+
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in
+        // minus rounding.
+        uint256 expectedBptOut = daiAmount + usdcAmount + wethAmount + wstEthAmount - 7;
+        uint256 minBptOut = 10 * poolInitAmount;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        address[] memory tokensIn = new address[](4);
+        tokensIn[vars.daiIdx] = address(dai);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+        tokensIn[vars.wstethIdx] = address(wsteth);
+
+        uint256[] memory amountsIn = new uint256[](4);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+        amountsIn[vars.wstethIdx] = wstEthAmount;
+
+        vm.prank(lp);
+        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.BptAmountOutBelowMin.selector, expectedBptOut, minBptOut));
+        compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPool,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+    }
+
+    function testAddLiquidityNestedPoolWrongTokenArray() public {
+        uint256 daiAmount = poolInitAmount;
+        uint256 usdcAmount = poolInitAmount;
+        uint256 wethAmount = poolInitAmount;
+        uint256 wstEthAmount = poolInitAmount;
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        address[] memory tokensIn = new address[](3);
+        tokensIn[0] = address(dai);
+        tokensIn[1] = address(usdc);
+        tokensIn[2] = address(weth);
+
+        uint256[] memory amountsIn = new uint256[](4);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+        amountsIn[vars.wstethIdx] = wstEthAmount;
+
+        vm.prank(lp);
+        // Since tokensIn and amountsIn have different lengths, revert.
+        vm.expectRevert(InputHelpers.InputLengthMismatch.selector);
+        compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPool,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+    }
+
+    function testAddLiquidityNestedPoolNonExistentToken() public {
+        ERC20TestToken newToken = new ERC20TestToken("New Token", "NT", 18);
+
+        uint256 daiAmount = poolInitAmount;
+        uint256 usdcAmount = poolInitAmount;
+        uint256 wethAmount = poolInitAmount;
+        uint256 wstEthAmount = poolInitAmount;
+        uint256 newTokenAmount = poolInitAmount;
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        address[] memory tokensIn = new address[](5);
+        tokensIn[vars.daiIdx] = address(dai);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+        tokensIn[vars.wstethIdx] = address(wsteth);
+        tokensIn[4] = address(newToken);
+
+        uint256[] memory amountsIn = new uint256[](5);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+        amountsIn[vars.wstethIdx] = wstEthAmount;
+        amountsIn[4] = newTokenAmount;
+
+        vm.startPrank(lp);
+        // Mints amount to LP, so it can pay for the transaction in the router.
+        newToken.mint(lp, poolInitAmount);
+        // Allow permit2 to move newToken amounts from sender to the router.
+        newToken.approve(address(permit2), type(uint256).max);
+        permit2.approve(address(newToken), address(compositeLiquidityRouter), type(uint160).max, type(uint48).max);
+        // Since user passed a token that was not deposited in any pool, transaction reverts.
+        vm.expectRevert(IVaultErrors.BalanceNotSettled.selector);
+        compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPool,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+        vm.stopPrank();
+    }
+
+    /*******************************************************************************
+                              Remove liquidity
+    *******************************************************************************/
+
+    function testRemoveLiquidityNestedPool__Fuzz(uint256 proportionToRemove) public {
+        // Remove between 0.0001% and 50% of each pool liquidity.
+        proportionToRemove = bound(proportionToRemove, 1e12, 50e16);
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPool).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        // During pool initialization, POOL_MINIMUM_TOTAL_SUPPLY amount of BPT is burned to address(0), so that the
+        // pool cannot be completely drained. We need to discount this amount of tokens from the total liquidity that
+        // we can extract from the child pools.
+        uint256 deadTokens = (POOL_MINIMUM_TOTAL_SUPPLY / 2).mulDown(proportionToRemove);
+
+        address[] memory tokensOut = new address[](4);
+        tokensOut[vars.daiIdx] = address(dai);
+        tokensOut[vars.wethIdx] = address(weth);
+        tokensOut[vars.wstethIdx] = address(wsteth);
+        tokensOut[vars.usdcIdx] = address(usdc);
+
+        uint256[] memory expectedAmountsOut = new uint256[](4);
+        // DAI exists in childPoolB and parentPool, so we expect 2x more DAI than the other tokens.
+        // Since pools are in their initial state, we can use poolInitAmount as the balance of each token in the pool.
+        // Also, we only need to account for deadTokens once, since we calculate the BPT in for the parent pool using
+        // totalSupply (so the burned POOL_MINIMUM_TOTAL_SUPPLY amount does not affect the BPT in circulation, and the
+        // amounts out are perfectly proportional to the parent pool balance).
+        expectedAmountsOut[vars.daiIdx] =
+            (poolInitAmount.mulDown(proportionToRemove) * 2) -
+            deadTokens -
+            MAX_ROUND_ERROR;
+        expectedAmountsOut[vars.wethIdx] = poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR;
+        expectedAmountsOut[vars.wstethIdx] = poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR;
+        expectedAmountsOut[vars.usdcIdx] = poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR;
+
+        vm.prank(lp);
+        uint256[] memory amountsOut = compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPool,
+            exactBptIn,
+            tokensOut,
+            expectedAmountsOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 burnedChildPoolABpt = vars.childPoolABefore.totalSupply - vars.childPoolAAfter.totalSupply;
+        uint256 burnedChildPoolBBpt = vars.childPoolBBefore.totalSupply - vars.childPoolBAfter.totalSupply;
+
+        // Check returned token amounts.
+        assertEq(amountsOut.length, 4, "amountsOut length is wrong");
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.daiIdx],
+            amountsOut[vars.daiIdx],
+            MAX_ROUND_ERROR,
+            "DAI amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.wethIdx],
+            amountsOut[vars.wethIdx],
+            MAX_ROUND_ERROR,
+            "WETH amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.wstethIdx],
+            amountsOut[vars.wstethIdx],
+            MAX_ROUND_ERROR,
+            "WstETH amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.usdcIdx],
+            amountsOut[vars.usdcIdx],
+            MAX_ROUND_ERROR,
+            "USDC amount out is wrong"
+        );
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai + amountsOut[vars.daiIdx], "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth + amountsOut[vars.wethIdx], "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.wsteth, vars.lpBefore.wsteth + amountsOut[vars.wstethIdx], "LP Wsteth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc + amountsOut[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(vars.lpAfter.childPoolABpt, vars.lpBefore.childPoolABpt, "LP ChildPoolA BPT Balance is wrong");
+        assertEq(vars.lpAfter.childPoolBBpt, vars.lpBefore.childPoolBBpt, "LP ChildPoolB BPT Balance is wrong");
+        assertEq(
+            vars.lpAfter.parentPoolBpt,
+            vars.lpBefore.parentPoolBpt - exactBptIn,
+            "LP ParentPool BPT Balance is wrong"
+        );
+
+        // Check Vault Balances.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai - amountsOut[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth - amountsOut[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(
+            vars.vaultAfter.wsteth,
+            vars.vaultBefore.wsteth - amountsOut[vars.wstethIdx],
+            "Vault Wsteth Balance is wrong"
+        );
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc - amountsOut[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        // Since all Child Pool BPT were allocated in the parent pool, vault was holding all of them. Since part of
+        // them was burned when liquidity was removed, we need to discount this amount from the Vault reserves.
+        assertEq(
+            vars.vaultAfter.childPoolABpt,
+            vars.vaultBefore.childPoolABpt - burnedChildPoolABpt,
+            "Vault ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.vaultAfter.childPoolBBpt,
+            vars.vaultBefore.childPoolBBpt - burnedChildPoolBBpt,
+            "Vault ChildPoolB BPT Balance is wrong"
+        );
+        // Vault did not hold the parent pool BPT.
+        assertEq(
+            vars.vaultAfter.parentPoolBpt,
+            vars.vaultBefore.parentPoolBpt,
+            "Vault ParentPool BPT Balance is wrong"
+        );
+
+        // Check ChildPoolA
+        assertEq(
+            vars.childPoolAAfter.weth,
+            vars.childPoolABefore.weth - amountsOut[vars.wethIdx],
+            "ChildPoolA Weth Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolAAfter.usdc,
+            vars.childPoolABefore.usdc - amountsOut[vars.usdcIdx],
+            "ChildPoolA Usdc Balance is wrong"
+        );
+
+        // Check ChildPoolB.
+        // Since DAI amountOut comes from parentPool and childPoolB, we need to calculate the proportion that comes
+        // from childPoolB.
+        assertApproxEqAbs(
+            vars.childPoolBAfter.dai,
+            vars.childPoolBBefore.dai - (amountsOut[vars.daiIdx] - poolInitAmount.mulDown(proportionToRemove)),
+            MAX_ROUND_ERROR,
+            "ChildPoolB Dai Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolBAfter.wsteth,
+            vars.childPoolBBefore.wsteth - amountsOut[vars.wstethIdx],
+            "ChildPoolB Wsteth Balance is wrong"
+        );
+
+        // Check ParentPool.
+        assertApproxEqAbs(
+            vars.parentPoolAfter.dai,
+            vars.parentPoolBefore.dai -
+                (amountsOut[vars.daiIdx] -
+                    (poolInitAmount - (POOL_MINIMUM_TOTAL_SUPPLY / 2)).mulDown(proportionToRemove)),
+            MAX_ROUND_ERROR,
+            "ParentPool Dai Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolABpt,
+            vars.parentPoolBefore.childPoolABpt - burnedChildPoolABpt,
+            "ParentPool ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolBBpt,
+            vars.parentPoolBefore.childPoolBBpt - burnedChildPoolBBpt,
+            "ParentPool ChildPoolB BPT Balance is wrong"
+        );
+    }
+
+    function testRemoveLiquidityNestedPoolWithEth__Fuzz(uint256 proportionToRemove) public {
+        // Remove between 0.0001% and 50% of each pool liquidity.
+        proportionToRemove = bound(proportionToRemove, 1e12, 50e16);
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPool).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        // During pool initialization, POOL_MINIMUM_TOTAL_SUPPLY amount of BPT is burned to address(0), so that the
+        // pool cannot be completely drained. We need to discount this amount of tokens from the total liquidity that
+        // we can extract from the child pools.
+        uint256 deadTokens = (POOL_MINIMUM_TOTAL_SUPPLY / 2).mulDown(proportionToRemove);
+
+        address[] memory tokensOut = new address[](4);
+        tokensOut[vars.daiIdx] = address(dai);
+        tokensOut[vars.wethIdx] = address(weth);
+        tokensOut[vars.wstethIdx] = address(wsteth);
+        tokensOut[vars.usdcIdx] = address(usdc);
+
+        uint256[] memory expectedAmountsOut = new uint256[](4);
+        // DAI exists in childPoolB and parentPool, so we expect 2x more DAI than the other tokens.
+        // Since pools are in their initial state, we can use poolInitAmount as the balance of each token in the pool.
+        // Also, we only need to account for deadTokens once, since we calculate the BPT in for the parent pool using
+        // totalSupply (so the burned POOL_MINIMUM_TOTAL_SUPPLY amount does not affect the BPT in circulation, and the
+        // amounts out are perfectly proportional to the parent pool balance).
+        expectedAmountsOut[vars.daiIdx] =
+            (poolInitAmount.mulDown(proportionToRemove) * 2) -
+            deadTokens -
+            MAX_ROUND_ERROR;
+        expectedAmountsOut[vars.wethIdx] = poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR;
+        expectedAmountsOut[vars.wstethIdx] = poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR;
+        expectedAmountsOut[vars.usdcIdx] = poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR;
+
+        vm.prank(lp);
+        uint256[] memory amountsOut = compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPool,
+            exactBptIn,
+            tokensOut,
+            expectedAmountsOut,
+            true,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 burnedChildPoolABpt = vars.childPoolABefore.totalSupply - vars.childPoolAAfter.totalSupply;
+        uint256 burnedChildPoolBBpt = vars.childPoolBBefore.totalSupply - vars.childPoolBAfter.totalSupply;
+
+        // Check returned token amounts.
+        assertEq(amountsOut.length, 4, "amountsOut length is wrong");
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.daiIdx],
+            amountsOut[vars.daiIdx],
+            MAX_ROUND_ERROR,
+            "DAI amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.wethIdx],
+            amountsOut[vars.wethIdx],
+            MAX_ROUND_ERROR,
+            "WETH amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.wstethIdx],
+            amountsOut[vars.wstethIdx],
+            MAX_ROUND_ERROR,
+            "WstETH amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.usdcIdx],
+            amountsOut[vars.usdcIdx],
+            MAX_ROUND_ERROR,
+            "USDC amount out is wrong"
+        );
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai + amountsOut[vars.daiIdx], "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.wsteth, vars.lpBefore.wsteth + amountsOut[vars.wstethIdx], "LP Wsteth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc + amountsOut[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(vars.lpAfter.childPoolABpt, vars.lpBefore.childPoolABpt, "LP ChildPoolA BPT Balance is wrong");
+        assertEq(vars.lpAfter.childPoolBBpt, vars.lpBefore.childPoolBBpt, "LP ChildPoolB BPT Balance is wrong");
+        assertEq(
+            vars.lpAfter.parentPoolBpt,
+            vars.lpBefore.parentPoolBpt - exactBptIn,
+            "LP ParentPool BPT Balance is wrong"
+        );
+
+        // LP should get ETH instead of WETH.
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth, "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.eth, vars.lpBefore.eth + amountsOut[vars.wethIdx], "LP ETH Balance is wrong");
+
+        // Check Vault Balances.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai - amountsOut[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth - amountsOut[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(
+            vars.vaultAfter.wsteth,
+            vars.vaultBefore.wsteth - amountsOut[vars.wstethIdx],
+            "Vault Wsteth Balance is wrong"
+        );
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc - amountsOut[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        // Since all Child Pool BPT were allocated in the parent pool, vault was holding all of them. Since part of
+        // them was burned when liquidity was removed, we need to discount this amount from the Vault reserves.
+        assertEq(
+            vars.vaultAfter.childPoolABpt,
+            vars.vaultBefore.childPoolABpt - burnedChildPoolABpt,
+            "Vault ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.vaultAfter.childPoolBBpt,
+            vars.vaultBefore.childPoolBBpt - burnedChildPoolBBpt,
+            "Vault ChildPoolB BPT Balance is wrong"
+        );
+        // Vault did not hold the parent pool BPT.
+        assertEq(
+            vars.vaultAfter.parentPoolBpt,
+            vars.vaultBefore.parentPoolBpt,
+            "Vault ParentPool BPT Balance is wrong"
+        );
+
+        // Check ChildPoolA
+        assertEq(
+            vars.childPoolAAfter.weth,
+            vars.childPoolABefore.weth - amountsOut[vars.wethIdx],
+            "ChildPoolA Weth Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolAAfter.usdc,
+            vars.childPoolABefore.usdc - amountsOut[vars.usdcIdx],
+            "ChildPoolA Usdc Balance is wrong"
+        );
+
+        // Check ChildPoolB.
+        // Since DAI amountOut comes from parentPool and childPoolB, we need to calculate the proportion that comes
+        // from childPoolB.
+        assertApproxEqAbs(
+            vars.childPoolBAfter.dai,
+            vars.childPoolBBefore.dai - (amountsOut[vars.daiIdx] - poolInitAmount.mulDown(proportionToRemove)),
+            MAX_ROUND_ERROR,
+            "ChildPoolB Dai Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolBAfter.wsteth,
+            vars.childPoolBBefore.wsteth - amountsOut[vars.wstethIdx],
+            "ChildPoolB Wsteth Balance is wrong"
+        );
+
+        // Check ParentPool.
+        assertApproxEqAbs(
+            vars.parentPoolAfter.dai,
+            vars.parentPoolBefore.dai -
+                (amountsOut[vars.daiIdx] -
+                    (poolInitAmount - (POOL_MINIMUM_TOTAL_SUPPLY / 2)).mulDown(proportionToRemove)),
+            MAX_ROUND_ERROR,
+            "ParentPool Dai Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolABpt,
+            vars.parentPoolBefore.childPoolABpt - burnedChildPoolABpt,
+            "ParentPool ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolBBpt,
+            vars.parentPoolBefore.childPoolBBpt - burnedChildPoolBBpt,
+            "ParentPool ChildPoolB BPT Balance is wrong"
+        );
+
+        assertEq(address(compositeLiquidityRouter).balance, 0, "Router has eth balance");
+    }
+
+    function testRemoveLiquidityNestedERC4626Pool__Fuzz(uint256 proportionToRemove) public {
+        // Remove between 0.0001% and 50% of each pool liquidity.
+        proportionToRemove = bound(proportionToRemove, 1e12, 50e16);
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPoolWithWrapper).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.daiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        // During pool initialization, POOL_MINIMUM_TOTAL_SUPPLY amount of BPT is burned to address(0), so that the
+        // pool cannot be completely drained. We need to discount this amount of tokens from the total liquidity that
+        // we can extract from the child pools.
+        uint256 deadTokens = (POOL_MINIMUM_TOTAL_SUPPLY / 4).mulDown(proportionToRemove);
+
+        address[] memory tokensOut = new address[](3);
+        tokensOut[vars.daiIdx] = address(dai);
+        tokensOut[vars.wethIdx] = address(weth);
+        tokensOut[vars.usdcIdx] = address(usdc);
+
+        uint256[] memory expectedAmountsOut = new uint256[](3);
+        // Since pools are in their initial state, we can use poolInitAmount as the balance of each token in the pool.
+        // Also, we only need to account for deadTokens once, since we calculate the BPT in for the parent pool using
+        // totalSupply (so the burned POOL_MINIMUM_TOTAL_SUPPLY amount does not affect the BPT in circulation, and the
+        // amounts out are perfectly proportional to the parent pool balance).
+        expectedAmountsOut[vars.daiIdx] = _vaultPreviewRedeem(
+            waDAI,
+            poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR
+        );
+        expectedAmountsOut[vars.wethIdx] = _vaultPreviewRedeem(
+            waWETH,
+            poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR
+        );
+        expectedAmountsOut[vars.usdcIdx] = _vaultPreviewRedeem(
+            waUSDC,
+            poolInitAmount.mulDown(proportionToRemove) - MAX_ROUND_ERROR
+        );
+
+        vm.prank(lp);
+        uint256[] memory amountsOut = compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPoolWithWrapper,
+            exactBptIn,
+            tokensOut,
+            expectedAmountsOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 burnedChildPoolERC4626Bpt = vars.childPoolERC4626Before.totalSupply -
+            vars.childPoolERC4626After.totalSupply;
+
+        // Check returned token amounts.
+        assertEq(amountsOut.length, 3, "amountsOut length is wrong");
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.daiIdx],
+            amountsOut[vars.daiIdx],
+            6 * MAX_ROUND_ERROR, // Increasing error because of ERC4626 conversion rounding
+            "DAI amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.wethIdx],
+            amountsOut[vars.wethIdx],
+            6 * MAX_ROUND_ERROR, // Increasing error because of ERC4626 conversion rounding
+            "WETH amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.usdcIdx],
+            amountsOut[vars.usdcIdx],
+            6 * MAX_ROUND_ERROR, // Increasing error because of ERC4626 conversion rounding
+            "USDC amount out is wrong"
+        );
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai + amountsOut[vars.daiIdx], "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth + amountsOut[vars.wethIdx], "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc + amountsOut[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(
+            vars.lpAfter.childPoolERC4626Bpt,
+            vars.lpBefore.childPoolERC4626Bpt,
+            "LP ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.lpAfter.parentPoolWithWrapperBpt,
+            vars.lpBefore.parentPoolWithWrapperBpt - exactBptIn,
+            "LP ParentPool BPT Balance is wrong"
+        );
+
+        // Check Vault Balances. Since the buffer has liquidity, the Vault only lost underlying amounts.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai - amountsOut[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.waDAI, vars.vaultBefore.waDAI, "Vault waDai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth - amountsOut[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(vars.vaultAfter.waWETH, vars.vaultBefore.waWETH, "Vault waWETH Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc - amountsOut[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        assertEq(vars.vaultAfter.waUSDC, vars.vaultBefore.waUSDC, "Vault waUSDC Balance is wrong");
+
+        // Since all Child Pool BPT were allocated in the parent pool, vault was holding all of them. Since part of
+        // them was burned when liquidity was removed, we need to discount this amount from the Vault reserves.
+        assertEq(
+            vars.vaultAfter.childPoolERC4626Bpt,
+            vars.vaultBefore.childPoolERC4626Bpt - burnedChildPoolERC4626Bpt,
+            "Vault childPoolERC4626 BPT Balance is wrong"
+        );
+
+        // Vault did not hold the parent pool BPT.
+        assertEq(
+            vars.vaultAfter.parentPoolWithWrapperBpt,
+            vars.vaultBefore.parentPoolWithWrapperBpt,
+            "Vault ParentPoolWithWrapper BPT Balance is wrong"
+        );
+
+        // Check ChildPoolERC4626
+        assertEq(
+            vars.childPoolERC4626After.waWETH,
+            vars.childPoolERC4626Before.waWETH - _vaultPreviewWithdraw(waWETH, amountsOut[vars.wethIdx]),
+            "ChildPoolERC4626 Weth Balance is wrong"
+        );
+        assertApproxEqAbs(
+            vars.childPoolERC4626After.waDAI,
+            vars.childPoolERC4626Before.waDAI - _vaultPreviewWithdraw(waDAI, amountsOut[vars.daiIdx]),
+            MAX_ROUND_ERROR,
+            "ChildPoolERC4626 waDAI Balance is wrong"
+        );
+
+        // Check ParentPoolWithWrapper.
+        assertApproxEqAbs(
+            vars.parentPoolWithWrapperAfter.waUSDC,
+            vars.parentPoolWithWrapperBefore.waUSDC - _vaultPreviewWithdraw(waUSDC, amountsOut[vars.usdcIdx]),
+            MAX_ROUND_ERROR,
+            "ParentPoolWithWrapper waUSDC Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolWithWrapperAfter.childPoolERC4626Bpt,
+            vars.parentPoolWithWrapperBefore.childPoolERC4626Bpt - burnedChildPoolERC4626Bpt,
+            "ParentPool ChildPoolERC4626 BPT Balance is wrong"
+        );
+    }
+
+    function testRemoveLiquidityNestedERC4626PoolWithEth__Fuzz(uint256 proportionToRemove) public {
+        // Remove between 0.0001% and 50% of each pool liquidity.
+        proportionToRemove = bound(proportionToRemove, 1e12, 50e16);
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPoolWithWrapper).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.daiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        // During pool initialization, POOL_MINIMUM_TOTAL_SUPPLY amount of BPT is burned to address(0), so that the
+        // pool cannot be completely drained. We need to discount this amount of tokens from the total liquidity that
+        // we can extract from the child pools.
+        uint256 deadTokens = (POOL_MINIMUM_TOTAL_SUPPLY / 4).mulDown(proportionToRemove);
+
+        address[] memory tokensOut = new address[](3);
+        tokensOut[vars.daiIdx] = address(dai);
+        tokensOut[vars.wethIdx] = address(weth);
+        tokensOut[vars.usdcIdx] = address(usdc);
+
+        uint256[] memory expectedAmountsOut = new uint256[](3);
+        // Since pools are in their initial state, we can use poolInitAmount as the balance of each token in the pool.
+        // Also, we only need to account for deadTokens once, since we calculate the BPT in for the parent pool using
+        // totalSupply (so the burned POOL_MINIMUM_TOTAL_SUPPLY amount does not affect the BPT in circulation, and the
+        // amounts out are perfectly proportional to the parent pool balance).
+        expectedAmountsOut[vars.daiIdx] = _vaultPreviewRedeem(
+            waDAI,
+            poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR
+        );
+        expectedAmountsOut[vars.wethIdx] = _vaultPreviewRedeem(
+            waWETH,
+            poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR
+        );
+        expectedAmountsOut[vars.usdcIdx] = _vaultPreviewRedeem(
+            waUSDC,
+            poolInitAmount.mulDown(proportionToRemove) - MAX_ROUND_ERROR
+        );
+
+        vm.prank(lp);
+        uint256[] memory amountsOut = compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPoolWithWrapper,
+            exactBptIn,
+            tokensOut,
+            expectedAmountsOut,
+            true,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 burnedChildPoolERC4626Bpt = vars.childPoolERC4626Before.totalSupply -
+            vars.childPoolERC4626After.totalSupply;
+
+        // Check returned token amounts.
+        assertEq(amountsOut.length, 3, "amountsOut length is wrong");
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.daiIdx],
+            amountsOut[vars.daiIdx],
+            6 * MAX_ROUND_ERROR, // Increasing error because of ERC4626 conversion rounding
+            "DAI amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.wethIdx],
+            amountsOut[vars.wethIdx],
+            6 * MAX_ROUND_ERROR, // Increasing error because of ERC4626 conversion rounding
+            "WETH amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.usdcIdx],
+            amountsOut[vars.usdcIdx],
+            6 * MAX_ROUND_ERROR, // Increasing error because of ERC4626 conversion rounding
+            "USDC amount out is wrong"
+        );
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai + amountsOut[vars.daiIdx], "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc + amountsOut[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(
+            vars.lpAfter.childPoolERC4626Bpt,
+            vars.lpBefore.childPoolERC4626Bpt,
+            "LP ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.lpAfter.parentPoolWithWrapperBpt,
+            vars.lpBefore.parentPoolWithWrapperBpt - exactBptIn,
+            "LP ParentPool BPT Balance is wrong"
+        );
+
+        // LP should get ETH instead of WETH.
+        assertEq(vars.lpAfter.eth, vars.lpBefore.eth + amountsOut[vars.wethIdx], "LP Eth Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth, "LP Weth Balance is wrong");
+
+        // Check Vault Balances. Since the buffer has liquidity, the Vault only lost underlying amounts.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai - amountsOut[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.waDAI, vars.vaultBefore.waDAI, "Vault waDai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth - amountsOut[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(vars.vaultAfter.waWETH, vars.vaultBefore.waWETH, "Vault waWETH Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc - amountsOut[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        assertEq(vars.vaultAfter.waUSDC, vars.vaultBefore.waUSDC, "Vault waUSDC Balance is wrong");
+
+        // Since all Child Pool BPT were allocated in the parent pool, vault was holding all of them. Since part of
+        // them was burned when liquidity was removed, we need to discount this amount from the Vault reserves.
+        assertEq(
+            vars.vaultAfter.childPoolERC4626Bpt,
+            vars.vaultBefore.childPoolERC4626Bpt - burnedChildPoolERC4626Bpt,
+            "Vault childPoolERC4626 BPT Balance is wrong"
+        );
+
+        // Vault did not hold the parent pool BPT.
+        assertEq(
+            vars.vaultAfter.parentPoolWithWrapperBpt,
+            vars.vaultBefore.parentPoolWithWrapperBpt,
+            "Vault ParentPoolWithWrapper BPT Balance is wrong"
+        );
+
+        // Check ChildPoolERC4626
+        assertEq(
+            vars.childPoolERC4626After.waWETH,
+            vars.childPoolERC4626Before.waWETH - _vaultPreviewWithdraw(waWETH, amountsOut[vars.wethIdx]),
+            "ChildPoolERC4626 Weth Balance is wrong"
+        );
+        assertApproxEqAbs(
+            vars.childPoolERC4626After.waDAI,
+            vars.childPoolERC4626Before.waDAI - _vaultPreviewWithdraw(waDAI, amountsOut[vars.daiIdx]),
+            MAX_ROUND_ERROR,
+            "ChildPoolERC4626 waDAI Balance is wrong"
+        );
+
+        // Check ParentPoolWithWrapper.
+        assertApproxEqAbs(
+            vars.parentPoolWithWrapperAfter.waUSDC,
+            vars.parentPoolWithWrapperBefore.waUSDC - _vaultPreviewWithdraw(waUSDC, amountsOut[vars.usdcIdx]),
+            MAX_ROUND_ERROR,
+            "ParentPoolWithWrapper waUSDC Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolWithWrapperAfter.childPoolERC4626Bpt,
+            vars.parentPoolWithWrapperBefore.childPoolERC4626Bpt - burnedChildPoolERC4626Bpt,
+            "ParentPool ChildPoolERC4626 BPT Balance is wrong"
+        );
+
+        assertEq(address(compositeLiquidityRouter).balance, 0, "Router has eth balance");
+    }
+
+    function testQueryRemoveLiquidityNestedERC4626Pool__Fuzz(uint256 proportionToRemove) public {
+        // Remove between 0.0001% and 50% of each pool liquidity.
+        proportionToRemove = bound(proportionToRemove, 1e12, 50e16);
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPoolWithWrapper).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.daiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        // During pool initialization, POOL_MINIMUM_TOTAL_SUPPLY amount of BPT is burned to address(0), so that the
+        // pool cannot be completely drained. We need to discount this amount of tokens from the total liquidity that
+        // we can extract from the child pools.
+        uint256 deadTokens = (POOL_MINIMUM_TOTAL_SUPPLY / 4).mulDown(proportionToRemove);
+
+        address[] memory tokensOut = new address[](3);
+        tokensOut[vars.daiIdx] = address(dai);
+        tokensOut[vars.wethIdx] = address(weth);
+        tokensOut[vars.usdcIdx] = address(usdc);
+
+        uint256[] memory expectedAmountsOut = new uint256[](3);
+        // Since pools are in their initial state, we can use poolInitAmount as the balance of each token in the pool.
+        // Also, we only need to account for deadTokens once, since we calculate the BPT in for the parent pool using
+        // totalSupply (so the burned POOL_MINIMUM_TOTAL_SUPPLY amount does not affect the BPT in circulation, and the
+        // amounts out are perfectly proportional to the parent pool balance).
+        expectedAmountsOut[vars.daiIdx] = _vaultPreviewRedeem(
+            waDAI,
+            poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR
+        );
+        expectedAmountsOut[vars.wethIdx] = _vaultPreviewRedeem(
+            waWETH,
+            poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR
+        );
+        expectedAmountsOut[vars.usdcIdx] = _vaultPreviewRedeem(
+            waUSDC,
+            poolInitAmount.mulDown(proportionToRemove) - MAX_ROUND_ERROR
+        );
+
+        uint256 snapshotId = vm.snapshot();
+        _prankStaticCall();
+        uint256[] memory queryAmountsOut = compositeLiquidityRouter.queryRemoveLiquidityProportionalNestedPool(
+            parentPoolWithWrapper,
+            exactBptIn,
+            tokensOut,
+            address(this),
+            bytes("")
+        );
+        vm.revertTo(snapshotId);
+
+        vm.prank(lp);
+        uint256[] memory amountsOut = compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPoolWithWrapper,
+            exactBptIn,
+            tokensOut,
+            expectedAmountsOut,
+            false,
+            bytes("")
+        );
+
+        for (uint256 i = 0; i < amountsOut.length; i++) {
+            assertEq(amountsOut[i], queryAmountsOut[i], "AmountsOut and QueryAmountsOut do not match");
+        }
+    }
+
+    function testRemoveLiquidityNestedPoolLimits() public {
+        // Remove 10% of pool liquidity.
+        uint256 proportionToRemove = 10e16;
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPool).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        // During pool initialization, POOL_MINIMUM_TOTAL_SUPPLY amount of BPT is burned to address(0), so that the
+        // pool cannot be completely drained. We need to discount this amount of tokens from the total liquidity that
+        // we can extract from the child pools.
+        uint256 deadTokens = (POOL_MINIMUM_TOTAL_SUPPLY / 2).mulDown(proportionToRemove);
+
+        address[] memory tokensOut = new address[](4);
+        tokensOut[vars.daiIdx] = address(dai);
+        tokensOut[vars.wethIdx] = address(weth);
+        tokensOut[vars.wstethIdx] = address(wsteth);
+        tokensOut[vars.usdcIdx] = address(usdc);
+
+        uint256[] memory minAmountsOut = new uint256[](4);
+        // Expect minAmountsOut to be the liquidity of the pool, which is more than what we should return,
+        // causing it to revert.
+        minAmountsOut[vars.daiIdx] = poolInitAmount;
+        minAmountsOut[vars.wethIdx] = poolInitAmount;
+        minAmountsOut[vars.wstethIdx] = poolInitAmount;
+        minAmountsOut[vars.usdcIdx] = poolInitAmount;
+
+        // DAI exists in childPoolB and parentPool, so we expect 2x more DAI than the other tokens.
+        // Since pools are in their initial state, we can use poolInitAmount as the balance of each token in the pool.
+        // Also, we only need to account for deadTokens once, since we calculate the BPT in for the parent pool using
+        // totalSupply (so the burned POOL_MINIMUM_TOTAL_SUPPLY amount does not affect the BPT in circulation, and the
+        // amounts out are perfectly proportional to the parent pool balance).
+
+        uint256 daiExpectedAmountOut = (poolInitAmount.mulDown(proportionToRemove) * 2) - deadTokens;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IVaultErrors.AmountOutBelowMin.selector,
+                address(dai),
+                daiExpectedAmountOut,
+                poolInitAmount
+            )
+        );
+        vm.prank(lp);
+        compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPool,
+            exactBptIn,
+            tokensOut,
+            minAmountsOut,
+            false,
+            bytes("")
+        );
+    }
+
+    function testRemoveLiquidityNestedPoolWrongMinAmountsOut() public {
+        // Remove 10% of pool liquidity.
+        uint256 proportionToRemove = 10e16;
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPool).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        address[] memory tokensOut = new address[](4);
+        tokensOut[vars.daiIdx] = address(dai);
+        tokensOut[vars.wethIdx] = address(weth);
+        tokensOut[vars.wstethIdx] = address(wsteth);
+        tokensOut[vars.usdcIdx] = address(usdc);
+
+        // Notice that minAmountsOut have a different length than tokensOut, so the transaction should revert.
+        uint256[] memory minAmountsOut = new uint256[](3);
+        minAmountsOut[0] = 1;
+        minAmountsOut[1] = 1;
+        minAmountsOut[2] = 1;
+
+        vm.expectRevert(InputHelpers.InputLengthMismatch.selector);
+
+        vm.prank(lp);
+        compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPool,
+            exactBptIn,
+            tokensOut,
+            minAmountsOut,
+            false,
+            bytes("")
+        );
+    }
+
+    function testRemoveLiquidityNestedPoolWrongTokenArray() public {
+        // Remove 10% of pool liquidity.
+        uint256 proportionToRemove = 10e16;
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPool).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        // DAI should be in the tokensOut array, but is not, so the transaction should revert.
+        // Order extracted from _currentSwapTokensOut().values() of `removeLiquidityProportionalNestedPool` after
+        // all child pools were called.
+        address[] memory expectedTokensOut = new address[](4);
+        expectedTokensOut[0] = address(dai);
+        expectedTokensOut[1] = address(wsteth);
+        expectedTokensOut[2] = address(weth);
+        expectedTokensOut[3] = address(usdc);
+
+        // Notice that tokensOut and minAmountsOut do not have DAI, so the transaction will revert.
+        address[] memory tokensOut = new address[](3);
+        tokensOut[0] = address(weth);
+        tokensOut[1] = address(wsteth);
+        tokensOut[2] = address(usdc);
+
+        uint256[] memory minAmountsOut = new uint256[](3);
+        minAmountsOut[0] = 1;
+        minAmountsOut[1] = 1;
+        minAmountsOut[2] = 1;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(ICompositeLiquidityRouter.WrongTokensOut.selector, expectedTokensOut, tokensOut)
+        );
+
+        vm.prank(lp);
+        compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPool,
+            exactBptIn,
+            tokensOut,
+            minAmountsOut,
+            false,
+            bytes("")
+        );
+    }
+
+    function testRemoveLiquidityNestedPoolRepeatedTokens() public {
+        // Remove 10% of pool liquidity.
+        uint256 proportionToRemove = 10e16;
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPool).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        // DAI should be in the tokensOut array, but is not, so the transaction should revert.
+        // Order extracted from _currentSwapTokensOut().values() of `removeLiquidityProportionalNestedPool` after
+        // all child pools were called.
+        address[] memory expectedTokensOut = new address[](4);
+        expectedTokensOut[0] = address(dai);
+        expectedTokensOut[1] = address(wsteth);
+        expectedTokensOut[2] = address(weth);
+        expectedTokensOut[3] = address(usdc);
+
+        // Notice that tokensOut has a repeated token, so the transaction should be reverted.
+        address[] memory tokensOut = new address[](4);
+        tokensOut[0] = address(dai);
+        tokensOut[1] = address(weth);
+        tokensOut[2] = address(dai);
+        tokensOut[3] = address(usdc);
+
+        uint256[] memory minAmountsOut = new uint256[](4);
+        minAmountsOut[0] = 1;
+        minAmountsOut[1] = 1;
+        minAmountsOut[2] = 1;
+        minAmountsOut[3] = 1;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(ICompositeLiquidityRouter.WrongTokensOut.selector, expectedTokensOut, tokensOut)
+        );
+
+        vm.prank(lp);
+        compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPool,
+            exactBptIn,
+            tokensOut,
+            minAmountsOut,
+            false,
+            bytes("")
+        );
+    }
+
+    struct NestedPoolTestLocals {
+        uint256 daiIdx;
+        uint256 wethIdx;
+        uint256 wstethIdx;
+        uint256 usdcIdx;
+        uint256 waDaiIdx;
+        uint256 waWethIdx;
+        uint256 waUsdcIdx;
+        TokenBalances lpBefore;
+        TokenBalances lpAfter;
+        TokenBalances vaultBefore;
+        TokenBalances vaultAfter;
+        TokenBalances childPoolABefore;
+        TokenBalances childPoolAAfter;
+        TokenBalances childPoolBBefore;
+        TokenBalances childPoolBAfter;
+        TokenBalances childPoolERC4626Before;
+        TokenBalances childPoolERC4626After;
+        TokenBalances parentPoolBefore;
+        TokenBalances parentPoolAfter;
+        TokenBalances parentPoolWithoutWrapperBefore;
+        TokenBalances parentPoolWithoutWrapperAfter;
+        TokenBalances parentPoolWithWrapperBefore;
+        TokenBalances parentPoolWithWrapperAfter;
+    }
+
+    struct TokenBalances {
+        uint256 dai;
+        uint256 eth;
+        uint256 weth;
+        uint256 wsteth;
+        uint256 usdc;
+        uint256 waDAI;
+        uint256 waWETH;
+        uint256 waUSDC;
+        uint256 childPoolABpt;
+        uint256 childPoolBBpt;
+        uint256 childPoolERC4626Bpt;
+        uint256 parentPoolBpt;
+        uint256 parentPoolWithoutWrapperBpt;
+        uint256 parentPoolWithWrapperBpt;
+        uint256 totalSupply;
+    }
+
+    function _createNestedPoolTestLocals() private view returns (NestedPoolTestLocals memory vars) {
+        // Create output token indexes, randomly chosen (no sort logic).
+        (vars.daiIdx, vars.wethIdx, vars.wstethIdx, vars.usdcIdx) = (0, 1, 2, 3);
+
+        vars.lpBefore = _getBalances(lp);
+        vars.vaultBefore = _getBalances(address(vault));
+        vars.childPoolABefore = _getPoolBalances(childPoolA);
+        vars.childPoolBBefore = _getPoolBalances(childPoolB);
+        vars.childPoolERC4626Before = _getPoolBalances(childPoolERC4626);
+        vars.parentPoolBefore = _getPoolBalances(parentPool);
+        vars.parentPoolWithoutWrapperBefore = _getPoolBalances(parentPoolWithoutWrapper);
+        vars.parentPoolWithWrapperBefore = _getPoolBalances(parentPoolWithWrapper);
+    }
+
+    function _fillNestedPoolTestLocalsAfter(NestedPoolTestLocals memory vars) private view {
+        vars.lpAfter = _getBalances(lp);
+        vars.vaultAfter = _getBalances(address(vault));
+        vars.childPoolAAfter = _getPoolBalances(childPoolA);
+        vars.childPoolBAfter = _getPoolBalances(childPoolB);
+        vars.childPoolERC4626After = _getPoolBalances(childPoolERC4626);
+        vars.parentPoolAfter = _getPoolBalances(parentPool);
+        vars.parentPoolWithoutWrapperAfter = _getPoolBalances(parentPoolWithoutWrapper);
+        vars.parentPoolWithWrapperAfter = _getPoolBalances(parentPoolWithWrapper);
+    }
+
+    function _getBalances(address entity) private view returns (TokenBalances memory balances) {
+        balances.dai = dai.balanceOf(entity);
+        balances.eth = entity.balance;
+        balances.weth = weth.balanceOf(entity);
+        balances.wsteth = wsteth.balanceOf(entity);
+        balances.usdc = usdc.balanceOf(entity);
+        balances.waDAI = waDAI.balanceOf(entity);
+        balances.waWETH = waWETH.balanceOf(entity);
+        balances.waUSDC = waUSDC.balanceOf(entity);
+        balances.childPoolABpt = IERC20(childPoolA).balanceOf(entity);
+        balances.childPoolBBpt = IERC20(childPoolB).balanceOf(entity);
+        balances.childPoolERC4626Bpt = IERC20(childPoolERC4626).balanceOf(entity);
+        balances.parentPoolBpt = IERC20(parentPool).balanceOf(entity);
+        balances.parentPoolWithoutWrapperBpt = IERC20(parentPoolWithoutWrapper).balanceOf(entity);
+        balances.parentPoolWithWrapperBpt = IERC20(parentPoolWithWrapper).balanceOf(entity);
+    }
+
+    function _getPoolBalances(address pool) private view returns (TokenBalances memory balances) {
+        (IERC20[] memory tokens, , uint256[] memory poolBalances, ) = vault.getPoolTokenInfo(pool);
+        for (uint256 i = 0; i < tokens.length; i++) {
+            IERC20 currentToken = tokens[i];
+            if (currentToken == dai) {
+                balances.dai = poolBalances[i];
+            } else if (currentToken == weth) {
+                balances.weth = poolBalances[i];
+            } else if (currentToken == wsteth) {
+                balances.wsteth = poolBalances[i];
+            } else if (currentToken == IERC20(address(waDAI))) {
+                balances.waDAI = poolBalances[i];
+            } else if (currentToken == IERC20(address(waUSDC))) {
+                balances.waUSDC = poolBalances[i];
+            } else if (currentToken == IERC20(address(waWETH))) {
+                balances.waWETH = poolBalances[i];
+            } else if (currentToken == usdc) {
+                balances.usdc = poolBalances[i];
+            } else if (currentToken == IERC20(childPoolA)) {
+                balances.childPoolABpt = poolBalances[i];
+            } else if (currentToken == IERC20(childPoolB)) {
+                balances.childPoolBBpt = poolBalances[i];
+            } else if (currentToken == IERC20(childPoolERC4626)) {
+                balances.childPoolERC4626Bpt = poolBalances[i];
+            }
+        }
+
+        balances.totalSupply = BalancerPoolToken(pool).totalSupply();
+    }
+}


### PR DESCRIPTION
# Description

By request, splitting into smaller PRs...

-----

This restores nested pool functionality to the CLR. It does not change the interface from the original code, which already automatically checked for an initialized buffer to detect ERC4626.

I also simply restored the old tests, without even looking at them, and just made sure they all passed so that we had semantic equivalence. This is a first pass with the goal of restoring the functionality while simplifying the code; I've still not looked at limits or tried to expand the tests.

The main simplifications are:
1) Removing recursion in add liquidity, as this is not supported on all chains

2) Replacing big "wrap/unwrapIfRequired" functions with smaller (and hopefully clearer) processTokenIn/Out functions, also preventing functions from being unnecessarily called multiple times within loops

3) Factoring out lots of code and sets of data that were used frequently, like parameters common to all functions (RouterCallParams), validating query parameters uniformly, "building" query params to avoid passing data around where several of the arguments were always the same, and centralizing token "interpretation" (ERC20, ERC4626, BPT) into an enum, to avoid lots of repetitive Vault calls. This defines an enum and some structures, and uses them for internal functions. (No interface changes, as noted above.)

I also organized the code into ERC4626, ERC4626 hooks, ERC4626 helpers; followed by the same for nested pools, for clarity.

The diff isn't very legible. I made the changes incrementally, so it might be better to review commit by commit.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Resolves #1256 
