### PR TITLE
Restore nested pool functionality to the CLR

### DIFF
--- a/pkg/interfaces/contracts/vault/ICompositeLiquidityRouter.sol
+++ b/pkg/interfaces/contracts/vault/ICompositeLiquidityRouter.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.24;
 
 /**
- * @notice The composite liquidity router supports add/remove liquidity operations on ERC4626 pools.
+ * @notice The composite liquidity router supports add/remove liquidity operations on ERC4626 and nested pools.
  * @dev This contract allow interacting with ERC4626 Pools (which contain wrapped ERC4626 tokens) using only underlying
  * standard tokens. For instance, with `addLiquidityUnbalancedToERC4626Pool` it is possible to add liquidity to an
  * ERC4626 Pool with [waDAI, waUSDC], using only DAI, only USDC, or an arbitrary amount of both. If the ERC4626 buffers
@@ -146,4 +146,86 @@ interface ICompositeLiquidityRouter {
         address sender,
         bytes memory userData
     ) external returns (address[] memory tokensOut, uint256[] memory amountsOut);
+
+    /***************************************************************************
+                                   Nested pools
+    ***************************************************************************/
+
+    /**
+     * @notice Adds liquidity unbalanced to a nested pool.
+     * @dev A nested pool is one in which one or more tokens are BPTs from another pool (child pool). Since there are
+     * multiple pools involved, the token order is not well-defined, and must be specified by the caller.
+     *
+     * @param parentPool The address of the parent pool (which contains BPTs of other pools)
+     * @param tokensIn An array with all tokens from the child pools, and all non-BPT parent tokens, in arbitrary order
+     * @param exactAmountsIn An array with the amountIn of each token, sorted in the same order as tokensIn
+     * @param minBptAmountOut Expected minimum amount of parent pool tokens to receive
+     * @param wethIsEth If true, incoming ETH will be wrapped to WETH and outgoing WETH will be unwrapped to ETH
+     * @param userData Additional (optional) data required for the operation
+     * @return bptAmountOut The actual amount of parent pool tokens received
+     */
+    function addLiquidityUnbalancedNestedPool(
+        address parentPool,
+        address[] memory tokensIn,
+        uint256[] memory exactAmountsIn,
+        uint256 minBptAmountOut,
+        bool wethIsEth,
+        bytes memory userData
+    ) external payable returns (uint256 bptAmountOut);
+
+    /**
+     * @notice Queries an `addLiquidityUnbalancedNestedPool` operation without actually executing it.
+     * @param parentPool The address of the parent pool (which contains BPTs of other pools)
+     * @param tokensIn An array with all tokens from the child pools, and all non-BPT parent tokens, in arbitrary order
+     * @param exactAmountsIn An array with the amountIn of each token, sorted in the same order as tokensIn
+     * @param sender The sender passed to the operation. It can influence results (e.g., with user-dependent hooks)
+     * @param userData Additional (optional) data required for the operation
+     * @return bptAmountOut The actual amount of parent pool tokens received
+     */
+    function queryAddLiquidityUnbalancedNestedPool(
+        address parentPool,
+        address[] memory tokensIn,
+        uint256[] memory exactAmountsIn,
+        address sender,
+        bytes memory userData
+    ) external returns (uint256 bptAmountOut);
+
+    /**
+     * @notice Removes liquidity from a nested pool.
+     * @dev A nested pool is one in which one or more tokens are BPTs from another pool (child pool). Since there are
+     * multiple pools involved, the token order is not well-defined, and must be specified by the caller.
+     *
+     * @param parentPool The address of the parent pool (which contains BPTs of other pools)
+     * @param exactBptAmountIn The exact amount of `parentPool` tokens provided
+     * @param tokensOut An array with all tokens from the child pools, and all non-BPT parent tokens, in arbitrary order
+     * @param minAmountsOut An array with the minimum amountOut of each token, sorted in the same order as tokensOut
+     * @param wethIsEth If true, incoming ETH will be wrapped to WETH and outgoing WETH will be unwrapped to ETH
+     * @param userData Additional (optional) data required for the operation
+     * @return amountsOut An array with the actual amountOut of each token, sorted in the same order as tokensOut
+     */
+    function removeLiquidityProportionalNestedPool(
+        address parentPool,
+        uint256 exactBptAmountIn,
+        address[] memory tokensOut,
+        uint256[] memory minAmountsOut,
+        bool wethIsEth,
+        bytes memory userData
+    ) external payable returns (uint256[] memory amountsOut);
+
+    /**
+     * @notice Queries an `removeLiquidityProportionalNestedPool` operation without actually executing it.
+     * @param parentPool The address of the parent pool (which contains BPTs of other pools)
+     * @param exactBptAmountIn The exact amount of `parentPool` tokens provided
+     * @param tokensOut An array with all tokens from the child pools, and all non-BPT parent tokens, in arbitrary order
+     * @param sender The sender passed to the operation. It can influence results (e.g., with user-dependent hooks)
+     * @param userData Additional (optional) data required for the operation
+     * @return amountsOut An array with the expected amountOut of each token, sorted in the same order as tokensOut
+     */
+    function queryRemoveLiquidityProportionalNestedPool(
+        address parentPool,
+        uint256 exactBptAmountIn,
+        address[] memory tokensOut,
+        address sender,
+        bytes memory userData
+    ) external returns (uint256[] memory amountsOut);
 }

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -23,7 +23,7 @@ import {
 import { BatchRouterCommon } from "./BatchRouterCommon.sol";
 
 /**
- * @notice Entrypoint for add/remove liquidity operations on ERC4626 pools.
+ * @notice Entrypoint for add/remove liquidity operations on ERC4626 and nested pools.
  * @dev The external API functions unlock the Vault, which calls back into the corresponding hook functions.
  * These execute the steps needed to add to and remove liquidity from these special types of pools, and settle
  * the operation with the Vault.
@@ -31,6 +31,21 @@ import { BatchRouterCommon } from "./BatchRouterCommon.sol";
 contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommon {
     using TransientEnumerableSet for TransientEnumerableSet.AddressSet;
     using TransientStorageHelpers for *;
+
+    // Token types for nested pools.
+    enum CompositeTokenType {
+        ERC20,
+        BPT,
+        ERC4626
+    }
+
+    // Factor out common parameters used for adding liquidity.
+    struct CompositeTokenInfo {
+        address token;
+        CompositeTokenType tokenType;
+        uint256 amount;
+        bool needToWrap;
+    }
 
     // Factor out common parameters used in internal liquidity functions.
     struct RouterCallParams {
@@ -208,7 +223,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
         RemoveLiquidityHookParams memory params = _buildQueryRemoveLiquidityParams(
             pool,
             exactBptAmountIn,
-            new uint256[](erc4626PoolTokens.length),
+            erc4626PoolTokens.length,
             userData
         );
 
@@ -601,6 +616,432 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
         _vault.settle(IERC20(address(wrappedToken)), wrappedAmount);
     }
 
+    /**
+     * @notice Centralized handler for ERC4626 unwrapping operations.
+     * @param wrappedToken The ERC4626 token to unwrap from
+     * @param wrappedAmount Amount of wrapped tokens to unwrap
+     * @return underlyingAmount Amount of underlying tokens received
+     */
+    function _executeUnwrapOperation(
+        IERC4626 wrappedToken,
+        uint256 wrappedAmount
+    ) internal returns (uint256 underlyingAmount) {
+        if (wrappedAmount == 0) {
+            return 0;
+        }
+
+        (, , underlyingAmount) = _vault.erc4626BufferWrapOrUnwrap(
+            BufferWrapOrUnwrapParams({
+                kind: SwapKind.EXACT_IN,
+                direction: WrappingDirection.UNWRAP,
+                wrappedToken: wrappedToken,
+                amountGivenRaw: wrappedAmount,
+                limitRaw: 0
+            })
+        );
+
+        address underlyingToken = _vault.getERC4626BufferAsset(wrappedToken);
+        _currentSwapTokensOut().add(underlyingToken);
+        _currentSwapTokenOutAmounts().tAdd(underlyingToken, underlyingAmount);
+    }
+
+    /***************************************************************************
+                                   Nested pools
+    ***************************************************************************/
+
+    /// @inheritdoc ICompositeLiquidityRouter
+    function addLiquidityUnbalancedNestedPool(
+        address parentPool,
+        address[] memory tokensIn,
+        uint256[] memory exactAmountsIn,
+        uint256 minBptAmountOut,
+        bool wethIsEth,
+        bytes memory userData
+    ) external payable saveSender(msg.sender) returns (uint256) {
+        return
+            abi.decode(
+                _vault.unlock(
+                    abi.encodeCall(
+                        CompositeLiquidityRouter.addLiquidityUnbalancedNestedPoolHook,
+                        (
+                            AddLiquidityHookParams({
+                                pool: parentPool,
+                                sender: msg.sender,
+                                maxAmountsIn: exactAmountsIn,
+                                minBptAmountOut: minBptAmountOut,
+                                kind: AddLiquidityKind.UNBALANCED,
+                                wethIsEth: wethIsEth,
+                                userData: userData
+                            }),
+                            tokensIn
+                        )
+                    )
+                ),
+                (uint256)
+            );
+    }
+
+    /// @inheritdoc ICompositeLiquidityRouter
+    function queryAddLiquidityUnbalancedNestedPool(
+        address parentPool,
+        address[] memory tokensIn,
+        uint256[] memory exactAmountsIn,
+        address sender,
+        bytes memory userData
+    ) external saveSender(sender) returns (uint256) {
+        AddLiquidityHookParams memory params = _buildQueryAddLiquidityParams(
+            parentPool,
+            exactAmountsIn,
+            0,
+            AddLiquidityKind.UNBALANCED,
+            userData
+        );
+
+        return
+            abi.decode(
+                _vault.quote(
+                    abi.encodeCall(CompositeLiquidityRouter.addLiquidityUnbalancedNestedPoolHook, (params, tokensIn))
+                ),
+                (uint256)
+            );
+    }
+
+    /// @inheritdoc ICompositeLiquidityRouter
+    function removeLiquidityProportionalNestedPool(
+        address parentPool,
+        uint256 exactBptAmountIn,
+        address[] memory tokensOut,
+        uint256[] memory minAmountsOut,
+        bool wethIsEth,
+        bytes memory userData
+    ) external payable saveSender(msg.sender) returns (uint256[] memory amountsOut) {
+        (amountsOut) = abi.decode(
+            _vault.unlock(
+                abi.encodeCall(
+                    CompositeLiquidityRouter.removeLiquidityProportionalNestedPoolHook,
+                    (
+                        RemoveLiquidityHookParams({
+                            sender: msg.sender,
+                            pool: parentPool,
+                            minAmountsOut: minAmountsOut,
+                            maxBptAmountIn: exactBptAmountIn,
+                            kind: RemoveLiquidityKind.PROPORTIONAL,
+                            wethIsEth: wethIsEth,
+                            userData: userData
+                        }),
+                        tokensOut
+                    )
+                )
+            ),
+            (uint256[])
+        );
+    }
+
+    /// @inheritdoc ICompositeLiquidityRouter
+    function queryRemoveLiquidityProportionalNestedPool(
+        address parentPool,
+        uint256 exactBptAmountIn,
+        address[] memory tokensOut,
+        address sender,
+        bytes memory userData
+    ) external saveSender(sender) returns (uint256[] memory amountsOut) {
+        RemoveLiquidityHookParams memory params = _buildQueryRemoveLiquidityParams(
+            parentPool,
+            exactBptAmountIn,
+            tokensOut.length,
+            userData
+        );
+
+        (amountsOut) = abi.decode(
+            _vault.quote(
+                abi.encodeCall(CompositeLiquidityRouter.removeLiquidityProportionalNestedPoolHook, (params, tokensOut))
+            ),
+            (uint256[])
+        );
+    }
+
+    // Nested Pool Hooks
+
+    function removeLiquidityProportionalNestedPoolHook(
+        RemoveLiquidityHookParams calldata params,
+        address[] memory tokensOut
+    ) external nonReentrant onlyVault returns (uint256[] memory amountsOut) {
+        IERC20[] memory parentPoolTokens = _vault.getPoolTokens(params.pool);
+
+        InputHelpers.ensureInputLengthMatch(params.minAmountsOut.length, tokensOut.length);
+
+        (, uint256[] memory parentPoolAmountsOut, ) = _vault.removeLiquidity(
+            RemoveLiquidityParams({
+                pool: params.pool,
+                from: params.sender,
+                maxBptAmountIn: params.maxBptAmountIn,
+                minAmountsOut: new uint256[](parentPoolTokens.length),
+                kind: params.kind,
+                userData: params.userData
+            })
+        );
+
+        for (uint256 i = 0; i < parentPoolTokens.length; i++) {
+            address childToken = address(parentPoolTokens[i]);
+            uint256 parentPoolAmountOut = parentPoolAmountsOut[i];
+
+            CompositeTokenType childTokenType = _getCompositeTokenType(childToken);
+
+            if (childTokenType == CompositeTokenType.BPT) {
+                // Token is a BPT, so remove liquidity from the child pool.
+
+                // We don't expect the sender to have BPT to burn. So, we flashloan tokens here (which should in
+                // practice just use the existing credit).
+                _vault.sendTo(IERC20(childToken), address(this), parentPoolAmountOut);
+
+                IERC20[] memory childPoolTokens = _vault.getPoolTokens(childToken);
+                // Router is an intermediary in this case. The Vault will burn tokens from the Router, so the Router
+                // is both owner and spender (which doesn't need approval).
+                (, uint256[] memory childPoolAmountsOut, ) = _vault.removeLiquidity(
+                    RemoveLiquidityParams({
+                        pool: childToken,
+                        from: address(this),
+                        maxBptAmountIn: parentPoolAmountOut,
+                        minAmountsOut: new uint256[](childPoolTokens.length),
+                        kind: params.kind,
+                        userData: params.userData
+                    })
+                );
+
+                // Return amounts to user.
+                for (uint256 j = 0; j < childPoolTokens.length; j++) {
+                    address childPoolToken = address(childPoolTokens[j]);
+                    uint256 childPoolAmountOut = childPoolAmountsOut[j];
+
+                    CompositeTokenType childPoolTokenType = _getCompositeTokenType(childPoolToken);
+                    if (childPoolTokenType == CompositeTokenType.ERC4626) {
+                        // Token is an ERC4626 wrapper, so unwrap it and return the underlying.
+                        _executeUnwrapOperation(IERC4626(childPoolToken), childPoolAmountOut);
+                    } else {
+                        _currentSwapTokensOut().add(childPoolToken);
+                        _currentSwapTokenOutAmounts().tAdd(childPoolToken, childPoolAmountOut);
+                    }
+                }
+            } else if (childTokenType == CompositeTokenType.ERC4626) {
+                // Token is an ERC4626 wrapper, so unwrap it and return the underlying.
+                _executeUnwrapOperation(IERC4626(childToken), parentPoolAmountOut);
+            } else {
+                // Token is neither a BPT nor ERC4626, so return the amount to the user.
+                _currentSwapTokensOut().add(childToken);
+                _currentSwapTokenOutAmounts().tAdd(childToken, parentPoolAmountOut);
+            }
+        }
+
+        if (_currentSwapTokensOut().length() != tokensOut.length) {
+            // If tokensOut length does not match with transient tokens out length, the tokensOut array is wrong.
+            revert WrongTokensOut(_currentSwapTokensOut().values(), tokensOut);
+        }
+
+        // The hook writes current swap token and token amounts out.
+        uint256 numTokensOut = tokensOut.length;
+        amountsOut = new uint256[](numTokensOut);
+
+        bool[] memory checkedTokenIndexes = new bool[](numTokensOut);
+        for (uint256 i = 0; i < numTokensOut; ++i) {
+            address tokenOut = tokensOut[i];
+            uint256 tokenIndex = _currentSwapTokensOut().indexOf(tokenOut);
+
+            if (_currentSwapTokensOut().contains(tokenOut) == false || checkedTokenIndexes[tokenIndex]) {
+                // If tokenOut is not in transient tokens out array or token is repeated, the tokensOut array is wrong.
+                revert WrongTokensOut(_currentSwapTokensOut().values(), tokensOut);
+            }
+
+            // Informs that the token in the transient array index has already been checked.
+            checkedTokenIndexes[tokenIndex] = true;
+
+            amountsOut[i] = _currentSwapTokenOutAmounts().tGet(tokenOut);
+
+            if (amountsOut[i] < params.minAmountsOut[i]) {
+                revert IVaultErrors.AmountOutBelowMin(IERC20(tokenOut), amountsOut[i], params.minAmountsOut[i]);
+            }
+        }
+
+        if (EVMCallModeHelpers.isStaticCall() == false) {
+            _settlePaths(params.sender, params.wethIsEth);
+        }
+    }
+
+    function addLiquidityUnbalancedNestedPoolHook(
+        AddLiquidityHookParams calldata params,
+        address[] memory tokensIn
+    ) external nonReentrant onlyVault returns (uint256 exactBptAmountOut) {
+        // Revert if tokensIn length does not match with maxAmountsIn length.
+        InputHelpers.ensureInputLengthMatch(params.maxAmountsIn.length, tokensIn.length);
+
+        // Loads a Set with all amounts to be inserted in the nested pools, so we don't need to iterate over the tokens
+        // array to find the child pool amounts to insert.
+        for (uint256 i = 0; i < tokensIn.length; ++i) {
+            if (params.maxAmountsIn[i] == 0) {
+                continue;
+            }
+
+            _currentSwapTokenInAmounts().tSet(tokensIn[i], params.maxAmountsIn[i]);
+            _currentSwapTokensIn().add(tokensIn[i]);
+        }
+
+        (uint256[] memory amountsIn, ) = _addLiquidity(params.pool, params);
+        bool isStaticCall = EVMCallModeHelpers.isStaticCall();
+
+        // Adds liquidity to the parent pool, mints parentPool's BPT to the sender and checks the minimum BPT out.
+        (, exactBptAmountOut, ) = _vault.addLiquidity(
+            AddLiquidityParams({
+                pool: params.pool,
+                to: isStaticCall ? address(this) : params.sender,
+                maxAmountsIn: amountsIn,
+                minBptAmountOut: params.minBptAmountOut,
+                kind: params.kind,
+                userData: params.userData
+            })
+        );
+
+        // Settle the amounts in.
+        if (isStaticCall == false) {
+            _settlePaths(params.sender, params.wethIsEth);
+        }
+    }
+
+    // Nested Pool helper functions
+
+    function _addLiquidity(
+        address pool,
+        AddLiquidityHookParams calldata params
+    ) internal returns (uint256[] memory amountsIn, bool allAmountsEmpty) {
+        IERC20[] memory parentPoolTokens = _vault.getPoolTokens(pool);
+        amountsIn = new uint256[](parentPoolTokens.length);
+        allAmountsEmpty = true;
+
+        for (uint256 i = 0; i < parentPoolTokens.length; i++) {
+            address token = address(parentPoolTokens[i]);
+            CompositeTokenInfo memory tokenInfo = _computeCompositeTokenInfo(
+                token,
+                _currentSwapTokenInAmounts().tGet(token)
+            );
+
+            amountsIn[i] = _settledTokenAmounts().tGet(token) > 0
+                ? _settledTokenAmounts().tGet(token)
+                : _processNestedPoolToken(tokenInfo, params);
+
+            if (amountsIn[i] > 0) {
+                allAmountsEmpty = false;
+            }
+        }
+    }
+
+    function _processNestedPoolToken(
+        CompositeTokenInfo memory tokenInfo,
+        AddLiquidityHookParams calldata params
+    ) internal returns (uint256 amountOut) {
+        address token = tokenInfo.token;
+
+        if (tokenInfo.tokenType == CompositeTokenType.BPT) {
+            amountOut = _addLiquidityToChildPool(token, params);
+        } else if (tokenInfo.tokenType == CompositeTokenType.ERC4626 && tokenInfo.needToWrap) {
+            amountOut = _wrapAndUpdateTokenInAmounts(IERC4626(token), params.sender, params.wethIsEth);
+        } else {
+            amountOut = _currentSwapTokenInAmounts().tGet(token);
+        }
+
+        _settledTokenAmounts().tSet(token, amountOut);
+    }
+
+    function _addLiquidityToChildPool(
+        address childPool,
+        AddLiquidityHookParams calldata params
+    ) internal returns (uint256 childBptAmountOut) {
+        IERC20[] memory childPoolTokens = _vault.getPoolTokens(childPool);
+        uint256[] memory childPoolAmountsIn = new uint256[](childPoolTokens.length);
+        bool childPoolAmountsEmpty = true;
+
+        // Process tokens in the child pool (no further nesting allowed).
+        for (uint256 j = 0; j < childPoolTokens.length; j++) {
+            address childPoolToken = address(childPoolTokens[j]);
+
+            CompositeTokenInfo memory tokenInfo = _computeCompositeTokenInfo(
+                childPoolToken,
+                _currentSwapTokenInAmounts().tGet(childPoolToken)
+            );
+
+            if (tokenInfo.tokenType == CompositeTokenType.BPT) {
+                // This would be a second level of nesting, which is not supported. Process as a standard ERC20 token.
+                if (_settledTokenAmounts().tGet(childPoolToken) == 0) {
+                    childPoolAmountsIn[j] = tokenInfo.amount;
+                    _settledTokenAmounts().tSet(childPoolToken, tokenInfo.amount);
+                }
+            } else if (
+                // wrapped amount in was not specified
+                tokenInfo.tokenType == CompositeTokenType.ERC4626 && tokenInfo.amount == 0
+            ) {
+                // Handle ERC4626 token wrapping at child pool level.
+                childPoolAmountsIn[j] = _wrapAndUpdateTokenInAmounts(
+                    IERC4626(childPoolToken),
+                    params.sender,
+                    params.wethIsEth
+                );
+            } else if (_settledTokenAmounts().tGet(childPoolToken) == 0) {
+                // Set this token's amountIn if it's a standard token that was not previously settled.
+                childPoolAmountsIn[j] = tokenInfo.amount;
+                _settledTokenAmounts().tSet(childPoolToken, tokenInfo.amount);
+            }
+
+            if (childPoolAmountsIn[j] > 0) {
+                childPoolAmountsEmpty = false;
+            }
+        }
+
+        if (childPoolAmountsEmpty == false) {
+            // Add Liquidity will mint childTokens to the Vault, so the insertion of liquidity in the parent
+            // pool will be an accounting adjustment, not a token transfer.
+            (, uint256 exactChildBptAmountOut, ) = _vault.addLiquidity(
+                AddLiquidityParams({
+                    pool: childPool,
+                    to: address(_vault),
+                    maxAmountsIn: childPoolAmountsIn,
+                    minBptAmountOut: 0,
+                    kind: params.kind,
+                    userData: params.userData
+                })
+            );
+
+            childBptAmountOut = exactChildBptAmountOut;
+
+            // Since the BPT will be add to the parent pool, get the credit from the inserted BPT in advance.
+            _vault.settle(IERC20(childPool), exactChildBptAmountOut);
+        }
+    }
+
+    // Fill in the information needed to correctly process nested pool tokens.
+    function _computeCompositeTokenInfo(
+        address token,
+        uint256 amount
+    ) private view returns (CompositeTokenInfo memory info) {
+        info.token = token;
+        info.amount = amount;
+        info.tokenType = _getCompositeTokenType(token);
+
+        if (info.tokenType == CompositeTokenType.ERC4626) {
+            info.needToWrap = (amount == 0 &&
+                _currentSwapTokenInAmounts().tGet(_vault.getERC4626BufferAsset(IERC4626(token))) > 0);
+        }
+    }
+
+    // Determine the token type to direct execution.
+    function _getCompositeTokenType(address token) internal view returns (CompositeTokenType tokenType) {
+        if (_vault.isPoolRegistered(token)) {
+            tokenType = CompositeTokenType.BPT;
+        } else if (_vault.isERC4626BufferInitialized(IERC4626(token))) {
+            tokenType = CompositeTokenType.ERC4626;
+        } else {
+            tokenType = CompositeTokenType.ERC20;
+        }
+    }
+
+    // Common helper functions
+
     // Construct a set of add liquidity hook params, adding in the invariant parameters.
     function _buildQueryAddLiquidityParams(
         address pool,
@@ -625,14 +1066,14 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, BatchRouterCommo
     function _buildQueryRemoveLiquidityParams(
         address pool,
         uint256 exactBptAmountIn,
-        uint256[] memory minAmountsOut,
+        uint256 numTokens,
         bytes memory userData
     ) private view returns (RemoveLiquidityHookParams memory) {
         return
             RemoveLiquidityHookParams({
                 sender: address(this), // Always use router address for queries
                 pool: pool,
-                minAmountsOut: minAmountsOut,
+                minAmountsOut: new uint256[](numTokens),
                 maxBptAmountIn: exactBptAmountIn,
                 kind: RemoveLiquidityKind.PROPORTIONAL, // Always proportional for supported use cases
                 wethIsEth: false, // Always false for queries

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	14.272
-InitCode	15.836
+Bytecode	22.425
+InitCode	24.304

--- a/pkg/vault/test/foundry/CompositeLiquidityRouterNestedPools.t.sol
+++ b/pkg/vault/test/foundry/CompositeLiquidityRouterNestedPools.t.sol
@@ -1,0 +1,2192 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
+import { ICompositeLiquidityRouter } from "@balancer-labs/v3-interfaces/contracts/vault/ICompositeLiquidityRouter.sol";
+
+import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/test/ArrayHelpers.sol";
+import { CastingHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/CastingHelpers.sol";
+import { ERC20TestToken } from "@balancer-labs/v3-solidity-utils/contracts/test/ERC20TestToken.sol";
+import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
+import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
+
+import { BalancerPoolToken } from "../../contracts/BalancerPoolToken.sol";
+import { BaseERC4626BufferTest } from "./utils/BaseERC4626BufferTest.sol";
+
+contract CompositeLiquidityRouterNestedPoolsTest is BaseERC4626BufferTest {
+    using ArrayHelpers for *;
+    using CastingHelpers for address[];
+    using FixedPoint for uint256;
+
+    address internal parentPool;
+    address internal childPoolA;
+    address internal childPoolB;
+
+    address internal childPoolERC4626;
+    address internal parentPoolWithoutWrapper;
+    address internal parentPoolWithWrapper;
+
+    // Max of 5 wei of error when retrieving tokens from a nested pool.
+    uint256 internal constant MAX_ROUND_ERROR = 5;
+
+    function setUp() public override {
+        BaseERC4626BufferTest.setUp();
+
+        (childPoolA, ) = _createPool([address(usdc), address(weth)].toMemoryArray(), "childPoolA");
+        (childPoolB, ) = _createPool([address(wsteth), address(dai)].toMemoryArray(), "childPoolB");
+        (parentPool, ) = _createPool(
+            [address(childPoolA), address(childPoolB), address(dai)].toMemoryArray(),
+            "parentPool"
+        );
+
+        (childPoolERC4626, ) = _createPool([address(waDAI), address(waWETH)].toMemoryArray(), "childPoolERC4626");
+        (parentPoolWithoutWrapper, ) = _createPool(
+            [address(childPoolERC4626), address(usdc)].toMemoryArray(),
+            "parentPoolWithoutWrapper"
+        );
+        (parentPoolWithWrapper, ) = _createPool(
+            [address(childPoolERC4626), address(waUSDC)].toMemoryArray(),
+            "parentPoolWithWrapper"
+        );
+
+        approveForPool(IERC20(childPoolA));
+        approveForPool(IERC20(childPoolB));
+        approveForPool(IERC20(childPoolERC4626));
+
+        approveForPool(IERC20(parentPool));
+        approveForPool(IERC20(parentPoolWithoutWrapper));
+        approveForPool(IERC20(parentPoolWithWrapper));
+
+        vm.startPrank(lp);
+        uint256 childPoolABptOut = _initPool(childPoolA, [poolInitAmount, poolInitAmount].toMemoryArray(), 0);
+        uint256 childPoolBBptOut = _initPool(childPoolB, [poolInitAmount, poolInitAmount].toMemoryArray(), 0);
+        // Initialize the ERC4626 child pool with 2x poolInitAmount, because we will split the BPT into two pools. So,
+        // it'll be easier to calculate the expectedAmountOut on removeLiquidity.
+        uint256 childPoolERC4626BptOut = _initPool(
+            childPoolERC4626,
+            [2 * poolInitAmount, 2 * poolInitAmount].toMemoryArray(),
+            0
+        );
+
+        _initPoolUnsorted(
+            parentPool,
+            [childPoolA, childPoolB, address(dai)].toMemoryArray(),
+            [childPoolABptOut, childPoolBBptOut, poolInitAmount].toMemoryArray()
+        );
+        _initPoolUnsorted(
+            parentPoolWithoutWrapper,
+            [childPoolERC4626, address(usdc)].toMemoryArray(),
+            [childPoolERC4626BptOut / 2, poolInitAmount].toMemoryArray()
+        );
+        _initPoolUnsorted(
+            parentPoolWithWrapper,
+            [childPoolERC4626, address(waUSDC)].toMemoryArray(),
+            [childPoolERC4626BptOut / 2, poolInitAmount].toMemoryArray()
+        );
+        vm.stopPrank();
+    }
+
+    function _initPoolUnsorted(
+        address poolToInitialize,
+        address[] memory unsortedTokensIn,
+        uint256[] memory unsortedAmountsIn
+    ) private {
+        uint256[] memory tokenIndexes = getSortedIndexes(unsortedTokensIn);
+
+        uint256[] memory sortedAmountsIn = new uint256[](unsortedTokensIn.length);
+        for (uint256 i = 0; i < unsortedTokensIn.length; i++) {
+            sortedAmountsIn[tokenIndexes[i]] = unsortedAmountsIn[i];
+        }
+
+        _initPool(poolToInitialize, sortedAmountsIn, 0);
+    }
+
+    /*******************************************************************************
+                                Add liquidity
+    *******************************************************************************/
+
+    function testAddLiquidityNestedPool__Fuzz(
+        uint256 daiAmount,
+        uint256 usdcAmount,
+        uint256 wethAmount,
+        uint256 wstEthAmount
+    ) public {
+        daiAmount = bound(daiAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        usdcAmount = bound(usdcAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        wethAmount = bound(wethAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        wstEthAmount = bound(wstEthAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        address[] memory tokensIn = new address[](4);
+        tokensIn[vars.daiIdx] = address(dai);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+        tokensIn[vars.wstethIdx] = address(wsteth);
+
+        uint256[] memory amountsIn = new uint256[](4);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+        amountsIn[vars.wstethIdx] = wstEthAmount;
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPool,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 mintedChildPoolABpt = vars.childPoolAAfter.totalSupply - vars.childPoolABefore.totalSupply;
+        uint256 mintedChildPoolBBpt = vars.childPoolBAfter.totalSupply - vars.childPoolBBefore.totalSupply;
+
+        // Check exact BPT out.
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in.
+        uint256 expectedBptOut = daiAmount + usdcAmount + wethAmount + wstEthAmount;
+        assertApproxEqAbs(exactBptOut, expectedBptOut, 10, "Exact BPT amount out is wrong");
+        assertLt(exactBptOut, expectedBptOut, "BPT out rounding direction is wrong");
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai - amountsIn[vars.daiIdx], "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth - amountsIn[vars.wethIdx], "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.wsteth, vars.lpBefore.wsteth - amountsIn[vars.wstethIdx], "LP Wsteth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc - amountsIn[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(vars.lpAfter.childPoolABpt, vars.lpBefore.childPoolABpt, "LP ChildPoolA BPT Balance is wrong");
+        assertEq(vars.lpAfter.childPoolBBpt, vars.lpBefore.childPoolBBpt, "LP ChildPoolB BPT Balance is wrong");
+        assertEq(
+            vars.lpAfter.parentPoolBpt,
+            vars.lpBefore.parentPoolBpt + exactBptOut,
+            "LP ParentPool BPT Balance is wrong"
+        );
+
+        // Check Vault Balances.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai + amountsIn[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth + amountsIn[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(
+            vars.vaultAfter.wsteth,
+            vars.vaultBefore.wsteth + amountsIn[vars.wstethIdx],
+            "Vault Wsteth Balance is wrong"
+        );
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc + amountsIn[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        // Since all Child Pool BPT were allocated in the parent pool, vault is holding all of the minted BPT.
+        assertEq(
+            vars.vaultAfter.childPoolABpt,
+            vars.vaultBefore.childPoolABpt + mintedChildPoolABpt,
+            "Vault ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.vaultAfter.childPoolBBpt,
+            vars.vaultBefore.childPoolBBpt + mintedChildPoolBBpt,
+            "Vault ChildPoolB BPT Balance is wrong"
+        );
+        // Vault's parent pool BPT did not change.
+        assertEq(
+            vars.vaultAfter.parentPoolBpt,
+            vars.vaultBefore.parentPoolBpt,
+            "Vault ParentPool BPT Balance is wrong"
+        );
+
+        // Check ChildPoolA balances.
+        assertEq(
+            vars.childPoolAAfter.weth,
+            vars.childPoolABefore.weth + amountsIn[vars.wethIdx],
+            "ChildPoolA Weth Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolAAfter.usdc,
+            vars.childPoolABefore.usdc + amountsIn[vars.usdcIdx],
+            "ChildPoolA Usdc Balance is wrong"
+        );
+
+        // Check ChildPoolB balances.
+        assertEq(vars.childPoolBAfter.dai, vars.childPoolBBefore.dai, "ChildPoolB Dai Balance is wrong");
+        assertEq(
+            vars.childPoolBAfter.wsteth,
+            vars.childPoolBBefore.wsteth + amountsIn[vars.wstethIdx],
+            "ChildPoolB Wsteth Balance is wrong"
+        );
+
+        // Check ParentPool balances.
+        assertApproxEqAbs(
+            vars.parentPoolAfter.dai,
+            vars.parentPoolBefore.dai + amountsIn[vars.daiIdx],
+            MAX_ROUND_ERROR,
+            "ParentPool Dai Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolABpt,
+            vars.parentPoolBefore.childPoolABpt + mintedChildPoolABpt,
+            "ParentPool ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolBBpt,
+            vars.parentPoolBefore.childPoolBBpt + mintedChildPoolBBpt,
+            "ParentPool ChildPoolB BPT Balance is wrong"
+        );
+    }
+
+    function testAddLiquidityUnbalanceToOneChildNestedPool() public {
+        uint256 usdcAmount = poolInitAmount;
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        address[] memory tokensIn = new address[](1);
+        tokensIn[0] = address(usdc);
+
+        uint256[] memory amountsIn = new uint256[](1);
+        amountsIn[0] = usdcAmount;
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPool,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 mintedChildPoolABpt = vars.childPoolAAfter.totalSupply - vars.childPoolABefore.totalSupply;
+
+        // Check exact BPT out.
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in.
+        uint256 expectedBptOut = usdcAmount;
+        assertApproxEqAbs(exactBptOut, expectedBptOut, 10, "Exact BPT amount out is wrong");
+        assertLt(exactBptOut, expectedBptOut, "BPT out rounding direction is wrong");
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai, "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth, "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.wsteth, vars.lpBefore.wsteth, "LP Wsteth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc - amountsIn[0], "LP Usdc Balance is wrong");
+        assertEq(vars.lpAfter.childPoolABpt, vars.lpBefore.childPoolABpt, "LP ChildPoolA BPT Balance is wrong");
+        assertEq(vars.lpAfter.childPoolBBpt, vars.lpBefore.childPoolBBpt, "LP ChildPoolB BPT Balance is wrong");
+        assertEq(
+            vars.lpAfter.parentPoolBpt,
+            vars.lpBefore.parentPoolBpt + exactBptOut,
+            "LP ParentPool BPT Balance is wrong"
+        );
+
+        // Check Vault Balances.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai, "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth, "Vault Weth Balance is wrong");
+        assertEq(vars.vaultAfter.wsteth, vars.vaultBefore.wsteth, "Vault Wsteth Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc + amountsIn[0], "Vault Usdc Balance is wrong");
+        // Since all Child Pool BPT were allocated in the parent pool, vault is holding all of the minted BPT.
+        assertEq(
+            vars.vaultAfter.childPoolABpt,
+            vars.vaultBefore.childPoolABpt + mintedChildPoolABpt,
+            "Vault ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.vaultAfter.childPoolBBpt,
+            vars.vaultBefore.childPoolBBpt,
+            "Vault ChildPoolB BPT Balance is wrong"
+        );
+        // Vault's parent pool BPT did not change.
+        assertEq(
+            vars.vaultAfter.parentPoolBpt,
+            vars.vaultBefore.parentPoolBpt,
+            "Vault ParentPool BPT Balance is wrong"
+        );
+
+        // Check ChildPoolA balances.
+        assertEq(vars.childPoolAAfter.weth, vars.childPoolABefore.weth, "ChildPoolA Weth Balance is wrong");
+        assertEq(
+            vars.childPoolAAfter.usdc,
+            vars.childPoolABefore.usdc + amountsIn[0],
+            "ChildPoolA Usdc Balance is wrong"
+        );
+
+        // Check ChildPoolB balances.
+        assertApproxEqAbs(
+            vars.childPoolBAfter.dai,
+            vars.childPoolBBefore.dai,
+            MAX_ROUND_ERROR,
+            "ChildPoolB Dai Balance is wrong"
+        );
+        assertEq(vars.childPoolBAfter.wsteth, vars.childPoolBBefore.wsteth, "ChildPoolB Wsteth Balance is wrong");
+
+        // Check ParentPool balances.
+        // The ParentPool's DAI balance does not change since all DAI amount is inserted in the child pool A.
+        assertEq(vars.parentPoolAfter.dai, vars.parentPoolBefore.dai, "ParentPool Dai Balance is wrong");
+        assertEq(
+            vars.parentPoolAfter.childPoolABpt,
+            vars.parentPoolBefore.childPoolABpt + mintedChildPoolABpt,
+            "ParentPool ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolBBpt,
+            vars.parentPoolBefore.childPoolBBpt,
+            "ParentPool ChildPoolB BPT Balance is wrong"
+        );
+    }
+
+    function testAddLiquidityNestedERC4626WithUnderlying__Fuzz(
+        uint256 daiAmount,
+        uint256 usdcAmount,
+        uint256 wethAmount
+    ) public {
+        daiAmount = bound(daiAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        usdcAmount = bound(usdcAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        wethAmount = bound(wethAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.daiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        address[] memory tokensIn = new address[](3);
+        tokensIn[vars.daiIdx] = address(dai);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+
+        uint256[] memory amountsIn = new uint256[](3);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPoolWithoutWrapper,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 mintedChildPoolERC4626Bpt = vars.childPoolERC4626After.totalSupply -
+            vars.childPoolERC4626Before.totalSupply;
+
+        // Check exact BPT out.
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in.
+        uint256 expectedBptOut = _vaultPreviewDeposit(waDAI, daiAmount) + usdcAmount + wethAmount;
+        assertApproxEqAbs(exactBptOut, expectedBptOut, 10, "Exact BPT amount out is wrong");
+        assertLt(exactBptOut, expectedBptOut, "BPT out rounding direction is wrong");
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai - amountsIn[vars.daiIdx], "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth - amountsIn[vars.wethIdx], "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc - amountsIn[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(
+            vars.lpAfter.childPoolERC4626Bpt,
+            vars.lpBefore.childPoolERC4626Bpt,
+            "LP ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.lpAfter.parentPoolWithoutWrapperBpt,
+            vars.lpBefore.parentPoolWithoutWrapperBpt + exactBptOut,
+            "LP ParentPoolWithoutWrapper BPT Balance is wrong"
+        );
+
+        // Check Vault Balances. Since the buffer has enough balance, the Vault only increased its underlying tokens.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai + amountsIn[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.waDAI, vars.vaultBefore.waDAI, "Vault waDai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth + amountsIn[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(vars.vaultAfter.waWETH, vars.vaultBefore.waWETH, "Vault waWETH Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc + amountsIn[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        assertEq(vars.vaultAfter.waUSDC, vars.vaultBefore.waUSDC, "Vault waUsdc Balance is wrong");
+        // Since all Child Pool BPT were allocated in the parent pool, vault is holding all of the minted BPT.
+        assertEq(
+            vars.vaultAfter.childPoolERC4626Bpt,
+            vars.vaultBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "Vault ChildPoolERC4626 BPT Balance is wrong"
+        );
+
+        // Vault's parent pool BPT did not change.
+        assertEq(
+            vars.vaultAfter.parentPoolWithoutWrapperBpt,
+            vars.vaultBefore.parentPoolWithoutWrapperBpt,
+            "Vault ParentPoolWithoutWrapper BPT Balance is wrong"
+        );
+
+        // Check ChildPoolERC4626 balances.
+        assertEq(
+            vars.childPoolERC4626After.waDAI,
+            vars.childPoolERC4626Before.waDAI + _vaultPreviewDeposit(waDAI, amountsIn[vars.daiIdx]),
+            "ChildPoolERC4626 waDAI Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolERC4626After.waWETH,
+            vars.childPoolERC4626Before.waWETH + _vaultPreviewDeposit(waWETH, amountsIn[vars.wethIdx]),
+            "ChildPoolERC4626 waWETH Balance is wrong"
+        );
+
+        // Check ParentPoolWithoutWrapper balances.
+        assertEq(
+            vars.parentPoolWithoutWrapperAfter.childPoolERC4626Bpt,
+            vars.parentPoolWithoutWrapperBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "ParentPoolWithoutWrapper ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolWithoutWrapperAfter.usdc,
+            vars.parentPoolWithoutWrapperBefore.usdc + amountsIn[vars.usdcIdx],
+            "ParentPoolWithoutWrapper USDC Balance is wrong"
+        );
+    }
+
+    function testAddLiquidityNestedERC4626WithEth__Fuzz(
+        uint256 daiAmount,
+        uint256 usdcAmount,
+        uint256 wethAmount,
+        bool forceEthLeftover
+    ) public {
+        daiAmount = bound(daiAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        usdcAmount = bound(usdcAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        wethAmount = bound(wethAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.daiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        address[] memory tokensIn = new address[](3);
+        tokensIn[vars.daiIdx] = address(dai);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+
+        uint256[] memory amountsIn = new uint256[](3);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool{
+            value: wethAmount + (forceEthLeftover ? 1e18 : 0)
+        }(parentPoolWithoutWrapper, tokensIn, amountsIn, minBptOut, true, bytes(""));
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 mintedChildPoolERC4626Bpt = vars.childPoolERC4626After.totalSupply -
+            vars.childPoolERC4626Before.totalSupply;
+
+        // Check exact BPT out.
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in.
+        uint256 expectedBptOut = _vaultPreviewDeposit(waDAI, daiAmount) + usdcAmount + wethAmount;
+        assertApproxEqAbs(exactBptOut, expectedBptOut, 10, "Exact BPT amount out is wrong");
+        assertLt(exactBptOut, expectedBptOut, "BPT out rounding direction is wrong");
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai - amountsIn[vars.daiIdx], "LP Dai Balance is wrong");
+        // LP Weth balance should not change, since ETH was used. Weth and Eth prices are the same.
+        assertEq(vars.lpAfter.eth, vars.lpBefore.eth - amountsIn[vars.wethIdx], "LP Eth Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth, "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc - amountsIn[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(
+            vars.lpAfter.childPoolERC4626Bpt,
+            vars.lpBefore.childPoolERC4626Bpt,
+            "LP ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.lpAfter.parentPoolWithoutWrapperBpt,
+            vars.lpBefore.parentPoolWithoutWrapperBpt + exactBptOut,
+            "LP ParentPoolWithoutWrapper BPT Balance is wrong"
+        );
+
+        // Check Vault Balances. Since the buffer has enough balance, the Vault only increased its underlying tokens.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai + amountsIn[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.waDAI, vars.vaultBefore.waDAI, "Vault waDai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth + amountsIn[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc + amountsIn[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        assertEq(vars.vaultAfter.waUSDC, vars.vaultBefore.waUSDC, "Vault waUsdc Balance is wrong");
+        // Since all Child Pool BPT were allocated in the parent pool, vault is holding all of the minted BPT.
+        assertEq(
+            vars.vaultAfter.childPoolERC4626Bpt,
+            vars.vaultBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "Vault ChildPoolERC4626 BPT Balance is wrong"
+        );
+
+        // Vault's parent pool BPT did not change.
+        assertEq(
+            vars.vaultAfter.parentPoolWithoutWrapperBpt,
+            vars.vaultBefore.parentPoolWithoutWrapperBpt,
+            "Vault ParentPoolWithoutWrapper BPT Balance is wrong"
+        );
+
+        // Check ChildPoolERC4626 balances.
+        assertEq(
+            vars.childPoolERC4626After.waDAI,
+            vars.childPoolERC4626Before.waDAI + _vaultPreviewDeposit(waDAI, amountsIn[vars.daiIdx]),
+            "ChildPoolERC4626 waDAI Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolERC4626After.waWETH,
+            vars.childPoolERC4626Before.waWETH + _vaultPreviewDeposit(waWETH, amountsIn[vars.wethIdx]),
+            "ChildPoolERC4626 waWETH Balance is wrong"
+        );
+
+        // Check ParentPoolWithoutWrapper balances.
+        assertEq(
+            vars.parentPoolWithoutWrapperAfter.childPoolERC4626Bpt,
+            vars.parentPoolWithoutWrapperBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "ParentPoolWithoutWrapper ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolWithoutWrapperAfter.usdc,
+            vars.parentPoolWithoutWrapperBefore.usdc + amountsIn[vars.usdcIdx],
+            "ParentPoolWithoutWrapper USDC Balance is wrong"
+        );
+
+        assertEq(address(compositeLiquidityRouter).balance, 0, "Router has eth balance");
+    }
+
+    function testAddLiquidityNestedERC4626WithWrapped__Fuzz(
+        uint256 waDaiAmount,
+        uint256 usdcAmount,
+        uint256 wethAmount
+    ) public {
+        waDaiAmount = bound(waDaiAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        usdcAmount = bound(usdcAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        wethAmount = bound(wethAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.waDaiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        address[] memory tokensIn = new address[](3);
+        tokensIn[vars.waDaiIdx] = address(waDAI);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+
+        uint256[] memory amountsIn = new uint256[](3);
+        amountsIn[vars.waDaiIdx] = waDaiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPoolWithoutWrapper,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 mintedChildPoolERC4626Bpt = vars.childPoolERC4626After.totalSupply -
+            vars.childPoolERC4626Before.totalSupply;
+
+        // Check exact BPT out.
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in.
+        uint256 expectedBptOut = waDaiAmount + usdcAmount + wethAmount;
+        assertApproxEqAbs(exactBptOut, expectedBptOut, 10, "Exact BPT amount out is wrong");
+        assertLt(exactBptOut, expectedBptOut, "BPT out rounding direction is wrong");
+
+        // Check LP Balances.
+        // Since LP passed the wrapper address as a token in, his DAI balance is not touched.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai, "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.waDAI, vars.lpBefore.waDAI - amountsIn[vars.waDaiIdx], "LP waDAI Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth - amountsIn[vars.wethIdx], "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc - amountsIn[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(
+            vars.lpAfter.childPoolERC4626Bpt,
+            vars.lpBefore.childPoolERC4626Bpt,
+            "LP ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.lpAfter.parentPoolWithoutWrapperBpt,
+            vars.lpBefore.parentPoolWithoutWrapperBpt + exactBptOut,
+            "LP ParentPoolWithoutWrapper BPT Balance is wrong"
+        );
+
+        // Check Vault Balances.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai, "Vault Dai Balance is wrong");
+        assertEq(
+            vars.vaultAfter.waDAI,
+            vars.vaultBefore.waDAI + amountsIn[vars.waDaiIdx],
+            "Vault waDAI Balance is wrong"
+        );
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth + amountsIn[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc + amountsIn[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        // Since all Child Pool BPT were allocated in the parent pool, vault is holding all of the minted BPT.
+        assertEq(
+            vars.vaultAfter.childPoolERC4626Bpt,
+            vars.vaultBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "Vault ChildPoolERC4626 BPT Balance is wrong"
+        );
+
+        // Vault's parent pool BPT did not change.
+        assertEq(
+            vars.vaultAfter.parentPoolWithoutWrapperBpt,
+            vars.vaultBefore.parentPoolWithoutWrapperBpt,
+            "Vault ParentPoolWithoutWrapper BPT Balance is wrong"
+        );
+
+        // Check ChildPoolERC4626 balances.
+        assertEq(
+            vars.childPoolERC4626After.waDAI,
+            vars.childPoolERC4626Before.waDAI + amountsIn[vars.waDaiIdx],
+            "ChildPoolERC4626 waDAI Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolERC4626After.waWETH,
+            vars.childPoolERC4626Before.waWETH + _vaultPreviewDeposit(waWETH, amountsIn[vars.wethIdx]),
+            "ChildPoolERC4626 waWETH Balance is wrong"
+        );
+
+        // Check ParentPoolWithoutWrapper balances.
+        assertEq(
+            vars.parentPoolWithoutWrapperAfter.childPoolERC4626Bpt,
+            vars.parentPoolWithoutWrapperBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "ParentPoolWithoutWrapper ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolWithoutWrapperAfter.usdc,
+            vars.parentPoolWithoutWrapperBefore.usdc + amountsIn[vars.usdcIdx],
+            "ParentPoolWithoutWrapper USDC Balance is wrong"
+        );
+    }
+
+    function testAddLiquidityNestedERC4626InParentWithUnderlying__Fuzz(
+        uint256 daiAmount,
+        uint256 usdcAmount,
+        uint256 wethAmount
+    ) public {
+        daiAmount = bound(daiAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        usdcAmount = bound(usdcAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        wethAmount = bound(wethAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.daiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        address[] memory tokensIn = new address[](3);
+        tokensIn[vars.daiIdx] = address(dai);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+
+        uint256[] memory amountsIn = new uint256[](3);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPoolWithWrapper,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 mintedChildPoolERC4626Bpt = vars.childPoolERC4626After.totalSupply -
+            vars.childPoolERC4626Before.totalSupply;
+
+        // Check exact BPT out.
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in.
+        uint256 expectedBptOut = _vaultPreviewDeposit(waDAI, daiAmount) +
+            _vaultPreviewDeposit(waUSDC, usdcAmount) +
+            _vaultPreviewDeposit(waWETH, wethAmount);
+        assertApproxEqAbs(exactBptOut, expectedBptOut, 10, "Exact BPT amount out is wrong");
+        assertLt(exactBptOut, expectedBptOut, "BPT out rounding direction is wrong");
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai - amountsIn[vars.daiIdx], "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth - amountsIn[vars.wethIdx], "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc - amountsIn[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(
+            vars.lpAfter.childPoolERC4626Bpt,
+            vars.lpBefore.childPoolERC4626Bpt,
+            "LP ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.lpAfter.parentPoolWithWrapperBpt,
+            vars.lpBefore.parentPoolWithWrapperBpt + exactBptOut,
+            "LP ParentPoolWithWrapper BPT Balance is wrong"
+        );
+
+        // Check Vault Balances. Since the buffer has enough balance, the Vault only increased its underlying tokens.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai + amountsIn[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.waDAI, vars.vaultBefore.waDAI, "Vault waDai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth + amountsIn[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(vars.vaultAfter.waWETH, vars.vaultBefore.waWETH, "Vault waWeth Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc + amountsIn[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        assertEq(vars.vaultAfter.waUSDC, vars.vaultBefore.waUSDC, "Vault waUSDC Balance is wrong");
+
+        // Since all Child Pool BPT were allocated in the parent pool, vault is holding all of the minted BPT.
+        assertEq(
+            vars.vaultAfter.childPoolERC4626Bpt,
+            vars.vaultBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "Vault ChildPoolERC4626 BPT Balance is wrong"
+        );
+
+        // Vault's parent pool BPT did not change.
+        assertEq(
+            vars.vaultAfter.parentPoolWithWrapperBpt,
+            vars.vaultBefore.parentPoolWithWrapperBpt,
+            "Vault ParentPoolWithWrapper BPT Balance is wrong"
+        );
+
+        // Check ChildPoolERC4626 balances.
+        assertEq(
+            vars.childPoolERC4626After.waDAI,
+            vars.childPoolERC4626Before.waDAI + _vaultPreviewDeposit(waDAI, amountsIn[vars.daiIdx]),
+            "ChildPoolERC4626 waDAI Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolERC4626After.waWETH,
+            vars.childPoolERC4626Before.waWETH + _vaultPreviewDeposit(waWETH, amountsIn[vars.wethIdx]),
+            "ChildPoolERC4626 waWETH Balance is wrong"
+        );
+
+        // Check ParentPoolWithoutWrapper balances.
+        assertEq(
+            vars.parentPoolWithWrapperAfter.childPoolERC4626Bpt,
+            vars.parentPoolWithWrapperBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "ParentPoolWithWrapper ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolWithWrapperAfter.waUSDC,
+            vars.parentPoolWithWrapperBefore.waUSDC + _vaultPreviewDeposit(waUSDC, amountsIn[vars.usdcIdx]),
+            "ParentPoolWithWrapper waUSDC Balance is wrong"
+        );
+    }
+
+    function testAddLiquidityNestedERC4626InParentWithWrapped__Fuzz(
+        uint256 waDaiAmount,
+        uint256 waUsdcAmount,
+        uint256 waWethAmount
+    ) public {
+        waDaiAmount = bound(waDaiAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        waUsdcAmount = bound(waUsdcAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        waWethAmount = bound(waWethAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.waDaiIdx = 0;
+        vars.waUsdcIdx = 1;
+        vars.waWethIdx = 2;
+
+        address[] memory tokensIn = new address[](3);
+        tokensIn[vars.waDaiIdx] = address(waDAI);
+        tokensIn[vars.waUsdcIdx] = address(waUSDC);
+        tokensIn[vars.waWethIdx] = address(waWETH);
+
+        uint256[] memory amountsIn = new uint256[](3);
+        amountsIn[vars.waDaiIdx] = waDaiAmount;
+        amountsIn[vars.waUsdcIdx] = waUsdcAmount;
+        amountsIn[vars.waWethIdx] = waWethAmount;
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPoolWithWrapper,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 mintedChildPoolERC4626Bpt = vars.childPoolERC4626After.totalSupply -
+            vars.childPoolERC4626Before.totalSupply;
+
+        // Check exact BPT out.
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in.
+        uint256 expectedBptOut = waDaiAmount + waUsdcAmount + waWethAmount;
+        assertApproxEqAbs(exactBptOut, expectedBptOut, 10, "Exact BPT amount out is wrong");
+        assertLt(exactBptOut, expectedBptOut, "BPT out rounding direction is wrong");
+
+        // Check LP Balances.
+        // Since LP passed the wrapper address as a token in, his DAI and USDC balances are not touched.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai, "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc, "LP USDC Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth, "LP WETH Balance is wrong");
+        assertEq(vars.lpAfter.waDAI, vars.lpBefore.waDAI - amountsIn[vars.waDaiIdx], "LP waDAI Balance is wrong");
+        assertEq(vars.lpAfter.waUSDC, vars.lpBefore.waUSDC - amountsIn[vars.waUsdcIdx], "LP waUSDC Balance is wrong");
+        assertEq(vars.lpAfter.waWETH, vars.lpBefore.waWETH - amountsIn[vars.waWethIdx], "LP waWETH Balance is wrong");
+        assertEq(
+            vars.lpAfter.childPoolERC4626Bpt,
+            vars.lpBefore.childPoolERC4626Bpt,
+            "LP ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.lpAfter.parentPoolWithWrapperBpt,
+            vars.lpBefore.parentPoolWithWrapperBpt + exactBptOut,
+            "LP ParentPoolWithWrapper BPT Balance is wrong"
+        );
+
+        // Check Vault Balances.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai, "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc, "Vault USDC Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth, "Vault USDC Balance is wrong");
+        assertEq(
+            vars.vaultAfter.waDAI,
+            vars.vaultBefore.waDAI + amountsIn[vars.waDaiIdx],
+            "Vault waDAI Balance is wrong"
+        );
+        assertEq(
+            vars.vaultAfter.waUSDC,
+            vars.vaultBefore.waUSDC + amountsIn[vars.waUsdcIdx],
+            "Vault waDAI Balance is wrong"
+        );
+        assertEq(
+            vars.vaultAfter.waWETH,
+            vars.vaultBefore.waWETH + amountsIn[vars.waWethIdx],
+            "Vault waWETH Balance is wrong"
+        );
+        // Since all Child Pool BPT were allocated in the parent pool, vault is holding all of the minted BPT.
+        assertEq(
+            vars.vaultAfter.childPoolERC4626Bpt,
+            vars.vaultBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "Vault ChildPoolERC4626 BPT Balance is wrong"
+        );
+
+        // Vault's parent pool BPT did not change.
+        assertEq(
+            vars.vaultAfter.parentPoolWithWrapperBpt,
+            vars.vaultBefore.parentPoolWithWrapperBpt,
+            "Vault ParentPoolWithWrapper BPT Balance is wrong"
+        );
+
+        // Check ChildPoolERC4626 balances.
+        assertEq(
+            vars.childPoolERC4626After.waDAI,
+            vars.childPoolERC4626Before.waDAI + amountsIn[vars.waDaiIdx],
+            "ChildPoolERC4626 waDAI Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolERC4626After.waWETH,
+            vars.childPoolERC4626Before.waWETH + amountsIn[vars.waWethIdx],
+            "ChildPoolERC4626 waWETH Balance is wrong"
+        );
+
+        // Check ParentPoolWithWrapper balances.
+        assertEq(
+            vars.parentPoolWithWrapperAfter.childPoolERC4626Bpt,
+            vars.parentPoolWithWrapperBefore.childPoolERC4626Bpt + mintedChildPoolERC4626Bpt,
+            "ParentPoolWithWrapper ChildPoolERC4626 BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolWithWrapperAfter.waUSDC,
+            vars.parentPoolWithWrapperBefore.waUSDC + amountsIn[vars.waUsdcIdx],
+            "ParentPoolWithWrapper waUSDC Balance is wrong"
+        );
+    }
+
+    function testQueryAddLiquidityNestedERC4626__Fuzz(
+        uint256 daiAmount,
+        uint256 usdcAmount,
+        uint256 wethAmount
+    ) public {
+        daiAmount = bound(daiAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        usdcAmount = bound(usdcAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+        wethAmount = bound(wethAmount, PRODUCTION_MIN_TRADE_AMOUNT, 10 * poolInitAmount);
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.daiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        address[] memory tokensIn = new address[](3);
+        tokensIn[vars.daiIdx] = address(dai);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+
+        uint256[] memory amountsIn = new uint256[](3);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+
+        _prankStaticCall();
+        uint256 queryBptOut = compositeLiquidityRouter.queryAddLiquidityUnbalancedNestedPool(
+            parentPoolWithWrapper,
+            tokensIn,
+            amountsIn,
+            lp,
+            bytes("")
+        );
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPoolWithWrapper,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+
+        // The actual `addLiquidity` changes rates of the wrappers when performing intermediate wrap / unwrap states,
+        // whereas `query` does not. Then, the final steps of the query are computed based off different values
+        // wrt. the actual operation, which in turn produces a different result. In general, the wrappers will round
+        // in their favor, so the query should produce a result that is more favorable to the user than the actual
+        // operation.
+        assertApproxEqAbs(exactBptOut, queryBptOut, 10, "BPT out do not match");
+        assertLt(exactBptOut, queryBptOut, "Wrapper rounding direction is incorrect");
+    }
+
+    function testAddLiquidityNestedPoolMissingToken() public {
+        uint256 daiAmount = poolInitAmount;
+        uint256 usdcAmount = poolInitAmount;
+        uint256 wethAmount = poolInitAmount;
+        // WstETH token won't be added to the Add Liquidity Unbalanced, but the operation should succeed.
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        vars.daiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        address[] memory tokensIn = new address[](3);
+        tokensIn[vars.daiIdx] = address(dai);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+
+        uint256[] memory amountsIn = new uint256[](3);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+
+        vm.prank(lp);
+        uint256 exactBptOut = compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPool,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 mintedChildPoolABpt = vars.childPoolAAfter.totalSupply - vars.childPoolABefore.totalSupply;
+        uint256 mintedChildPoolBBpt = vars.childPoolBAfter.totalSupply - vars.childPoolBBefore.totalSupply;
+
+        // Check exact BPT out.
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in.
+        uint256 expectedBptOut = daiAmount + usdcAmount + wethAmount;
+        assertApproxEqAbs(exactBptOut, expectedBptOut, 10, "Exact BPT amount out is wrong");
+        assertLt(exactBptOut, expectedBptOut, "BPT out rounding direction is wrong");
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai - amountsIn[vars.daiIdx], "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth - amountsIn[vars.wethIdx], "LP Weth Balance is wrong");
+        // WstETH is the missing token, so its amount does not change.
+        assertEq(vars.lpAfter.wsteth, vars.lpBefore.wsteth, "LP Wsteth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc - amountsIn[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(vars.lpAfter.childPoolABpt, vars.lpBefore.childPoolABpt, "LP ChildPoolA BPT Balance is wrong");
+        assertEq(vars.lpAfter.childPoolBBpt, vars.lpBefore.childPoolBBpt, "LP ChildPoolB BPT Balance is wrong");
+        assertEq(
+            vars.lpAfter.parentPoolBpt,
+            vars.lpBefore.parentPoolBpt + exactBptOut,
+            "LP ParentPool BPT Balance is wrong"
+        );
+
+        // Check Vault Balances.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai + amountsIn[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth + amountsIn[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(vars.vaultAfter.wsteth, vars.vaultBefore.wsteth, "Vault Wsteth Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc + amountsIn[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        // Since all Child Pool BPT were allocated in the parent pool, vault is holding all of the minted BPT.
+        assertEq(
+            vars.vaultAfter.childPoolABpt,
+            vars.vaultBefore.childPoolABpt + mintedChildPoolABpt,
+            "Vault ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.vaultAfter.childPoolBBpt,
+            vars.vaultBefore.childPoolBBpt + mintedChildPoolBBpt,
+            "Vault ChildPoolB BPT Balance is wrong"
+        );
+        // Vault's parent pool BPT did not change.
+        assertEq(
+            vars.vaultAfter.parentPoolBpt,
+            vars.vaultBefore.parentPoolBpt,
+            "Vault ParentPool BPT Balance is wrong"
+        );
+
+        // Check ChildPoolA balances.
+        assertEq(
+            vars.childPoolAAfter.weth,
+            vars.childPoolABefore.weth + amountsIn[vars.wethIdx],
+            "ChildPoolA Weth Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolAAfter.usdc,
+            vars.childPoolABefore.usdc + amountsIn[vars.usdcIdx],
+            "ChildPoolA Usdc Balance is wrong"
+        );
+
+        // Check ChildPoolB balances.
+        assertApproxEqAbs(
+            vars.childPoolBAfter.dai,
+            vars.childPoolBBefore.dai,
+            MAX_ROUND_ERROR,
+            "ChildPoolB Dai Balance is wrong"
+        );
+        assertEq(vars.childPoolBAfter.wsteth, vars.childPoolBBefore.wsteth, "ChildPoolB Wsteth Balance is wrong");
+
+        // Check ParentPool balances.
+        // The ParentPool's DAI balance does not change since all DAI amount is inserted in the child pool A.
+        assertEq(
+            vars.parentPoolAfter.dai,
+            vars.parentPoolBefore.dai + amountsIn[vars.daiIdx],
+            "ParentPool Dai Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolABpt,
+            vars.parentPoolBefore.childPoolABpt + mintedChildPoolABpt,
+            "ParentPool ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolBBpt,
+            vars.parentPoolBefore.childPoolBBpt + mintedChildPoolBBpt,
+            "ParentPool ChildPoolB BPT Balance is wrong"
+        );
+    }
+
+    function testAddLiquidityNestedPoolBptLimit() public {
+        uint256 daiAmount = poolInitAmount;
+        uint256 usdcAmount = poolInitAmount;
+        uint256 wethAmount = poolInitAmount;
+        uint256 wstEthAmount = poolInitAmount;
+
+        // Since all pools are linear and there's no rate, the expected BPT amount out is the sum of all amounts in
+        // minus rounding.
+        uint256 expectedBptOut = daiAmount + usdcAmount + wethAmount + wstEthAmount - 7;
+        uint256 minBptOut = 10 * poolInitAmount;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        address[] memory tokensIn = new address[](4);
+        tokensIn[vars.daiIdx] = address(dai);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+        tokensIn[vars.wstethIdx] = address(wsteth);
+
+        uint256[] memory amountsIn = new uint256[](4);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+        amountsIn[vars.wstethIdx] = wstEthAmount;
+
+        vm.prank(lp);
+        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.BptAmountOutBelowMin.selector, expectedBptOut, minBptOut));
+        compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPool,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+    }
+
+    function testAddLiquidityNestedPoolWrongTokenArray() public {
+        uint256 daiAmount = poolInitAmount;
+        uint256 usdcAmount = poolInitAmount;
+        uint256 wethAmount = poolInitAmount;
+        uint256 wstEthAmount = poolInitAmount;
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        address[] memory tokensIn = new address[](3);
+        tokensIn[0] = address(dai);
+        tokensIn[1] = address(usdc);
+        tokensIn[2] = address(weth);
+
+        uint256[] memory amountsIn = new uint256[](4);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+        amountsIn[vars.wstethIdx] = wstEthAmount;
+
+        vm.prank(lp);
+        // Since tokensIn and amountsIn have different lengths, revert.
+        vm.expectRevert(InputHelpers.InputLengthMismatch.selector);
+        compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPool,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+    }
+
+    function testAddLiquidityNestedPoolNonExistentToken() public {
+        ERC20TestToken newToken = new ERC20TestToken("New Token", "NT", 18);
+
+        uint256 daiAmount = poolInitAmount;
+        uint256 usdcAmount = poolInitAmount;
+        uint256 wethAmount = poolInitAmount;
+        uint256 wstEthAmount = poolInitAmount;
+        uint256 newTokenAmount = poolInitAmount;
+
+        uint256 minBptOut = 0;
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        address[] memory tokensIn = new address[](5);
+        tokensIn[vars.daiIdx] = address(dai);
+        tokensIn[vars.usdcIdx] = address(usdc);
+        tokensIn[vars.wethIdx] = address(weth);
+        tokensIn[vars.wstethIdx] = address(wsteth);
+        tokensIn[4] = address(newToken);
+
+        uint256[] memory amountsIn = new uint256[](5);
+        amountsIn[vars.daiIdx] = daiAmount;
+        amountsIn[vars.usdcIdx] = usdcAmount;
+        amountsIn[vars.wethIdx] = wethAmount;
+        amountsIn[vars.wstethIdx] = wstEthAmount;
+        amountsIn[4] = newTokenAmount;
+
+        vm.startPrank(lp);
+        // Mints amount to LP, so it can pay for the transaction in the router.
+        newToken.mint(lp, poolInitAmount);
+        // Allow permit2 to move newToken amounts from sender to the router.
+        newToken.approve(address(permit2), type(uint256).max);
+        permit2.approve(address(newToken), address(compositeLiquidityRouter), type(uint160).max, type(uint48).max);
+        // Since user passed a token that was not deposited in any pool, transaction reverts.
+        vm.expectRevert(IVaultErrors.BalanceNotSettled.selector);
+        compositeLiquidityRouter.addLiquidityUnbalancedNestedPool(
+            parentPool,
+            tokensIn,
+            amountsIn,
+            minBptOut,
+            false,
+            bytes("")
+        );
+        vm.stopPrank();
+    }
+
+    /*******************************************************************************
+                              Remove liquidity
+    *******************************************************************************/
+
+    function testRemoveLiquidityNestedPool__Fuzz(uint256 proportionToRemove) public {
+        // Remove between 0.0001% and 50% of each pool liquidity.
+        proportionToRemove = bound(proportionToRemove, 1e12, 50e16);
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPool).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        // During pool initialization, POOL_MINIMUM_TOTAL_SUPPLY amount of BPT is burned to address(0), so that the
+        // pool cannot be completely drained. We need to discount this amount of tokens from the total liquidity that
+        // we can extract from the child pools.
+        uint256 deadTokens = (POOL_MINIMUM_TOTAL_SUPPLY / 2).mulDown(proportionToRemove);
+
+        address[] memory tokensOut = new address[](4);
+        tokensOut[vars.daiIdx] = address(dai);
+        tokensOut[vars.wethIdx] = address(weth);
+        tokensOut[vars.wstethIdx] = address(wsteth);
+        tokensOut[vars.usdcIdx] = address(usdc);
+
+        uint256[] memory expectedAmountsOut = new uint256[](4);
+        // DAI exists in childPoolB and parentPool, so we expect 2x more DAI than the other tokens.
+        // Since pools are in their initial state, we can use poolInitAmount as the balance of each token in the pool.
+        // Also, we only need to account for deadTokens once, since we calculate the BPT in for the parent pool using
+        // totalSupply (so the burned POOL_MINIMUM_TOTAL_SUPPLY amount does not affect the BPT in circulation, and the
+        // amounts out are perfectly proportional to the parent pool balance).
+        expectedAmountsOut[vars.daiIdx] =
+            (poolInitAmount.mulDown(proportionToRemove) * 2) -
+            deadTokens -
+            MAX_ROUND_ERROR;
+        expectedAmountsOut[vars.wethIdx] = poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR;
+        expectedAmountsOut[vars.wstethIdx] = poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR;
+        expectedAmountsOut[vars.usdcIdx] = poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR;
+
+        vm.prank(lp);
+        uint256[] memory amountsOut = compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPool,
+            exactBptIn,
+            tokensOut,
+            expectedAmountsOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 burnedChildPoolABpt = vars.childPoolABefore.totalSupply - vars.childPoolAAfter.totalSupply;
+        uint256 burnedChildPoolBBpt = vars.childPoolBBefore.totalSupply - vars.childPoolBAfter.totalSupply;
+
+        // Check returned token amounts.
+        assertEq(amountsOut.length, 4, "amountsOut length is wrong");
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.daiIdx],
+            amountsOut[vars.daiIdx],
+            MAX_ROUND_ERROR,
+            "DAI amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.wethIdx],
+            amountsOut[vars.wethIdx],
+            MAX_ROUND_ERROR,
+            "WETH amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.wstethIdx],
+            amountsOut[vars.wstethIdx],
+            MAX_ROUND_ERROR,
+            "WstETH amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.usdcIdx],
+            amountsOut[vars.usdcIdx],
+            MAX_ROUND_ERROR,
+            "USDC amount out is wrong"
+        );
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai + amountsOut[vars.daiIdx], "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth + amountsOut[vars.wethIdx], "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.wsteth, vars.lpBefore.wsteth + amountsOut[vars.wstethIdx], "LP Wsteth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc + amountsOut[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(vars.lpAfter.childPoolABpt, vars.lpBefore.childPoolABpt, "LP ChildPoolA BPT Balance is wrong");
+        assertEq(vars.lpAfter.childPoolBBpt, vars.lpBefore.childPoolBBpt, "LP ChildPoolB BPT Balance is wrong");
+        assertEq(
+            vars.lpAfter.parentPoolBpt,
+            vars.lpBefore.parentPoolBpt - exactBptIn,
+            "LP ParentPool BPT Balance is wrong"
+        );
+
+        // Check Vault Balances.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai - amountsOut[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth - amountsOut[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(
+            vars.vaultAfter.wsteth,
+            vars.vaultBefore.wsteth - amountsOut[vars.wstethIdx],
+            "Vault Wsteth Balance is wrong"
+        );
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc - amountsOut[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        // Since all Child Pool BPT were allocated in the parent pool, vault was holding all of them. Since part of
+        // them was burned when liquidity was removed, we need to discount this amount from the Vault reserves.
+        assertEq(
+            vars.vaultAfter.childPoolABpt,
+            vars.vaultBefore.childPoolABpt - burnedChildPoolABpt,
+            "Vault ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.vaultAfter.childPoolBBpt,
+            vars.vaultBefore.childPoolBBpt - burnedChildPoolBBpt,
+            "Vault ChildPoolB BPT Balance is wrong"
+        );
+        // Vault did not hold the parent pool BPT.
+        assertEq(
+            vars.vaultAfter.parentPoolBpt,
+            vars.vaultBefore.parentPoolBpt,
+            "Vault ParentPool BPT Balance is wrong"
+        );
+
+        // Check ChildPoolA
+        assertEq(
+            vars.childPoolAAfter.weth,
+            vars.childPoolABefore.weth - amountsOut[vars.wethIdx],
+            "ChildPoolA Weth Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolAAfter.usdc,
+            vars.childPoolABefore.usdc - amountsOut[vars.usdcIdx],
+            "ChildPoolA Usdc Balance is wrong"
+        );
+
+        // Check ChildPoolB.
+        // Since DAI amountOut comes from parentPool and childPoolB, we need to calculate the proportion that comes
+        // from childPoolB.
+        assertApproxEqAbs(
+            vars.childPoolBAfter.dai,
+            vars.childPoolBBefore.dai - (amountsOut[vars.daiIdx] - poolInitAmount.mulDown(proportionToRemove)),
+            MAX_ROUND_ERROR,
+            "ChildPoolB Dai Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolBAfter.wsteth,
+            vars.childPoolBBefore.wsteth - amountsOut[vars.wstethIdx],
+            "ChildPoolB Wsteth Balance is wrong"
+        );
+
+        // Check ParentPool.
+        assertApproxEqAbs(
+            vars.parentPoolAfter.dai,
+            vars.parentPoolBefore.dai -
+                (amountsOut[vars.daiIdx] -
+                    (poolInitAmount - (POOL_MINIMUM_TOTAL_SUPPLY / 2)).mulDown(proportionToRemove)),
+            MAX_ROUND_ERROR,
+            "ParentPool Dai Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolABpt,
+            vars.parentPoolBefore.childPoolABpt - burnedChildPoolABpt,
+            "ParentPool ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolBBpt,
+            vars.parentPoolBefore.childPoolBBpt - burnedChildPoolBBpt,
+            "ParentPool ChildPoolB BPT Balance is wrong"
+        );
+    }
+
+    function testRemoveLiquidityNestedPoolWithEth__Fuzz(uint256 proportionToRemove) public {
+        // Remove between 0.0001% and 50% of each pool liquidity.
+        proportionToRemove = bound(proportionToRemove, 1e12, 50e16);
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPool).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        // During pool initialization, POOL_MINIMUM_TOTAL_SUPPLY amount of BPT is burned to address(0), so that the
+        // pool cannot be completely drained. We need to discount this amount of tokens from the total liquidity that
+        // we can extract from the child pools.
+        uint256 deadTokens = (POOL_MINIMUM_TOTAL_SUPPLY / 2).mulDown(proportionToRemove);
+
+        address[] memory tokensOut = new address[](4);
+        tokensOut[vars.daiIdx] = address(dai);
+        tokensOut[vars.wethIdx] = address(weth);
+        tokensOut[vars.wstethIdx] = address(wsteth);
+        tokensOut[vars.usdcIdx] = address(usdc);
+
+        uint256[] memory expectedAmountsOut = new uint256[](4);
+        // DAI exists in childPoolB and parentPool, so we expect 2x more DAI than the other tokens.
+        // Since pools are in their initial state, we can use poolInitAmount as the balance of each token in the pool.
+        // Also, we only need to account for deadTokens once, since we calculate the BPT in for the parent pool using
+        // totalSupply (so the burned POOL_MINIMUM_TOTAL_SUPPLY amount does not affect the BPT in circulation, and the
+        // amounts out are perfectly proportional to the parent pool balance).
+        expectedAmountsOut[vars.daiIdx] =
+            (poolInitAmount.mulDown(proportionToRemove) * 2) -
+            deadTokens -
+            MAX_ROUND_ERROR;
+        expectedAmountsOut[vars.wethIdx] = poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR;
+        expectedAmountsOut[vars.wstethIdx] = poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR;
+        expectedAmountsOut[vars.usdcIdx] = poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR;
+
+        vm.prank(lp);
+        uint256[] memory amountsOut = compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPool,
+            exactBptIn,
+            tokensOut,
+            expectedAmountsOut,
+            true,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 burnedChildPoolABpt = vars.childPoolABefore.totalSupply - vars.childPoolAAfter.totalSupply;
+        uint256 burnedChildPoolBBpt = vars.childPoolBBefore.totalSupply - vars.childPoolBAfter.totalSupply;
+
+        // Check returned token amounts.
+        assertEq(amountsOut.length, 4, "amountsOut length is wrong");
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.daiIdx],
+            amountsOut[vars.daiIdx],
+            MAX_ROUND_ERROR,
+            "DAI amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.wethIdx],
+            amountsOut[vars.wethIdx],
+            MAX_ROUND_ERROR,
+            "WETH amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.wstethIdx],
+            amountsOut[vars.wstethIdx],
+            MAX_ROUND_ERROR,
+            "WstETH amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.usdcIdx],
+            amountsOut[vars.usdcIdx],
+            MAX_ROUND_ERROR,
+            "USDC amount out is wrong"
+        );
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai + amountsOut[vars.daiIdx], "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.wsteth, vars.lpBefore.wsteth + amountsOut[vars.wstethIdx], "LP Wsteth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc + amountsOut[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(vars.lpAfter.childPoolABpt, vars.lpBefore.childPoolABpt, "LP ChildPoolA BPT Balance is wrong");
+        assertEq(vars.lpAfter.childPoolBBpt, vars.lpBefore.childPoolBBpt, "LP ChildPoolB BPT Balance is wrong");
+        assertEq(
+            vars.lpAfter.parentPoolBpt,
+            vars.lpBefore.parentPoolBpt - exactBptIn,
+            "LP ParentPool BPT Balance is wrong"
+        );
+
+        // LP should get ETH instead of WETH.
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth, "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.eth, vars.lpBefore.eth + amountsOut[vars.wethIdx], "LP ETH Balance is wrong");
+
+        // Check Vault Balances.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai - amountsOut[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth - amountsOut[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(
+            vars.vaultAfter.wsteth,
+            vars.vaultBefore.wsteth - amountsOut[vars.wstethIdx],
+            "Vault Wsteth Balance is wrong"
+        );
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc - amountsOut[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        // Since all Child Pool BPT were allocated in the parent pool, vault was holding all of them. Since part of
+        // them was burned when liquidity was removed, we need to discount this amount from the Vault reserves.
+        assertEq(
+            vars.vaultAfter.childPoolABpt,
+            vars.vaultBefore.childPoolABpt - burnedChildPoolABpt,
+            "Vault ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.vaultAfter.childPoolBBpt,
+            vars.vaultBefore.childPoolBBpt - burnedChildPoolBBpt,
+            "Vault ChildPoolB BPT Balance is wrong"
+        );
+        // Vault did not hold the parent pool BPT.
+        assertEq(
+            vars.vaultAfter.parentPoolBpt,
+            vars.vaultBefore.parentPoolBpt,
+            "Vault ParentPool BPT Balance is wrong"
+        );
+
+        // Check ChildPoolA
+        assertEq(
+            vars.childPoolAAfter.weth,
+            vars.childPoolABefore.weth - amountsOut[vars.wethIdx],
+            "ChildPoolA Weth Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolAAfter.usdc,
+            vars.childPoolABefore.usdc - amountsOut[vars.usdcIdx],
+            "ChildPoolA Usdc Balance is wrong"
+        );
+
+        // Check ChildPoolB.
+        // Since DAI amountOut comes from parentPool and childPoolB, we need to calculate the proportion that comes
+        // from childPoolB.
+        assertApproxEqAbs(
+            vars.childPoolBAfter.dai,
+            vars.childPoolBBefore.dai - (amountsOut[vars.daiIdx] - poolInitAmount.mulDown(proportionToRemove)),
+            MAX_ROUND_ERROR,
+            "ChildPoolB Dai Balance is wrong"
+        );
+        assertEq(
+            vars.childPoolBAfter.wsteth,
+            vars.childPoolBBefore.wsteth - amountsOut[vars.wstethIdx],
+            "ChildPoolB Wsteth Balance is wrong"
+        );
+
+        // Check ParentPool.
+        assertApproxEqAbs(
+            vars.parentPoolAfter.dai,
+            vars.parentPoolBefore.dai -
+                (amountsOut[vars.daiIdx] -
+                    (poolInitAmount - (POOL_MINIMUM_TOTAL_SUPPLY / 2)).mulDown(proportionToRemove)),
+            MAX_ROUND_ERROR,
+            "ParentPool Dai Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolABpt,
+            vars.parentPoolBefore.childPoolABpt - burnedChildPoolABpt,
+            "ParentPool ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolAfter.childPoolBBpt,
+            vars.parentPoolBefore.childPoolBBpt - burnedChildPoolBBpt,
+            "ParentPool ChildPoolB BPT Balance is wrong"
+        );
+
+        assertEq(address(compositeLiquidityRouter).balance, 0, "Router has eth balance");
+    }
+
+    function testRemoveLiquidityNestedERC4626Pool__Fuzz(uint256 proportionToRemove) public {
+        // Remove between 0.0001% and 50% of each pool liquidity.
+        proportionToRemove = bound(proportionToRemove, 1e12, 50e16);
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPoolWithWrapper).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.daiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        // During pool initialization, POOL_MINIMUM_TOTAL_SUPPLY amount of BPT is burned to address(0), so that the
+        // pool cannot be completely drained. We need to discount this amount of tokens from the total liquidity that
+        // we can extract from the child pools.
+        uint256 deadTokens = (POOL_MINIMUM_TOTAL_SUPPLY / 4).mulDown(proportionToRemove);
+
+        address[] memory tokensOut = new address[](3);
+        tokensOut[vars.daiIdx] = address(dai);
+        tokensOut[vars.wethIdx] = address(weth);
+        tokensOut[vars.usdcIdx] = address(usdc);
+
+        uint256[] memory expectedAmountsOut = new uint256[](3);
+        // Since pools are in their initial state, we can use poolInitAmount as the balance of each token in the pool.
+        // Also, we only need to account for deadTokens once, since we calculate the BPT in for the parent pool using
+        // totalSupply (so the burned POOL_MINIMUM_TOTAL_SUPPLY amount does not affect the BPT in circulation, and the
+        // amounts out are perfectly proportional to the parent pool balance).
+        expectedAmountsOut[vars.daiIdx] = _vaultPreviewRedeem(
+            waDAI,
+            poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR
+        );
+        expectedAmountsOut[vars.wethIdx] = _vaultPreviewRedeem(
+            waWETH,
+            poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR
+        );
+        expectedAmountsOut[vars.usdcIdx] = _vaultPreviewRedeem(
+            waUSDC,
+            poolInitAmount.mulDown(proportionToRemove) - MAX_ROUND_ERROR
+        );
+
+        vm.prank(lp);
+        uint256[] memory amountsOut = compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPoolWithWrapper,
+            exactBptIn,
+            tokensOut,
+            expectedAmountsOut,
+            false,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 burnedChildPoolERC4626Bpt = vars.childPoolERC4626Before.totalSupply -
+            vars.childPoolERC4626After.totalSupply;
+
+        // Check returned token amounts.
+        assertEq(amountsOut.length, 3, "amountsOut length is wrong");
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.daiIdx],
+            amountsOut[vars.daiIdx],
+            6 * MAX_ROUND_ERROR, // Increasing error because of ERC4626 conversion rounding
+            "DAI amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.wethIdx],
+            amountsOut[vars.wethIdx],
+            6 * MAX_ROUND_ERROR, // Increasing error because of ERC4626 conversion rounding
+            "WETH amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.usdcIdx],
+            amountsOut[vars.usdcIdx],
+            6 * MAX_ROUND_ERROR, // Increasing error because of ERC4626 conversion rounding
+            "USDC amount out is wrong"
+        );
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai + amountsOut[vars.daiIdx], "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth + amountsOut[vars.wethIdx], "LP Weth Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc + amountsOut[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(
+            vars.lpAfter.childPoolERC4626Bpt,
+            vars.lpBefore.childPoolERC4626Bpt,
+            "LP ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.lpAfter.parentPoolWithWrapperBpt,
+            vars.lpBefore.parentPoolWithWrapperBpt - exactBptIn,
+            "LP ParentPool BPT Balance is wrong"
+        );
+
+        // Check Vault Balances. Since the buffer has liquidity, the Vault only lost underlying amounts.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai - amountsOut[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.waDAI, vars.vaultBefore.waDAI, "Vault waDai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth - amountsOut[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(vars.vaultAfter.waWETH, vars.vaultBefore.waWETH, "Vault waWETH Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc - amountsOut[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        assertEq(vars.vaultAfter.waUSDC, vars.vaultBefore.waUSDC, "Vault waUSDC Balance is wrong");
+
+        // Since all Child Pool BPT were allocated in the parent pool, vault was holding all of them. Since part of
+        // them was burned when liquidity was removed, we need to discount this amount from the Vault reserves.
+        assertEq(
+            vars.vaultAfter.childPoolERC4626Bpt,
+            vars.vaultBefore.childPoolERC4626Bpt - burnedChildPoolERC4626Bpt,
+            "Vault childPoolERC4626 BPT Balance is wrong"
+        );
+
+        // Vault did not hold the parent pool BPT.
+        assertEq(
+            vars.vaultAfter.parentPoolWithWrapperBpt,
+            vars.vaultBefore.parentPoolWithWrapperBpt,
+            "Vault ParentPoolWithWrapper BPT Balance is wrong"
+        );
+
+        // Check ChildPoolERC4626
+        assertEq(
+            vars.childPoolERC4626After.waWETH,
+            vars.childPoolERC4626Before.waWETH - _vaultPreviewWithdraw(waWETH, amountsOut[vars.wethIdx]),
+            "ChildPoolERC4626 Weth Balance is wrong"
+        );
+        assertApproxEqAbs(
+            vars.childPoolERC4626After.waDAI,
+            vars.childPoolERC4626Before.waDAI - _vaultPreviewWithdraw(waDAI, amountsOut[vars.daiIdx]),
+            MAX_ROUND_ERROR,
+            "ChildPoolERC4626 waDAI Balance is wrong"
+        );
+
+        // Check ParentPoolWithWrapper.
+        assertApproxEqAbs(
+            vars.parentPoolWithWrapperAfter.waUSDC,
+            vars.parentPoolWithWrapperBefore.waUSDC - _vaultPreviewWithdraw(waUSDC, amountsOut[vars.usdcIdx]),
+            MAX_ROUND_ERROR,
+            "ParentPoolWithWrapper waUSDC Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolWithWrapperAfter.childPoolERC4626Bpt,
+            vars.parentPoolWithWrapperBefore.childPoolERC4626Bpt - burnedChildPoolERC4626Bpt,
+            "ParentPool ChildPoolERC4626 BPT Balance is wrong"
+        );
+    }
+
+    function testRemoveLiquidityNestedERC4626PoolWithEth__Fuzz(uint256 proportionToRemove) public {
+        // Remove between 0.0001% and 50% of each pool liquidity.
+        proportionToRemove = bound(proportionToRemove, 1e12, 50e16);
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPoolWithWrapper).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.daiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        // During pool initialization, POOL_MINIMUM_TOTAL_SUPPLY amount of BPT is burned to address(0), so that the
+        // pool cannot be completely drained. We need to discount this amount of tokens from the total liquidity that
+        // we can extract from the child pools.
+        uint256 deadTokens = (POOL_MINIMUM_TOTAL_SUPPLY / 4).mulDown(proportionToRemove);
+
+        address[] memory tokensOut = new address[](3);
+        tokensOut[vars.daiIdx] = address(dai);
+        tokensOut[vars.wethIdx] = address(weth);
+        tokensOut[vars.usdcIdx] = address(usdc);
+
+        uint256[] memory expectedAmountsOut = new uint256[](3);
+        // Since pools are in their initial state, we can use poolInitAmount as the balance of each token in the pool.
+        // Also, we only need to account for deadTokens once, since we calculate the BPT in for the parent pool using
+        // totalSupply (so the burned POOL_MINIMUM_TOTAL_SUPPLY amount does not affect the BPT in circulation, and the
+        // amounts out are perfectly proportional to the parent pool balance).
+        expectedAmountsOut[vars.daiIdx] = _vaultPreviewRedeem(
+            waDAI,
+            poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR
+        );
+        expectedAmountsOut[vars.wethIdx] = _vaultPreviewRedeem(
+            waWETH,
+            poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR
+        );
+        expectedAmountsOut[vars.usdcIdx] = _vaultPreviewRedeem(
+            waUSDC,
+            poolInitAmount.mulDown(proportionToRemove) - MAX_ROUND_ERROR
+        );
+
+        vm.prank(lp);
+        uint256[] memory amountsOut = compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPoolWithWrapper,
+            exactBptIn,
+            tokensOut,
+            expectedAmountsOut,
+            true,
+            bytes("")
+        );
+
+        _fillNestedPoolTestLocalsAfter(vars);
+        uint256 burnedChildPoolERC4626Bpt = vars.childPoolERC4626Before.totalSupply -
+            vars.childPoolERC4626After.totalSupply;
+
+        // Check returned token amounts.
+        assertEq(amountsOut.length, 3, "amountsOut length is wrong");
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.daiIdx],
+            amountsOut[vars.daiIdx],
+            6 * MAX_ROUND_ERROR, // Increasing error because of ERC4626 conversion rounding
+            "DAI amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.wethIdx],
+            amountsOut[vars.wethIdx],
+            6 * MAX_ROUND_ERROR, // Increasing error because of ERC4626 conversion rounding
+            "WETH amount out is wrong"
+        );
+        assertApproxEqAbs(
+            expectedAmountsOut[vars.usdcIdx],
+            amountsOut[vars.usdcIdx],
+            6 * MAX_ROUND_ERROR, // Increasing error because of ERC4626 conversion rounding
+            "USDC amount out is wrong"
+        );
+
+        // Check LP Balances.
+        assertEq(vars.lpAfter.dai, vars.lpBefore.dai + amountsOut[vars.daiIdx], "LP Dai Balance is wrong");
+        assertEq(vars.lpAfter.usdc, vars.lpBefore.usdc + amountsOut[vars.usdcIdx], "LP Usdc Balance is wrong");
+        assertEq(
+            vars.lpAfter.childPoolERC4626Bpt,
+            vars.lpBefore.childPoolERC4626Bpt,
+            "LP ChildPoolA BPT Balance is wrong"
+        );
+        assertEq(
+            vars.lpAfter.parentPoolWithWrapperBpt,
+            vars.lpBefore.parentPoolWithWrapperBpt - exactBptIn,
+            "LP ParentPool BPT Balance is wrong"
+        );
+
+        // LP should get ETH instead of WETH.
+        assertEq(vars.lpAfter.eth, vars.lpBefore.eth + amountsOut[vars.wethIdx], "LP Eth Balance is wrong");
+        assertEq(vars.lpAfter.weth, vars.lpBefore.weth, "LP Weth Balance is wrong");
+
+        // Check Vault Balances. Since the buffer has liquidity, the Vault only lost underlying amounts.
+        assertEq(vars.vaultAfter.dai, vars.vaultBefore.dai - amountsOut[vars.daiIdx], "Vault Dai Balance is wrong");
+        assertEq(vars.vaultAfter.waDAI, vars.vaultBefore.waDAI, "Vault waDai Balance is wrong");
+        assertEq(vars.vaultAfter.weth, vars.vaultBefore.weth - amountsOut[vars.wethIdx], "Vault Weth Balance is wrong");
+        assertEq(vars.vaultAfter.waWETH, vars.vaultBefore.waWETH, "Vault waWETH Balance is wrong");
+        assertEq(vars.vaultAfter.usdc, vars.vaultBefore.usdc - amountsOut[vars.usdcIdx], "Vault Usdc Balance is wrong");
+        assertEq(vars.vaultAfter.waUSDC, vars.vaultBefore.waUSDC, "Vault waUSDC Balance is wrong");
+
+        // Since all Child Pool BPT were allocated in the parent pool, vault was holding all of them. Since part of
+        // them was burned when liquidity was removed, we need to discount this amount from the Vault reserves.
+        assertEq(
+            vars.vaultAfter.childPoolERC4626Bpt,
+            vars.vaultBefore.childPoolERC4626Bpt - burnedChildPoolERC4626Bpt,
+            "Vault childPoolERC4626 BPT Balance is wrong"
+        );
+
+        // Vault did not hold the parent pool BPT.
+        assertEq(
+            vars.vaultAfter.parentPoolWithWrapperBpt,
+            vars.vaultBefore.parentPoolWithWrapperBpt,
+            "Vault ParentPoolWithWrapper BPT Balance is wrong"
+        );
+
+        // Check ChildPoolERC4626
+        assertEq(
+            vars.childPoolERC4626After.waWETH,
+            vars.childPoolERC4626Before.waWETH - _vaultPreviewWithdraw(waWETH, amountsOut[vars.wethIdx]),
+            "ChildPoolERC4626 Weth Balance is wrong"
+        );
+        assertApproxEqAbs(
+            vars.childPoolERC4626After.waDAI,
+            vars.childPoolERC4626Before.waDAI - _vaultPreviewWithdraw(waDAI, amountsOut[vars.daiIdx]),
+            MAX_ROUND_ERROR,
+            "ChildPoolERC4626 waDAI Balance is wrong"
+        );
+
+        // Check ParentPoolWithWrapper.
+        assertApproxEqAbs(
+            vars.parentPoolWithWrapperAfter.waUSDC,
+            vars.parentPoolWithWrapperBefore.waUSDC - _vaultPreviewWithdraw(waUSDC, amountsOut[vars.usdcIdx]),
+            MAX_ROUND_ERROR,
+            "ParentPoolWithWrapper waUSDC Balance is wrong"
+        );
+        assertEq(
+            vars.parentPoolWithWrapperAfter.childPoolERC4626Bpt,
+            vars.parentPoolWithWrapperBefore.childPoolERC4626Bpt - burnedChildPoolERC4626Bpt,
+            "ParentPool ChildPoolERC4626 BPT Balance is wrong"
+        );
+
+        assertEq(address(compositeLiquidityRouter).balance, 0, "Router has eth balance");
+    }
+
+    function testQueryRemoveLiquidityNestedERC4626Pool__Fuzz(uint256 proportionToRemove) public {
+        // Remove between 0.0001% and 50% of each pool liquidity.
+        proportionToRemove = bound(proportionToRemove, 1e12, 50e16);
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPoolWithWrapper).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+        // Override indexes, since wstEth is not used in this test.
+        vars.daiIdx = 0;
+        vars.usdcIdx = 1;
+        vars.wethIdx = 2;
+
+        // During pool initialization, POOL_MINIMUM_TOTAL_SUPPLY amount of BPT is burned to address(0), so that the
+        // pool cannot be completely drained. We need to discount this amount of tokens from the total liquidity that
+        // we can extract from the child pools.
+        uint256 deadTokens = (POOL_MINIMUM_TOTAL_SUPPLY / 4).mulDown(proportionToRemove);
+
+        address[] memory tokensOut = new address[](3);
+        tokensOut[vars.daiIdx] = address(dai);
+        tokensOut[vars.wethIdx] = address(weth);
+        tokensOut[vars.usdcIdx] = address(usdc);
+
+        uint256[] memory expectedAmountsOut = new uint256[](3);
+        // Since pools are in their initial state, we can use poolInitAmount as the balance of each token in the pool.
+        // Also, we only need to account for deadTokens once, since we calculate the BPT in for the parent pool using
+        // totalSupply (so the burned POOL_MINIMUM_TOTAL_SUPPLY amount does not affect the BPT in circulation, and the
+        // amounts out are perfectly proportional to the parent pool balance).
+        expectedAmountsOut[vars.daiIdx] = _vaultPreviewRedeem(
+            waDAI,
+            poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR
+        );
+        expectedAmountsOut[vars.wethIdx] = _vaultPreviewRedeem(
+            waWETH,
+            poolInitAmount.mulDown(proportionToRemove) - deadTokens - MAX_ROUND_ERROR
+        );
+        expectedAmountsOut[vars.usdcIdx] = _vaultPreviewRedeem(
+            waUSDC,
+            poolInitAmount.mulDown(proportionToRemove) - MAX_ROUND_ERROR
+        );
+
+        uint256 snapshotId = vm.snapshot();
+        _prankStaticCall();
+        uint256[] memory queryAmountsOut = compositeLiquidityRouter.queryRemoveLiquidityProportionalNestedPool(
+            parentPoolWithWrapper,
+            exactBptIn,
+            tokensOut,
+            address(this),
+            bytes("")
+        );
+        vm.revertTo(snapshotId);
+
+        vm.prank(lp);
+        uint256[] memory amountsOut = compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPoolWithWrapper,
+            exactBptIn,
+            tokensOut,
+            expectedAmountsOut,
+            false,
+            bytes("")
+        );
+
+        for (uint256 i = 0; i < amountsOut.length; i++) {
+            assertEq(amountsOut[i], queryAmountsOut[i], "AmountsOut and QueryAmountsOut do not match");
+        }
+    }
+
+    function testRemoveLiquidityNestedPoolLimits() public {
+        // Remove 10% of pool liquidity.
+        uint256 proportionToRemove = 10e16;
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPool).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        // During pool initialization, POOL_MINIMUM_TOTAL_SUPPLY amount of BPT is burned to address(0), so that the
+        // pool cannot be completely drained. We need to discount this amount of tokens from the total liquidity that
+        // we can extract from the child pools.
+        uint256 deadTokens = (POOL_MINIMUM_TOTAL_SUPPLY / 2).mulDown(proportionToRemove);
+
+        address[] memory tokensOut = new address[](4);
+        tokensOut[vars.daiIdx] = address(dai);
+        tokensOut[vars.wethIdx] = address(weth);
+        tokensOut[vars.wstethIdx] = address(wsteth);
+        tokensOut[vars.usdcIdx] = address(usdc);
+
+        uint256[] memory minAmountsOut = new uint256[](4);
+        // Expect minAmountsOut to be the liquidity of the pool, which is more than what we should return,
+        // causing it to revert.
+        minAmountsOut[vars.daiIdx] = poolInitAmount;
+        minAmountsOut[vars.wethIdx] = poolInitAmount;
+        minAmountsOut[vars.wstethIdx] = poolInitAmount;
+        minAmountsOut[vars.usdcIdx] = poolInitAmount;
+
+        // DAI exists in childPoolB and parentPool, so we expect 2x more DAI than the other tokens.
+        // Since pools are in their initial state, we can use poolInitAmount as the balance of each token in the pool.
+        // Also, we only need to account for deadTokens once, since we calculate the BPT in for the parent pool using
+        // totalSupply (so the burned POOL_MINIMUM_TOTAL_SUPPLY amount does not affect the BPT in circulation, and the
+        // amounts out are perfectly proportional to the parent pool balance).
+
+        uint256 daiExpectedAmountOut = (poolInitAmount.mulDown(proportionToRemove) * 2) - deadTokens;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IVaultErrors.AmountOutBelowMin.selector,
+                address(dai),
+                daiExpectedAmountOut,
+                poolInitAmount
+            )
+        );
+        vm.prank(lp);
+        compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPool,
+            exactBptIn,
+            tokensOut,
+            minAmountsOut,
+            false,
+            bytes("")
+        );
+    }
+
+    function testRemoveLiquidityNestedPoolWrongMinAmountsOut() public {
+        // Remove 10% of pool liquidity.
+        uint256 proportionToRemove = 10e16;
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPool).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        NestedPoolTestLocals memory vars = _createNestedPoolTestLocals();
+
+        address[] memory tokensOut = new address[](4);
+        tokensOut[vars.daiIdx] = address(dai);
+        tokensOut[vars.wethIdx] = address(weth);
+        tokensOut[vars.wstethIdx] = address(wsteth);
+        tokensOut[vars.usdcIdx] = address(usdc);
+
+        // Notice that minAmountsOut have a different length than tokensOut, so the transaction should revert.
+        uint256[] memory minAmountsOut = new uint256[](3);
+        minAmountsOut[0] = 1;
+        minAmountsOut[1] = 1;
+        minAmountsOut[2] = 1;
+
+        vm.expectRevert(InputHelpers.InputLengthMismatch.selector);
+
+        vm.prank(lp);
+        compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPool,
+            exactBptIn,
+            tokensOut,
+            minAmountsOut,
+            false,
+            bytes("")
+        );
+    }
+
+    function testRemoveLiquidityNestedPoolWrongTokenArray() public {
+        // Remove 10% of pool liquidity.
+        uint256 proportionToRemove = 10e16;
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPool).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        // DAI should be in the tokensOut array, but is not, so the transaction should revert.
+        // Order extracted from _currentSwapTokensOut().values() of `removeLiquidityProportionalNestedPool` after
+        // all child pools were called.
+        address[] memory expectedTokensOut = new address[](4);
+        expectedTokensOut[0] = address(dai);
+        expectedTokensOut[1] = address(wsteth);
+        expectedTokensOut[2] = address(weth);
+        expectedTokensOut[3] = address(usdc);
+
+        // Notice that tokensOut and minAmountsOut do not have DAI, so the transaction will revert.
+        address[] memory tokensOut = new address[](3);
+        tokensOut[0] = address(weth);
+        tokensOut[1] = address(wsteth);
+        tokensOut[2] = address(usdc);
+
+        uint256[] memory minAmountsOut = new uint256[](3);
+        minAmountsOut[0] = 1;
+        minAmountsOut[1] = 1;
+        minAmountsOut[2] = 1;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(ICompositeLiquidityRouter.WrongTokensOut.selector, expectedTokensOut, tokensOut)
+        );
+
+        vm.prank(lp);
+        compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPool,
+            exactBptIn,
+            tokensOut,
+            minAmountsOut,
+            false,
+            bytes("")
+        );
+    }
+
+    function testRemoveLiquidityNestedPoolRepeatedTokens() public {
+        // Remove 10% of pool liquidity.
+        uint256 proportionToRemove = 10e16;
+
+        uint256 totalPoolBPT = BalancerPoolToken(parentPool).totalSupply();
+        // Since LP is the owner of all BPT supply, and part of the BPT were burned in the initialization step, using
+        // totalSupply is more accurate to remove exactly the proportion that we intend from each pool.
+        uint256 exactBptIn = totalPoolBPT.mulDown(proportionToRemove);
+
+        // DAI should be in the tokensOut array, but is not, so the transaction should revert.
+        // Order extracted from _currentSwapTokensOut().values() of `removeLiquidityProportionalNestedPool` after
+        // all child pools were called.
+        address[] memory expectedTokensOut = new address[](4);
+        expectedTokensOut[0] = address(dai);
+        expectedTokensOut[1] = address(wsteth);
+        expectedTokensOut[2] = address(weth);
+        expectedTokensOut[3] = address(usdc);
+
+        // Notice that tokensOut has a repeated token, so the transaction should be reverted.
+        address[] memory tokensOut = new address[](4);
+        tokensOut[0] = address(dai);
+        tokensOut[1] = address(weth);
+        tokensOut[2] = address(dai);
+        tokensOut[3] = address(usdc);
+
+        uint256[] memory minAmountsOut = new uint256[](4);
+        minAmountsOut[0] = 1;
+        minAmountsOut[1] = 1;
+        minAmountsOut[2] = 1;
+        minAmountsOut[3] = 1;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(ICompositeLiquidityRouter.WrongTokensOut.selector, expectedTokensOut, tokensOut)
+        );
+
+        vm.prank(lp);
+        compositeLiquidityRouter.removeLiquidityProportionalNestedPool(
+            parentPool,
+            exactBptIn,
+            tokensOut,
+            minAmountsOut,
+            false,
+            bytes("")
+        );
+    }
+
+    struct NestedPoolTestLocals {
+        uint256 daiIdx;
+        uint256 wethIdx;
+        uint256 wstethIdx;
+        uint256 usdcIdx;
+        uint256 waDaiIdx;
+        uint256 waWethIdx;
+        uint256 waUsdcIdx;
+        TokenBalances lpBefore;
+        TokenBalances lpAfter;
+        TokenBalances vaultBefore;
+        TokenBalances vaultAfter;
+        TokenBalances childPoolABefore;
+        TokenBalances childPoolAAfter;
+        TokenBalances childPoolBBefore;
+        TokenBalances childPoolBAfter;
+        TokenBalances childPoolERC4626Before;
+        TokenBalances childPoolERC4626After;
+        TokenBalances parentPoolBefore;
+        TokenBalances parentPoolAfter;
+        TokenBalances parentPoolWithoutWrapperBefore;
+        TokenBalances parentPoolWithoutWrapperAfter;
+        TokenBalances parentPoolWithWrapperBefore;
+        TokenBalances parentPoolWithWrapperAfter;
+    }
+
+    struct TokenBalances {
+        uint256 dai;
+        uint256 eth;
+        uint256 weth;
+        uint256 wsteth;
+        uint256 usdc;
+        uint256 waDAI;
+        uint256 waWETH;
+        uint256 waUSDC;
+        uint256 childPoolABpt;
+        uint256 childPoolBBpt;
+        uint256 childPoolERC4626Bpt;
+        uint256 parentPoolBpt;
+        uint256 parentPoolWithoutWrapperBpt;
+        uint256 parentPoolWithWrapperBpt;
+        uint256 totalSupply;
+    }
+
+    function _createNestedPoolTestLocals() private view returns (NestedPoolTestLocals memory vars) {
+        // Create output token indexes, randomly chosen (no sort logic).
+        (vars.daiIdx, vars.wethIdx, vars.wstethIdx, vars.usdcIdx) = (0, 1, 2, 3);
+
+        vars.lpBefore = _getBalances(lp);
+        vars.vaultBefore = _getBalances(address(vault));
+        vars.childPoolABefore = _getPoolBalances(childPoolA);
+        vars.childPoolBBefore = _getPoolBalances(childPoolB);
+        vars.childPoolERC4626Before = _getPoolBalances(childPoolERC4626);
+        vars.parentPoolBefore = _getPoolBalances(parentPool);
+        vars.parentPoolWithoutWrapperBefore = _getPoolBalances(parentPoolWithoutWrapper);
+        vars.parentPoolWithWrapperBefore = _getPoolBalances(parentPoolWithWrapper);
+    }
+
+    function _fillNestedPoolTestLocalsAfter(NestedPoolTestLocals memory vars) private view {
+        vars.lpAfter = _getBalances(lp);
+        vars.vaultAfter = _getBalances(address(vault));
+        vars.childPoolAAfter = _getPoolBalances(childPoolA);
+        vars.childPoolBAfter = _getPoolBalances(childPoolB);
+        vars.childPoolERC4626After = _getPoolBalances(childPoolERC4626);
+        vars.parentPoolAfter = _getPoolBalances(parentPool);
+        vars.parentPoolWithoutWrapperAfter = _getPoolBalances(parentPoolWithoutWrapper);
+        vars.parentPoolWithWrapperAfter = _getPoolBalances(parentPoolWithWrapper);
+    }
+
+    function _getBalances(address entity) private view returns (TokenBalances memory balances) {
+        balances.dai = dai.balanceOf(entity);
+        balances.eth = entity.balance;
+        balances.weth = weth.balanceOf(entity);
+        balances.wsteth = wsteth.balanceOf(entity);
+        balances.usdc = usdc.balanceOf(entity);
+        balances.waDAI = waDAI.balanceOf(entity);
+        balances.waWETH = waWETH.balanceOf(entity);
+        balances.waUSDC = waUSDC.balanceOf(entity);
+        balances.childPoolABpt = IERC20(childPoolA).balanceOf(entity);
+        balances.childPoolBBpt = IERC20(childPoolB).balanceOf(entity);
+        balances.childPoolERC4626Bpt = IERC20(childPoolERC4626).balanceOf(entity);
+        balances.parentPoolBpt = IERC20(parentPool).balanceOf(entity);
+        balances.parentPoolWithoutWrapperBpt = IERC20(parentPoolWithoutWrapper).balanceOf(entity);
+        balances.parentPoolWithWrapperBpt = IERC20(parentPoolWithWrapper).balanceOf(entity);
+    }
+
+    function _getPoolBalances(address pool) private view returns (TokenBalances memory balances) {
+        (IERC20[] memory tokens, , uint256[] memory poolBalances, ) = vault.getPoolTokenInfo(pool);
+        for (uint256 i = 0; i < tokens.length; i++) {
+            IERC20 currentToken = tokens[i];
+            if (currentToken == dai) {
+                balances.dai = poolBalances[i];
+            } else if (currentToken == weth) {
+                balances.weth = poolBalances[i];
+            } else if (currentToken == wsteth) {
+                balances.wsteth = poolBalances[i];
+            } else if (currentToken == IERC20(address(waDAI))) {
+                balances.waDAI = poolBalances[i];
+            } else if (currentToken == IERC20(address(waUSDC))) {
+                balances.waUSDC = poolBalances[i];
+            } else if (currentToken == IERC20(address(waWETH))) {
+                balances.waWETH = poolBalances[i];
+            } else if (currentToken == usdc) {
+                balances.usdc = poolBalances[i];
+            } else if (currentToken == IERC20(childPoolA)) {
+                balances.childPoolABpt = poolBalances[i];
+            } else if (currentToken == IERC20(childPoolB)) {
+                balances.childPoolBBpt = poolBalances[i];
+            } else if (currentToken == IERC20(childPoolERC4626)) {
+                balances.childPoolERC4626Bpt = poolBalances[i];
+            }
+        }
+
+        balances.totalSupply = BalancerPoolToken(pool).totalSupply();
+    }
+}


### PR DESCRIPTION
# Description

Based off #1415 (and superseding #1413), this restores nested pool functionality to the CLR.

It does not change the interface from the original code, which already automatically checked for an initialized buffer to detect ERC4626.

I also simply restored the old tests, without even looking at them, and just made sure they all passed so that we had semantic equivalence. This is a first pass with the goal of restoring the functionality while simplifying the code; I've still not looked at limits or tried to expand the tests.

The main simplification from the boosted token base is removing recursion in add liquidity, as this is not supported on all chains. I also organized the code into ERC4626, ERC4626 hooks, ERC4626 helpers; followed by the same for nested pools, for clarity.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
