### PR TITLE
Onchain token pair registry

### DIFF
--- a/pkg/interfaces/contracts/standalone-utils/ITokenPairRegistry.sol
+++ b/pkg/interfaces/contracts/standalone-utils/ITokenPairRegistry.sol
@@ -22,78 +22,76 @@ interface ITokenPairRegistry {
     event TokenPairRemoved(address indexed pool, address indexed tokenA, address indexed tokenB);
 
     /**
-     * @notice Emitted when a adding a pool or buffer for a given pair which had already been added to the registry.
-     * @param pool The address of the pool or buffer that was already added
+     * @notice The given path is not a valid pool or buffer.
+     * @param path Pool or buffer address
+     */
+    error InvalidPath(address path);
+
+    /**
+     * @notice Thrown when a adding a pool or buffer for a given pair which had already been added to the registry.
+     * @param path The address of the pool or buffer that was already added
      * @param tokenA The address of the first token in the pair
      * @param tokenB The address of the second token in the pair
      */
-    error PoolAlreadyAddedForPair(address pool, address tokenA, address tokenB);
+    error PathAlreadyAddedForPair(address path, address tokenA, address tokenB);
 
     /**
-     * @notice Emitted when a removing a pool or buffer for a given pair which had not been added to the registry.
-     * @param pool The address of the pool or buffer being removed
+     * @notice Thrown when a removing a pool or buffer for a given pair which had not been added to the registry.
+     * @param path The address of the pool or buffer being removed
      * @param tokenA The address of the first token in the pair
      * @param tokenB The address of the second token in the pair
      */
-    error PoolNotAddedForPair(address pool, address tokenA, address tokenB);
+    error PathNotAddedForPair(address path, address tokenA, address tokenB);
 
     /**
-     * @notice Returns the pool address for a given token pair at a specific index.
+     * @notice Returns the path address for a given token pair at a specific index.
      * @dev Safe version, reverts if the index is out of bounds.
      * @param tokenA The address of the first token in the pair
      * @param tokenB The address of the second token in the pair
-     * @param index The index of the pool in the list of pools for the token pair
-     * @return The address of the pool at the specified index for the token pair
+     * @param index The index of the path in the list of paths for the token pair
+     * @return The address of the path at the specified index for the token pair
      */
-    function getPoolAt(address tokenA, address tokenB, uint256 index) external view returns (address);
+    function getPathAt(address tokenA, address tokenB, uint256 index) external view returns (address);
 
     /**
-     * @notice Returns the pool address for a given token pair at a specific index.
+     * @notice Returns the path address for a given token pair at a specific index.
      * @dev Unsafe version, use only when index is known to be within bounds.
      * @param tokenA The address of the first token in the pair
      * @param tokenB The address of the second token in the pair
-     * @param index The index of the pool in the list of pools for the token pair
-     * @return The address of the pool at the specified index for the token pair
+     * @param index The index of the path in the list of paths for the token pair
+     * @return The address of the path at the specified index for the token pair
      */
-    function getPoolAtUnchecked(address tokenA, address tokenB, uint256 index) external view returns (address);
+    function getPathAtUnchecked(address tokenA, address tokenB, uint256 index) external view returns (address);
 
     /**
-     * @notice Returns the number of pools registered for a given token pair.
+     * @notice Returns the number of paths registered for a given token pair.
      * @param tokenA The address of the first token in the pair
      * @param tokenB The address of the second token in the pair
-     * @return The number of pools registered for the token pair
+     * @return The number of paths registered for the token pair
      */
-    function getPoolCount(address tokenA, address tokenB) external view returns (uint256);
+    function getPathCount(address tokenA, address tokenB) external view returns (uint256);
 
     /**
-     * @notice Returns the pools registered for a given token pair.
+     * @notice Returns the paths registered for a given token pair.
      * @param tokenA The address of the first token in the pair
      * @param tokenB The address of the second token in the pair
-     * @return An array of pool addresses registered for the token pair
+     * @return An array of path addresses registered for the token pair
      */
-    function getPools(address tokenA, address tokenB) external view returns (address[] memory);
+    function getPaths(address tokenA, address tokenB) external view returns (address[] memory);
 
     /**
-     * @notice Returns true if a pool is registered for a given token pair.
+     * @notice Returns true if a path is registered for a given token pair.
      * @param tokenA The address of the first token in the pair
      * @param tokenB The address of the second token in the pair
-     * @return True if the pool is registered for the given token pair, false otherwise
+     * @return True if the path is registered for the given token pair, false otherwise
      */
-    function hasPool(address tokenA, address tokenB, address pool) external view returns (bool);
+    function hasPath(address tokenA, address tokenB, address path) external view returns (bool);
 
     /**
-     * @notice Adds a pool to the registry for all token pairs it supports.
-     * @dev This function is permissioned. The call will revert if the pool is already registered for the token pair.
+     * @notice Adds a pool or buffer to the registry for all token pairs they support.
+     * @dev This function is permissioned. The call will revert if the path is already registered for the token pair.
      */
-    function addPool(address pool) external;
+    function addPath(address path) external;
 
-    /**
-     * @notice Adds a buffer to the registry, supporting underlying <> wrapped operations.
-     * @dev This function is permissioned. The call will revert if the buffer is already registered for the token pair.
-     */
-    function addBuffer(IERC4626 wrappedToken) external;
-
-    function removePool(address pool) external;
-
-    function removeBuffer(IERC4626 wrappedToken) external;
+    function removePath(address path) external;
 }

--- a/pkg/interfaces/contracts/standalone-utils/ITokenPairRegistry.sol
+++ b/pkg/interfaces/contracts/standalone-utils/ITokenPairRegistry.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+pragma solidity ^0.8.24;
+
+interface ITokenPairRegistry {
+    /**
+     * @notice Emitted when a new token pair is added to the registry.
+     * @param pool The address of the pool that supports the token pair
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     */
+    event TokenPairAdded(address indexed pool, address indexed tokenA, address indexed tokenB);
+
+    /**
+     * @notice Emitted when an existing token pair is removed from the registry.
+     * @param pool The address of the pool that supports the token pair
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     */
+    event TokenPairRemoved(address indexed pool, address indexed tokenA, address indexed tokenB);
+
+    /**
+     * @notice Emitted when a adding a pool or buffer for a given pair which had already been added to the registry.
+     * @param pool The address of the pool or buffer that was already added
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     */
+    error PoolAlreadyAddedForPair(address pool, address tokenA, address tokenB);
+
+    /**
+     * @notice Emitted when a removing a pool or buffer for a given pair which had not been added to the registry.
+     * @param pool The address of the pool or buffer being removed
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     */
+    error PoolNotAddedForPair(address pool, address tokenA, address tokenB);
+
+    /**
+     * @notice Returns the pool address for a given token pair at a specific index.
+     * @dev Safe version, reverts if the index is out of bounds.
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     * @param index The index of the pool in the list of pools for the token pair
+     * @return The address of the pool at the specified index for the token pair
+     */
+    function getPoolAt(address tokenA, address tokenB, uint256 index) external view returns (address);
+
+    /**
+     * @notice Returns the pool address for a given token pair at a specific index.
+     * @dev Unsafe version, use only when index is known to be within bounds.
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     * @param index The index of the pool in the list of pools for the token pair
+     * @return The address of the pool at the specified index for the token pair
+     */
+    function getPoolAtUnchecked(address tokenA, address tokenB, uint256 index) external view returns (address);
+
+    /**
+     * @notice Returns the number of pools registered for a given token pair.
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     * @return The number of pools registered for the token pair
+     */
+    function getPoolCount(address tokenA, address tokenB) external view returns (uint256);
+
+    /**
+     * @notice Returns the pools registered for a given token pair.
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     * @return An array of pool addresses registered for the token pair
+     */
+    function getPools(address tokenA, address tokenB) external view returns (address[] memory);
+
+    /**
+     * @notice Returns true if a pool is registered for a given token pair.
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     * @return True if the pool is registered for the given token pair, false otherwise
+     */
+    function hasPool(address tokenA, address tokenB, address pool) external view returns (bool);
+
+    /**
+     * @notice Adds a pool to the registry for all token pairs it supports.
+     * @dev This function is permissioned. The call will revert if the pool is already registered for the token pair.
+     */
+    function addPool(address pool) external;
+
+    /**
+     * @notice Adds a buffer to the registry, supporting underlying <> wrapped operations.
+     * @dev This function is permissioned. The call will revert if the buffer is already registered for the token pair.
+     */
+    function addBuffer(IERC4626 wrappedToken) external;
+
+    function removePool(address pool) external;
+
+    function removeBuffer(IERC4626 wrappedToken) external;
+}

--- a/pkg/standalone-utils/contracts/TokenPairRegistry.sol
+++ b/pkg/standalone-utils/contracts/TokenPairRegistry.sol
@@ -6,24 +6,54 @@ import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import { EnumerableSet } from "@balancer-labs/v3-solidity-utils/contracts/openzeppelin/EnumerableSet.sol";
 import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
 
 import { OwnableAuthentication } from "./OwnableAuthentication.sol";
 
 contract TokenPairRegistry is OwnableAuthentication {
-    event TokenPairRegistered(address indexed pool, address indexed tokenA, address indexed tokenB);
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    event TokenPairAdded(address indexed pool, address indexed tokenA, address indexed tokenB);
+
+    event TokenPairRemoved(address indexed pool, address indexed tokenA, address indexed tokenB);
 
     error WrongTokenOrder();
 
-    mapping (bytes32 pairId => address pool) internal pairsToPool;
+    error PoolAlreadyAddedForPair(address pool, address tokenA, address tokenB);
+
+    error PoolNotAddedForPair(address pool, address tokenA, address tokenB);
+
+    mapping(bytes32 pairId => EnumerableSet.AddressSet pools) internal pairsToPool;
 
     constructor(IVault vault, address initialOwner) OwnableAuthentication(vault, initialOwner) {
         // solhint-disable-previous-line no-empty-blocks
     }
 
-    function getPool(address tokenA, address tokenB) external view returns (address) {
+    function getPoolAt(address tokenA, address tokenB, uint256 index) external view returns (address) {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
-        return pairsToPool[tokenId];
+        return pairsToPool[tokenId].at(index);
+    }
+
+    function getPoolAtUnchecked(address tokenA, address tokenB, uint256 index) external view returns (address) {
+        bytes32 tokenId = _getTokenId(tokenA, tokenB);
+        return pairsToPool[tokenId].unchecked_at(index);
+    }
+
+    function getPoolCount(address tokenA, address tokenB) external view returns (uint256) {
+        bytes32 tokenId = _getTokenId(tokenA, tokenB);
+        return pairsToPool[tokenId].length();
+    }
+
+    function getPools(address tokenA, address tokenB) external view returns (address[] memory) {
+        bytes32 tokenId = _getTokenId(tokenA, tokenB);
+        EnumerableSet.AddressSet storage pools = pairsToPool[tokenId];
+        return pools._values;
+    }
+
+    function hasPool(address tokenA, address tokenB, address pool) external view returns (bool) {
+        bytes32 tokenId = _getTokenId(tokenA, tokenB);
+        return pairsToPool[tokenId].contains(pool);
     }
 
     function addPool(address pool) external authenticate {
@@ -33,25 +63,53 @@ contract TokenPairRegistry is OwnableAuthentication {
         uint256 tokenPairs = tokens.length - 1;
         for (uint256 i = 0; i < tokenPairs; ++i) {
             for (uint256 j = i + 1; j < tokens.length; ++j) {
-                _registerTokenPair(pool, address(tokens[i]), address(tokens[j]));
+                _addTokenPair(pool, address(tokens[i]), address(tokens[j]));
             }
         }
     }
 
     /**
      * @dev The "pool" for (underlying, wrapped) shall be `wrapped` always, but only if it's registered as a vault
-     * buffer. 
+     * buffer.
      */
     function addBuffer(IERC4626 wrappedToken) external authenticate {
         address underlyingToken = vault.getBufferAsset(wrappedToken);
-        _registerTokenPair(address(wrappedToken), underlyingToken, address(wrappedToken));
+        _addTokenPair(address(wrappedToken), underlyingToken, address(wrappedToken));
     }
 
-    function _registerTokenPair(address pool, address tokenA, address tokenB) internal {
+    function removePool(address pool) external authenticate {
+        // This call reverts if the pool is not registered.
+        IERC20[] memory tokens = vault.getPoolTokens(pool);
+
+        uint256 tokenPairs = tokens.length - 1;
+        for (uint256 i = 0; i < tokenPairs; ++i) {
+            for (uint256 j = i + 1; j < tokens.length; ++j) {
+                _removeTokenPair(pool, address(tokens[i]), address(tokens[j]));
+            }
+        }
+    }
+
+    function removeBuffer(IERC4626 wrappedToken) external authenticate {
+        address underlyingToken = vault.getBufferAsset(wrappedToken);
+        _removeTokenPair(address(wrappedToken), underlyingToken, address(wrappedToken));
+    }
+
+    function _addTokenPair(address pool, address tokenA, address tokenB) internal {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
 
-        pairsToPool[tokenId] = pool;
-        emit TokenPairRegistered(pool, tokenA, tokenB);
+        if (pairsToPool[tokenId].add(pool) == false) {
+            revert PoolAlreadyAddedForPair(pool, tokenA, tokenB);
+        }
+        emit TokenPairAdded(pool, tokenA, tokenB);
+    }
+
+    function _removeTokenPair(address pool, address tokenA, address tokenB) internal {
+        bytes32 tokenId = _getTokenId(tokenA, tokenB);
+
+        if (pairsToPool[tokenId].remove(pool) == false) {
+            revert PoolNotAddedForPair(pool, tokenA, tokenB);
+        }
+        emit TokenPairRemoved(pool, tokenA, tokenB);
     }
 
     /// @dev Returns a unique identifier for the token pair, ensuring that the order of tokens does not matter.

--- a/pkg/standalone-utils/contracts/TokenPairRegistry.sol
+++ b/pkg/standalone-utils/contracts/TokenPairRegistry.sol
@@ -121,7 +121,6 @@ contract TokenPairRegistry is ITokenPairRegistry, OwnableAuthentication {
         _removeTokenPair(address(wrappedToken), underlyingToken, address(wrappedToken));
     }
 
-
     /// @dev Returns a unique identifier for the token pair, ensuring that the order of tokens does not matter.
     function _getTokenId(address tokenA, address tokenB) internal pure returns (bytes32) {
         (tokenA, tokenB) = tokenA <= tokenB ? (tokenA, tokenB) : (tokenB, tokenA);

--- a/pkg/standalone-utils/contracts/TokenPairRegistry.sol
+++ b/pkg/standalone-utils/contracts/TokenPairRegistry.sol
@@ -15,7 +15,7 @@ import { OwnableAuthentication } from "./OwnableAuthentication.sol";
 contract TokenPairRegistry is ITokenPairRegistry, OwnableAuthentication {
     using EnumerableSet for EnumerableSet.AddressSet;
 
-    mapping(bytes32 pairId => EnumerableSet.AddressSet pools) internal pairsToPath;
+    mapping(bytes32 pairId => EnumerableSet.AddressSet pools) internal _pairsToPath;
 
     constructor(IVault vault, address initialOwner) OwnableAuthentication(vault, initialOwner) {
         // solhint-disable-previous-line no-empty-blocks
@@ -23,28 +23,28 @@ contract TokenPairRegistry is ITokenPairRegistry, OwnableAuthentication {
 
     function getPathAt(address tokenA, address tokenB, uint256 index) external view returns (address) {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
-        return pairsToPath[tokenId].at(index);
+        return _pairsToPath[tokenId].at(index);
     }
 
     function getPathAtUnchecked(address tokenA, address tokenB, uint256 index) external view returns (address) {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
-        return pairsToPath[tokenId].unchecked_at(index);
+        return _pairsToPath[tokenId].unchecked_at(index);
     }
 
     function getPathCount(address tokenA, address tokenB) external view returns (uint256) {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
-        return pairsToPath[tokenId].length();
+        return _pairsToPath[tokenId].length();
     }
 
     function getPaths(address tokenA, address tokenB) external view returns (address[] memory) {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
-        EnumerableSet.AddressSet storage pools = pairsToPath[tokenId];
+        EnumerableSet.AddressSet storage pools = _pairsToPath[tokenId];
         return pools._values;
     }
 
     function hasPath(address tokenA, address tokenB, address pool) external view returns (bool) {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
-        return pairsToPath[tokenId].contains(pool);
+        return _pairsToPath[tokenId].contains(pool);
     }
 
     function addPath(address path) external authenticate {
@@ -90,7 +90,7 @@ contract TokenPairRegistry is ITokenPairRegistry, OwnableAuthentication {
     function _addTokenPair(address pool, address tokenA, address tokenB) internal {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
 
-        if (pairsToPath[tokenId].add(pool) == false) {
+        if (_pairsToPath[tokenId].add(pool) == false) {
             revert PathAlreadyAddedForPair(pool, tokenA, tokenB);
         }
         emit TokenPairAdded(pool, tokenA, tokenB);
@@ -110,7 +110,7 @@ contract TokenPairRegistry is ITokenPairRegistry, OwnableAuthentication {
     function _removeTokenPair(address pool, address tokenA, address tokenB) internal {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
 
-        if (pairsToPath[tokenId].remove(pool) == false) {
+        if (_pairsToPath[tokenId].remove(pool) == false) {
             revert PathNotAddedForPair(pool, tokenA, tokenB);
         }
         emit TokenPairRemoved(pool, tokenA, tokenB);

--- a/pkg/standalone-utils/contracts/TokenPairRegistry.sol
+++ b/pkg/standalone-utils/contracts/TokenPairRegistry.sol
@@ -5,24 +5,15 @@ pragma solidity ^0.8.24;
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import { ITokenPairRegistry } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/ITokenPairRegistry.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import { EnumerableSet } from "@balancer-labs/v3-solidity-utils/contracts/openzeppelin/EnumerableSet.sol";
 import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
 
 import { OwnableAuthentication } from "./OwnableAuthentication.sol";
 
-contract TokenPairRegistry is OwnableAuthentication {
+contract TokenPairRegistry is ITokenPairRegistry, OwnableAuthentication {
     using EnumerableSet for EnumerableSet.AddressSet;
-
-    event TokenPairAdded(address indexed pool, address indexed tokenA, address indexed tokenB);
-
-    event TokenPairRemoved(address indexed pool, address indexed tokenA, address indexed tokenB);
-
-    error WrongTokenOrder();
-
-    error PoolAlreadyAddedForPair(address pool, address tokenA, address tokenB);
-
-    error PoolNotAddedForPair(address pool, address tokenA, address tokenB);
 
     mapping(bytes32 pairId => EnumerableSet.AddressSet pools) internal pairsToPool;
 

--- a/pkg/standalone-utils/contracts/TokenPairRegistry.sol
+++ b/pkg/standalone-utils/contracts/TokenPairRegistry.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
+
+import { OwnableAuthentication } from "./OwnableAuthentication.sol";
+
+contract TokenPairRegistry is OwnableAuthentication {
+    event TokenPairRegistered(address indexed pool, address indexed tokenA, address indexed tokenB);
+
+    error WrongTokenOrder();
+
+    mapping (bytes32 pairId => address pool) internal pairsToPool;
+
+    constructor(IVault vault, address initialOwner) OwnableAuthentication(vault, initialOwner) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    function getPool(address tokenA, address tokenB) external view returns (address) {
+        bytes32 tokenId = _getTokenId(tokenA, tokenB);
+        return pairsToPool[tokenId];
+    }
+
+    function addPool(address pool) external authenticate {
+        // This call reverts if the pool is not registered.
+        IERC20[] memory tokens = vault.getPoolTokens(pool);
+
+        uint256 tokenPairs = tokens.length - 1;
+        for (uint256 i = 0; i < tokenPairs; ++i) {
+            for (uint256 j = i + 1; j < tokens.length; ++j) {
+                _registerTokenPair(pool, address(tokens[i]), address(tokens[j]));
+            }
+        }
+    }
+
+    /**
+     * @dev The "pool" for (underlying, wrapped) shall be `wrapped` always, but only if it's registered as a vault
+     * buffer. 
+     */
+    function addBuffer(IERC4626 wrappedToken) external authenticate {
+        address underlyingToken = vault.getBufferAsset(wrappedToken);
+        _registerTokenPair(address(wrappedToken), underlyingToken, address(wrappedToken));
+    }
+
+    function _registerTokenPair(address pool, address tokenA, address tokenB) internal {
+        bytes32 tokenId = _getTokenId(tokenA, tokenB);
+
+        pairsToPool[tokenId] = pool;
+        emit TokenPairRegistered(pool, tokenA, tokenB);
+    }
+
+    /// @dev Returns a unique identifier for the token pair, ensuring that the order of tokens does not matter.
+    function _getTokenId(address tokenA, address tokenB) internal pure returns (bytes32) {
+        (tokenA, tokenB) = tokenA <= tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+        return keccak256(abi.encodePacked(tokenA, tokenB));
+    }
+}


### PR DESCRIPTION
# Description

Add a small registry that maps token pairs --> pools.
A buffer can also be considered a path for (underlying, wrapped) tokens; pools and buffers are treated equally.

Modifying the registry is permissioned (with owner + governance), and one pair might have multiple paths.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #1439 