### PR TITLE
Add `OwnableAuthentication` contract

### DIFF
--- a/pkg/standalone-utils/contracts/OwnableAuthentication.sol
+++ b/pkg/standalone-utils/contracts/OwnableAuthentication.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
+
+import { IAuthorizer } from "@balancer-labs/v3-interfaces/contracts/vault/IAuthorizer.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+
+import { Authentication } from "@balancer-labs/v3-solidity-utils/contracts/helpers/Authentication.sol";
+
+/**
+ * @notice OwnableAuthentication is a contract that combines ownership management with authentication.
+ * @dev Use it to pre-wire admin multisigs upon deployment to a contract that requires permissioned functions to work,
+ * where the impact of the owner going rogue is minimal. Contract registries, fee burners, and other utility contracts
+ * are good examples.
+ * In turn, the pre-configured owner can speed up operations as it can perform any action right after deployment without
+ * waiting for governance to set up the authorizer, which can take whole weeks.
+ * On the other hand, governance can always revoke or change the owner at any given time, keeping superior powers
+ * above the owner.
+ */
+contract OwnableAuthentication is Ownable2Step, Authentication {
+    /// @notice The vault has not been set.
+    error VaultNotSet();
+
+    IVault public immutable vault;
+
+    constructor(
+        IVault vault_,
+        address initialOwner
+    ) Ownable(initialOwner) Authentication(bytes32(uint256(uint160(address(this))))) {
+        if (address(vault_) == address(0)) {
+            revert VaultNotSet();
+        }
+
+        vault = vault_;
+    }
+
+    /// @notice Returns the authorizer address according to the Vault.
+    function getAuthorizer() external view returns (IAuthorizer) {
+        return vault.getAuthorizer();
+    }
+
+    /**
+     * @notice Transfer ownership without the 2-step process. It cannot be called by the current owner; governance only.
+     * @dev This allows governance to revoke the owner at any time, preserving control above the owner at all times.
+     * address(0) is also a valid owner, as governance can simply choose to revoke ownership.
+     * Ownership can always be forced back to any address later on.
+     */
+    function forceTransferOwnership(address newOwner) external authenticate {
+        // `authenticate` let's the owner through, so we filter it out here.
+        if (msg.sender == owner()) {
+            revert SenderNotAllowed();
+        }
+        _transferOwnership(newOwner);
+    }
+
+    function _canPerform(bytes32 actionId, address user) internal view virtual override returns (bool) {
+        // The owner is always allowed to perform any action.
+        if (user == owner()) {
+            return true;
+        }
+
+        // Otherwise, check the vault's authorizer for permission.
+        return vault.getAuthorizer().canPerform(actionId, user, address(this));
+    }
+}

--- a/pkg/standalone-utils/contracts/test/OwnableAuthenticationMock.sol
+++ b/pkg/standalone-utils/contracts/test/OwnableAuthenticationMock.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
+
+import { IAuthorizer } from "@balancer-labs/v3-interfaces/contracts/vault/IAuthorizer.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+
+import { Authentication } from "@balancer-labs/v3-solidity-utils/contracts/helpers/Authentication.sol";
+
+import { OwnableAuthentication } from "../OwnableAuthentication.sol";
+
+contract OwnableAuthenticationMock is OwnableAuthentication {
+    constructor(IVault vault, address initialOwner) OwnableAuthentication(vault, initialOwner) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    function permissionedFunction() external view authenticate {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+}

--- a/pkg/standalone-utils/test/foundry/OwnableAuthentication.t.sol
+++ b/pkg/standalone-utils/test/foundry/OwnableAuthentication.t.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.24;
 
 import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 
 import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVaultTest.sol";
 
@@ -30,6 +31,11 @@ contract OwnableAuthenticationTest is BaseVaultTest {
             IAuthentication(address(authentication)).getActionId(OwnableAuthentication.forceTransferOwnership.selector),
             admin
         );
+    }
+
+    function testConstructor() external {
+        vm.expectRevert(OwnableAuthentication.VaultNotSet.selector);
+        new OwnableAuthentication(IVault(address(0)), bob);
     }
 
     function testGetVault() external view {

--- a/pkg/standalone-utils/test/foundry/OwnableAuthentication.t.sol
+++ b/pkg/standalone-utils/test/foundry/OwnableAuthentication.t.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
+
+import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVaultTest.sol";
+
+import { OwnableAuthentication } from "../../contracts/OwnableAuthentication.sol";
+import { OwnableAuthenticationMock } from "../../contracts/test/OwnableAuthenticationMock.sol";
+
+contract OwnableAuthenticationTest is BaseVaultTest {
+    OwnableAuthenticationMock internal authentication;
+    address owner;
+
+    function setUp() public virtual override {
+        BaseVaultTest.setUp();
+        owner = bob;
+
+        authentication = new OwnableAuthenticationMock(vault, owner);
+
+        authorizer.grantRole(
+            IAuthentication(address(authentication)).getActionId(
+                OwnableAuthenticationMock.permissionedFunction.selector
+            ),
+            admin
+        );
+
+        authorizer.grantRole(
+            IAuthentication(address(authentication)).getActionId(OwnableAuthentication.forceTransferOwnership.selector),
+            admin
+        );
+    }
+
+    function testGetVault() external view {
+        assertEq(address(authentication.vault()), address(vault), "Vault address mismatch");
+    }
+
+    function testAuthorizer() external view {
+        assertEq(
+            address(authentication.getAuthorizer()),
+            address(vault.getAuthorizer()),
+            "Authorizer address mismatch"
+        );
+    }
+
+    function testPermissionedFunctionOwner() external {
+        // Does not revert.
+        vm.prank(owner);
+        authentication.permissionedFunction();
+    }
+
+    function testPermissionedFunctionGovernance() external {
+        // Does not revert.
+        vm.prank(admin);
+        authentication.permissionedFunction();
+    }
+
+    function testPermissionedFunctionOther() external {
+        vm.prank(alice);
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        authentication.permissionedFunction();
+    }
+
+    function testForceTransferOwnership() external {
+        assertNotEq(authentication.owner(), alice, "Ownership already transferred");
+        vm.prank(admin);
+        authentication.forceTransferOwnership(alice);
+
+        assertEq(authentication.owner(), alice, "Ownership not transferred to alice");
+        assertEq(authentication.pendingOwner(), address(0), "Pending owner should be cleared");
+    }
+
+    function testForceTransferOwnershipOngoingTransfer() external {
+        vm.prank(owner);
+        authentication.transferOwnership(lp);
+        assertEq(authentication.pendingOwner(), lp, "Pending owner should be lp");
+
+        assertNotEq(authentication.owner(), alice, "Ownership already transferred to alice");
+        assertNotEq(authentication.owner(), lp, "Ownership already transferred to lp");
+        vm.prank(admin);
+        authentication.forceTransferOwnership(alice);
+
+        assertEq(authentication.owner(), alice, "Ownership not transferred to alice");
+        assertEq(authentication.pendingOwner(), address(0), "Pending owner should be cleared");
+    }
+
+    function testForceTransferOwnershipByOwnerOrOther() external {
+        vm.prank(owner);
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        authentication.forceTransferOwnership(alice);
+
+        vm.prank(lp);
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        authentication.forceTransferOwnership(alice);
+    }
+}


### PR DESCRIPTION
# Description

Add small helper contract for admin contracts, to make wireup easier in general while retaining governance powers over permissioned functions.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

This will be used later on for #1439 