### PR TITLE
Onchain token pair registry (alt requirements)

### DIFF
--- a/pkg/interfaces/contracts/standalone-utils/ITokenPairRegistry.sol
+++ b/pkg/interfaces/contracts/standalone-utils/ITokenPairRegistry.sol
@@ -22,78 +22,76 @@ interface ITokenPairRegistry {
     event TokenPairRemoved(address indexed pool, address indexed tokenA, address indexed tokenB);
 
     /**
-     * @notice Emitted when a adding a pool or buffer for a given pair which had already been added to the registry.
-     * @param pool The address of the pool or buffer that was already added
+     * @notice The given path is not a valid pool or buffer.
+     * @param path Pool or buffer address
+     */
+    error InvalidPath(address path);
+
+    /**
+     * @notice Thrown when a adding a pool or buffer for a given pair which had already been added to the registry.
+     * @param path The address of the pool or buffer that was already added
      * @param tokenA The address of the first token in the pair
      * @param tokenB The address of the second token in the pair
      */
-    error PoolAlreadyAddedForPair(address pool, address tokenA, address tokenB);
+    error PathAlreadyAddedForPair(address path, address tokenA, address tokenB);
 
     /**
-     * @notice Emitted when a removing a pool or buffer for a given pair which had not been added to the registry.
-     * @param pool The address of the pool or buffer being removed
+     * @notice Thrown when a removing a pool or buffer for a given pair which had not been added to the registry.
+     * @param path The address of the pool or buffer being removed
      * @param tokenA The address of the first token in the pair
      * @param tokenB The address of the second token in the pair
      */
-    error PoolNotAddedForPair(address pool, address tokenA, address tokenB);
+    error PathNotAddedForPair(address path, address tokenA, address tokenB);
 
     /**
-     * @notice Returns the pool address for a given token pair at a specific index.
+     * @notice Returns the path address for a given token pair at a specific index.
      * @dev Safe version, reverts if the index is out of bounds.
      * @param tokenA The address of the first token in the pair
      * @param tokenB The address of the second token in the pair
-     * @param index The index of the pool in the list of pools for the token pair
-     * @return The address of the pool at the specified index for the token pair
+     * @param index The index of the path in the list of paths for the token pair
+     * @return The address of the path at the specified index for the token pair
      */
-    function getPoolAt(address tokenA, address tokenB, uint256 index) external view returns (address);
+    function getPathAt(address tokenA, address tokenB, uint256 index) external view returns (address);
 
     /**
-     * @notice Returns the pool address for a given token pair at a specific index.
+     * @notice Returns the path address for a given token pair at a specific index.
      * @dev Unsafe version, use only when index is known to be within bounds.
      * @param tokenA The address of the first token in the pair
      * @param tokenB The address of the second token in the pair
-     * @param index The index of the pool in the list of pools for the token pair
-     * @return The address of the pool at the specified index for the token pair
+     * @param index The index of the path in the list of paths for the token pair
+     * @return The address of the path at the specified index for the token pair
      */
-    function getPoolAtUnchecked(address tokenA, address tokenB, uint256 index) external view returns (address);
+    function getPathAtUnchecked(address tokenA, address tokenB, uint256 index) external view returns (address);
 
     /**
-     * @notice Returns the number of pools registered for a given token pair.
+     * @notice Returns the number of paths registered for a given token pair.
      * @param tokenA The address of the first token in the pair
      * @param tokenB The address of the second token in the pair
-     * @return The number of pools registered for the token pair
+     * @return The number of paths registered for the token pair
      */
-    function getPoolCount(address tokenA, address tokenB) external view returns (uint256);
+    function getPathCount(address tokenA, address tokenB) external view returns (uint256);
 
     /**
-     * @notice Returns the pools registered for a given token pair.
+     * @notice Returns the paths registered for a given token pair.
      * @param tokenA The address of the first token in the pair
      * @param tokenB The address of the second token in the pair
-     * @return An array of pool addresses registered for the token pair
+     * @return An array of path addresses registered for the token pair
      */
-    function getPools(address tokenA, address tokenB) external view returns (address[] memory);
+    function getPaths(address tokenA, address tokenB) external view returns (address[] memory);
 
     /**
-     * @notice Returns true if a pool is registered for a given token pair.
+     * @notice Returns true if a path is registered for a given token pair.
      * @param tokenA The address of the first token in the pair
      * @param tokenB The address of the second token in the pair
-     * @return True if the pool is registered for the given token pair, false otherwise
+     * @return True if the path is registered for the given token pair, false otherwise
      */
-    function hasPool(address tokenA, address tokenB, address pool) external view returns (bool);
+    function hasPath(address tokenA, address tokenB, address path) external view returns (bool);
 
     /**
-     * @notice Adds a pool to the registry for all token pairs it supports.
-     * @dev This function is permissioned. The call will revert if the pool is already registered for the token pair.
+     * @notice Adds a pool or buffer to the registry for all token pairs they support.
+     * @dev This function is permissioned. The call will revert if the path is already registered for the token pair.
      */
-    function addPool(address pool) external;
+    function addPath(address path) external;
 
-    /**
-     * @notice Adds a buffer to the registry, supporting underlying <> wrapped operations.
-     * @dev This function is permissioned. The call will revert if the buffer is already registered for the token pair.
-     */
-    function addBuffer(IERC4626 wrappedToken) external;
-
-    function removePool(address pool) external;
-
-    function removeBuffer(IERC4626 wrappedToken) external;
+    function removePath(address path) external;
 }

--- a/pkg/interfaces/contracts/standalone-utils/ITokenPairRegistry.sol
+++ b/pkg/interfaces/contracts/standalone-utils/ITokenPairRegistry.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+pragma solidity ^0.8.24;
+
+interface ITokenPairRegistry {
+    /**
+     * @notice Emitted when a new token pair is added to the registry.
+     * @param pool The address of the pool that supports the token pair
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     */
+    event TokenPairAdded(address indexed pool, address indexed tokenA, address indexed tokenB);
+
+    /**
+     * @notice Emitted when an existing token pair is removed from the registry.
+     * @param pool The address of the pool that supports the token pair
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     */
+    event TokenPairRemoved(address indexed pool, address indexed tokenA, address indexed tokenB);
+
+    /**
+     * @notice Emitted when a adding a pool or buffer for a given pair which had already been added to the registry.
+     * @param pool The address of the pool or buffer that was already added
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     */
+    error PoolAlreadyAddedForPair(address pool, address tokenA, address tokenB);
+
+    /**
+     * @notice Emitted when a removing a pool or buffer for a given pair which had not been added to the registry.
+     * @param pool The address of the pool or buffer being removed
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     */
+    error PoolNotAddedForPair(address pool, address tokenA, address tokenB);
+
+    /**
+     * @notice Returns the pool address for a given token pair at a specific index.
+     * @dev Safe version, reverts if the index is out of bounds.
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     * @param index The index of the pool in the list of pools for the token pair
+     * @return The address of the pool at the specified index for the token pair
+     */
+    function getPoolAt(address tokenA, address tokenB, uint256 index) external view returns (address);
+
+    /**
+     * @notice Returns the pool address for a given token pair at a specific index.
+     * @dev Unsafe version, use only when index is known to be within bounds.
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     * @param index The index of the pool in the list of pools for the token pair
+     * @return The address of the pool at the specified index for the token pair
+     */
+    function getPoolAtUnchecked(address tokenA, address tokenB, uint256 index) external view returns (address);
+
+    /**
+     * @notice Returns the number of pools registered for a given token pair.
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     * @return The number of pools registered for the token pair
+     */
+    function getPoolCount(address tokenA, address tokenB) external view returns (uint256);
+
+    /**
+     * @notice Returns the pools registered for a given token pair.
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     * @return An array of pool addresses registered for the token pair
+     */
+    function getPools(address tokenA, address tokenB) external view returns (address[] memory);
+
+    /**
+     * @notice Returns true if a pool is registered for a given token pair.
+     * @param tokenA The address of the first token in the pair
+     * @param tokenB The address of the second token in the pair
+     * @return True if the pool is registered for the given token pair, false otherwise
+     */
+    function hasPool(address tokenA, address tokenB, address pool) external view returns (bool);
+
+    /**
+     * @notice Adds a pool to the registry for all token pairs it supports.
+     * @dev This function is permissioned. The call will revert if the pool is already registered for the token pair.
+     */
+    function addPool(address pool) external;
+
+    /**
+     * @notice Adds a buffer to the registry, supporting underlying <> wrapped operations.
+     * @dev This function is permissioned. The call will revert if the buffer is already registered for the token pair.
+     */
+    function addBuffer(IERC4626 wrappedToken) external;
+
+    function removePool(address pool) external;
+
+    function removeBuffer(IERC4626 wrappedToken) external;
+}

--- a/pkg/standalone-utils/contracts/TokenPairRegistry.sol
+++ b/pkg/standalone-utils/contracts/TokenPairRegistry.sol
@@ -6,24 +6,54 @@ import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import { EnumerableSet } from "@balancer-labs/v3-solidity-utils/contracts/openzeppelin/EnumerableSet.sol";
 import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
 
 import { OwnableAuthentication } from "./OwnableAuthentication.sol";
 
 contract TokenPairRegistry is OwnableAuthentication {
-    event TokenPairRegistered(address indexed pool, address indexed tokenA, address indexed tokenB);
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    event TokenPairAdded(address indexed pool, address indexed tokenA, address indexed tokenB);
+
+    event TokenPairRemoved(address indexed pool, address indexed tokenA, address indexed tokenB);
 
     error WrongTokenOrder();
 
-    mapping (bytes32 pairId => address pool) internal pairsToPool;
+    error PoolAlreadyAddedForPair(address pool, address tokenA, address tokenB);
+
+    error PoolNotAddedForPair(address pool, address tokenA, address tokenB);
+
+    mapping(bytes32 pairId => EnumerableSet.AddressSet pools) internal pairsToPool;
 
     constructor(IVault vault, address initialOwner) OwnableAuthentication(vault, initialOwner) {
         // solhint-disable-previous-line no-empty-blocks
     }
 
-    function getPool(address tokenA, address tokenB) external view returns (address) {
+    function getPoolAt(address tokenA, address tokenB, uint256 index) external view returns (address) {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
-        return pairsToPool[tokenId];
+        return pairsToPool[tokenId].at(index);
+    }
+
+    function getPoolAtUnchecked(address tokenA, address tokenB, uint256 index) external view returns (address) {
+        bytes32 tokenId = _getTokenId(tokenA, tokenB);
+        return pairsToPool[tokenId].unchecked_at(index);
+    }
+
+    function getPoolCount(address tokenA, address tokenB) external view returns (uint256) {
+        bytes32 tokenId = _getTokenId(tokenA, tokenB);
+        return pairsToPool[tokenId].length();
+    }
+
+    function getPools(address tokenA, address tokenB) external view returns (address[] memory) {
+        bytes32 tokenId = _getTokenId(tokenA, tokenB);
+        EnumerableSet.AddressSet storage pools = pairsToPool[tokenId];
+        return pools._values;
+    }
+
+    function hasPool(address tokenA, address tokenB, address pool) external view returns (bool) {
+        bytes32 tokenId = _getTokenId(tokenA, tokenB);
+        return pairsToPool[tokenId].contains(pool);
     }
 
     function addPool(address pool) external authenticate {
@@ -33,25 +63,53 @@ contract TokenPairRegistry is OwnableAuthentication {
         uint256 tokenPairs = tokens.length - 1;
         for (uint256 i = 0; i < tokenPairs; ++i) {
             for (uint256 j = i + 1; j < tokens.length; ++j) {
-                _registerTokenPair(pool, address(tokens[i]), address(tokens[j]));
+                _addTokenPair(pool, address(tokens[i]), address(tokens[j]));
             }
         }
     }
 
     /**
      * @dev The "pool" for (underlying, wrapped) shall be `wrapped` always, but only if it's registered as a vault
-     * buffer. 
+     * buffer.
      */
     function addBuffer(IERC4626 wrappedToken) external authenticate {
         address underlyingToken = vault.getBufferAsset(wrappedToken);
-        _registerTokenPair(address(wrappedToken), underlyingToken, address(wrappedToken));
+        _addTokenPair(address(wrappedToken), underlyingToken, address(wrappedToken));
     }
 
-    function _registerTokenPair(address pool, address tokenA, address tokenB) internal {
+    function removePool(address pool) external authenticate {
+        // This call reverts if the pool is not registered.
+        IERC20[] memory tokens = vault.getPoolTokens(pool);
+
+        uint256 tokenPairs = tokens.length - 1;
+        for (uint256 i = 0; i < tokenPairs; ++i) {
+            for (uint256 j = i + 1; j < tokens.length; ++j) {
+                _removeTokenPair(pool, address(tokens[i]), address(tokens[j]));
+            }
+        }
+    }
+
+    function removeBuffer(IERC4626 wrappedToken) external authenticate {
+        address underlyingToken = vault.getBufferAsset(wrappedToken);
+        _removeTokenPair(address(wrappedToken), underlyingToken, address(wrappedToken));
+    }
+
+    function _addTokenPair(address pool, address tokenA, address tokenB) internal {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
 
-        pairsToPool[tokenId] = pool;
-        emit TokenPairRegistered(pool, tokenA, tokenB);
+        if (pairsToPool[tokenId].add(pool) == false) {
+            revert PoolAlreadyAddedForPair(pool, tokenA, tokenB);
+        }
+        emit TokenPairAdded(pool, tokenA, tokenB);
+    }
+
+    function _removeTokenPair(address pool, address tokenA, address tokenB) internal {
+        bytes32 tokenId = _getTokenId(tokenA, tokenB);
+
+        if (pairsToPool[tokenId].remove(pool) == false) {
+            revert PoolNotAddedForPair(pool, tokenA, tokenB);
+        }
+        emit TokenPairRemoved(pool, tokenA, tokenB);
     }
 
     /// @dev Returns a unique identifier for the token pair, ensuring that the order of tokens does not matter.

--- a/pkg/standalone-utils/contracts/TokenPairRegistry.sol
+++ b/pkg/standalone-utils/contracts/TokenPairRegistry.sol
@@ -121,7 +121,6 @@ contract TokenPairRegistry is ITokenPairRegistry, OwnableAuthentication {
         _removeTokenPair(address(wrappedToken), underlyingToken, address(wrappedToken));
     }
 
-
     /// @dev Returns a unique identifier for the token pair, ensuring that the order of tokens does not matter.
     function _getTokenId(address tokenA, address tokenB) internal pure returns (bytes32) {
         (tokenA, tokenB) = tokenA <= tokenB ? (tokenA, tokenB) : (tokenB, tokenA);

--- a/pkg/standalone-utils/contracts/TokenPairRegistry.sol
+++ b/pkg/standalone-utils/contracts/TokenPairRegistry.sol
@@ -15,7 +15,7 @@ import { OwnableAuthentication } from "./OwnableAuthentication.sol";
 contract TokenPairRegistry is ITokenPairRegistry, OwnableAuthentication {
     using EnumerableSet for EnumerableSet.AddressSet;
 
-    mapping(bytes32 pairId => EnumerableSet.AddressSet pools) internal pairsToPath;
+    mapping(bytes32 pairId => EnumerableSet.AddressSet pools) internal _pairsToPath;
 
     constructor(IVault vault, address initialOwner) OwnableAuthentication(vault, initialOwner) {
         // solhint-disable-previous-line no-empty-blocks
@@ -23,28 +23,28 @@ contract TokenPairRegistry is ITokenPairRegistry, OwnableAuthentication {
 
     function getPathAt(address tokenA, address tokenB, uint256 index) external view returns (address) {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
-        return pairsToPath[tokenId].at(index);
+        return _pairsToPath[tokenId].at(index);
     }
 
     function getPathAtUnchecked(address tokenA, address tokenB, uint256 index) external view returns (address) {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
-        return pairsToPath[tokenId].unchecked_at(index);
+        return _pairsToPath[tokenId].unchecked_at(index);
     }
 
     function getPathCount(address tokenA, address tokenB) external view returns (uint256) {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
-        return pairsToPath[tokenId].length();
+        return _pairsToPath[tokenId].length();
     }
 
     function getPaths(address tokenA, address tokenB) external view returns (address[] memory) {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
-        EnumerableSet.AddressSet storage pools = pairsToPath[tokenId];
+        EnumerableSet.AddressSet storage pools = _pairsToPath[tokenId];
         return pools._values;
     }
 
     function hasPath(address tokenA, address tokenB, address pool) external view returns (bool) {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
-        return pairsToPath[tokenId].contains(pool);
+        return _pairsToPath[tokenId].contains(pool);
     }
 
     function addPath(address path) external authenticate {
@@ -90,7 +90,7 @@ contract TokenPairRegistry is ITokenPairRegistry, OwnableAuthentication {
     function _addTokenPair(address pool, address tokenA, address tokenB) internal {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
 
-        if (pairsToPath[tokenId].add(pool) == false) {
+        if (_pairsToPath[tokenId].add(pool) == false) {
             revert PathAlreadyAddedForPair(pool, tokenA, tokenB);
         }
         emit TokenPairAdded(pool, tokenA, tokenB);
@@ -110,7 +110,7 @@ contract TokenPairRegistry is ITokenPairRegistry, OwnableAuthentication {
     function _removeTokenPair(address pool, address tokenA, address tokenB) internal {
         bytes32 tokenId = _getTokenId(tokenA, tokenB);
 
-        if (pairsToPath[tokenId].remove(pool) == false) {
+        if (_pairsToPath[tokenId].remove(pool) == false) {
             revert PathNotAddedForPair(pool, tokenA, tokenB);
         }
         emit TokenPairRemoved(pool, tokenA, tokenB);

--- a/pkg/standalone-utils/contracts/TokenPairRegistry.sol
+++ b/pkg/standalone-utils/contracts/TokenPairRegistry.sol
@@ -5,24 +5,15 @@ pragma solidity ^0.8.24;
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import { ITokenPairRegistry } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/ITokenPairRegistry.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import { EnumerableSet } from "@balancer-labs/v3-solidity-utils/contracts/openzeppelin/EnumerableSet.sol";
 import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
 
 import { OwnableAuthentication } from "./OwnableAuthentication.sol";
 
-contract TokenPairRegistry is OwnableAuthentication {
+contract TokenPairRegistry is ITokenPairRegistry, OwnableAuthentication {
     using EnumerableSet for EnumerableSet.AddressSet;
-
-    event TokenPairAdded(address indexed pool, address indexed tokenA, address indexed tokenB);
-
-    event TokenPairRemoved(address indexed pool, address indexed tokenA, address indexed tokenB);
-
-    error WrongTokenOrder();
-
-    error PoolAlreadyAddedForPair(address pool, address tokenA, address tokenB);
-
-    error PoolNotAddedForPair(address pool, address tokenA, address tokenB);
 
     mapping(bytes32 pairId => EnumerableSet.AddressSet pools) internal pairsToPool;
 

--- a/pkg/standalone-utils/contracts/TokenPairRegistry.sol
+++ b/pkg/standalone-utils/contracts/TokenPairRegistry.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
+
+import { OwnableAuthentication } from "./OwnableAuthentication.sol";
+
+contract TokenPairRegistry is OwnableAuthentication {
+    event TokenPairRegistered(address indexed pool, address indexed tokenA, address indexed tokenB);
+
+    error WrongTokenOrder();
+
+    mapping (bytes32 pairId => address pool) internal pairsToPool;
+
+    constructor(IVault vault, address initialOwner) OwnableAuthentication(vault, initialOwner) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    function getPool(address tokenA, address tokenB) external view returns (address) {
+        bytes32 tokenId = _getTokenId(tokenA, tokenB);
+        return pairsToPool[tokenId];
+    }
+
+    function addPool(address pool) external authenticate {
+        // This call reverts if the pool is not registered.
+        IERC20[] memory tokens = vault.getPoolTokens(pool);
+
+        uint256 tokenPairs = tokens.length - 1;
+        for (uint256 i = 0; i < tokenPairs; ++i) {
+            for (uint256 j = i + 1; j < tokens.length; ++j) {
+                _registerTokenPair(pool, address(tokens[i]), address(tokens[j]));
+            }
+        }
+    }
+
+    /**
+     * @dev The "pool" for (underlying, wrapped) shall be `wrapped` always, but only if it's registered as a vault
+     * buffer. 
+     */
+    function addBuffer(IERC4626 wrappedToken) external authenticate {
+        address underlyingToken = vault.getBufferAsset(wrappedToken);
+        _registerTokenPair(address(wrappedToken), underlyingToken, address(wrappedToken));
+    }
+
+    function _registerTokenPair(address pool, address tokenA, address tokenB) internal {
+        bytes32 tokenId = _getTokenId(tokenA, tokenB);
+
+        pairsToPool[tokenId] = pool;
+        emit TokenPairRegistered(pool, tokenA, tokenB);
+    }
+
+    /// @dev Returns a unique identifier for the token pair, ensuring that the order of tokens does not matter.
+    function _getTokenId(address tokenA, address tokenB) internal pure returns (bytes32) {
+        (tokenA, tokenB) = tokenA <= tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+        return keccak256(abi.encodePacked(tokenA, tokenB));
+    }
+}

--- a/pkg/standalone-utils/test/foundry/TokenPairRegistry.t.sol
+++ b/pkg/standalone-utils/test/foundry/TokenPairRegistry.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
+import { IBatchRouter } from "@balancer-labs/v3-interfaces/contracts/vault/IBatchRouter.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
+import { TokenConfig, TokenType } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+
+import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/test/ArrayHelpers.sol";
+
+import { PoolFactoryMock } from "@balancer-labs/v3-vault/contracts/test/PoolFactoryMock.sol";
+import { BaseERC4626BufferTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseERC4626BufferTest.sol";
+import { PoolMock } from "@balancer-labs/v3-vault/contracts/test/PoolMock.sol";
+
+import { TokenPairRegistry } from "../../contracts/TokenPairRegistry.sol";
+
+contract TokenPairRegistryTest is BaseERC4626BufferTest {
+    using ArrayHelpers for *;
+
+    TokenPairRegistry internal registry;
+
+    function setUp() public virtual override {
+        super.setUp();
+        registry = new TokenPairRegistry(vault, admin);
+    }
+
+    function testAddPathPermissioned() external {
+        address tokenIn = address(waDAI);
+        IBatchRouter.SwapPathStep[] memory steps;
+
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        registry.addPath(tokenIn, steps);
+    }
+}

--- a/pkg/standalone-utils/test/foundry/TokenPairRegistry.t.sol
+++ b/pkg/standalone-utils/test/foundry/TokenPairRegistry.t.sol
@@ -2,20 +2,18 @@
 
 pragma solidity ^0.8.24;
 
+import "forge-std/Test.sol";
+
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 
 import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
+import { ITokenPairRegistry } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/ITokenPairRegistry.sol";
 import { IBatchRouter } from "@balancer-labs/v3-interfaces/contracts/vault/IBatchRouter.sol";
-import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
-import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
-import { TokenConfig, TokenType } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
 import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/test/ArrayHelpers.sol";
 
-import { PoolFactoryMock } from "@balancer-labs/v3-vault/contracts/test/PoolFactoryMock.sol";
 import { BaseERC4626BufferTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseERC4626BufferTest.sol";
-import { PoolMock } from "@balancer-labs/v3-vault/contracts/test/PoolMock.sol";
 
 import { TokenPairRegistry } from "../../contracts/TokenPairRegistry.sol";
 
@@ -23,10 +21,12 @@ contract TokenPairRegistryTest is BaseERC4626BufferTest {
     using ArrayHelpers for *;
 
     TokenPairRegistry internal registry;
+    address internal otherPool;
 
     function setUp() public virtual override {
         super.setUp();
         registry = new TokenPairRegistry(vault, admin);
+        (otherPool, ) = createPool();
     }
 
     function testAddPathPermissioned() external {
@@ -35,5 +35,281 @@ contract TokenPairRegistryTest is BaseERC4626BufferTest {
 
         vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         registry.addPath(tokenIn, steps);
+    }
+
+    function testAddPath() external {
+        address tokenIn = address(weth);
+        address tokenOut = address(dai);
+        IBatchRouter.SwapPathStep[] memory steps = new IBatchRouter.SwapPathStep[](3);
+
+        steps[0] = IBatchRouter.SwapPathStep({ pool: address(waWETH), tokenOut: waWETH, isBuffer: true });
+        steps[1] = IBatchRouter.SwapPathStep({ pool: address(pool), tokenOut: waDAI, isBuffer: false });
+        steps[2] = IBatchRouter.SwapPathStep({ pool: address(waDAI), tokenOut: dai, isBuffer: true });
+
+        vm.expectEmit();
+        emit ITokenPairRegistry.PathAdded(address(weth), address(dai), 1);
+
+        vm.prank(admin);
+        registry.addPath(tokenIn, steps);
+
+        assertEq(registry.getPathCount(tokenIn, tokenOut), 1, "Wrong path count");
+        assertEq(registry.getPaths(tokenIn, tokenOut).length, 1, "Paths length does not match count");
+        assertEq(registry.getPathAt(tokenIn, tokenOut, 0).length, 3, "Path[0] length does not match steps length");
+    }
+
+    function testAddSimplePathPermissioned() external {
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        registry.addSimplePath(pool);
+    }
+
+    function testAddSimplePathNonRegisteredPoolOrBuffer() external {
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(ITokenPairRegistry.InvalidSimplePath.selector, address(123)));
+        registry.addSimplePath(address(123));
+    }
+
+    function testPoolAddSimplePath() external {
+        _expectEmitPathAddedEvents(address(waDAI), address(waWETH));
+
+        vm.prank(admin);
+        registry.addSimplePath(pool);
+
+        assertEq(registry.getPathCount(address(waWETH), address(waDAI)), 1, "Wrong path count waWETH / waDAI");
+        assertEq(registry.getPathCount(address(waDAI), address(waWETH)), 1, "Wrong path count waDAI / waWETH");
+
+        IBatchRouter.SwapPathStep[][] memory pathsWethDai = registry.getPaths(address(waWETH), address(waDAI));
+        assertEq(pathsWethDai.length, 1, "Wrong path length waWETH / waDAI");
+        assertEq(pathsWethDai[0].length, 1, "Wrong path[0] waWETH / waDAI steps length");
+        assertEq(pathsWethDai[0][0].pool, address(pool), "Wrong path[0] waWETH / waDAI step pool");
+        assertEq(address(pathsWethDai[0][0].tokenOut), address(waDAI), "Wrong path[0] waWETH / waDAI token out");
+        assertFalse(pathsWethDai[0][0].isBuffer, "Wrong path[0] waWETH / waDAI step isBuffer");
+
+        // getPathAt returns the correct one
+        IBatchRouter.SwapPathStep[] memory pathWethDai0 = registry.getPathAt(address(waWETH), address(waDAI), 0);
+        assertEq(
+            keccak256(abi.encode(pathWethDai0)),
+            keccak256(abi.encode(pathsWethDai[0])),
+            "waWETH / waDAI getPathAt mismatch"
+        );
+
+        IBatchRouter.SwapPathStep[][] memory pathsDaiWeth = registry.getPaths(address(waDAI), address(waWETH));
+        assertEq(pathsDaiWeth.length, 1, "Wrong path length waDAI / waWETH");
+        assertEq(pathsDaiWeth[0].length, 1, "Wrong path[0] waDAI / waWETH steps length");
+        assertEq(pathsDaiWeth[0][0].pool, address(pool), "Wrong path[0] waDAI / waWETH step pool");
+        assertEq(address(pathsDaiWeth[0][0].tokenOut), address(waWETH), "Wrong path[0] waDAI / waWETH token out");
+        assertFalse(pathsDaiWeth[0][0].isBuffer, "Wrong path[0] waDAI / waWETH step isBuffer");
+
+        // getPathAt returns the correct one
+        IBatchRouter.SwapPathStep[] memory pathDaiWeth0 = registry.getPathAt(address(waDAI), address(waWETH), 0);
+        assertEq(
+            keccak256(abi.encode(pathDaiWeth0)),
+            keccak256(abi.encode(pathsDaiWeth[0])),
+            "waDAI / waWETH getPathAt mismatch"
+        );
+    }
+
+    function testBufferAddSimplePath() external {
+        _expectEmitPathAddedEvents(address(weth), address(waWETH));
+        vm.prank(admin);
+        registry.addSimplePath(address(waWETH));
+
+        assertEq(registry.getPathCount(address(weth), address(waWETH)), 1, "Wrong path count weth / waWETH");
+        assertEq(registry.getPathCount(address(waWETH), address(weth)), 1, "Wrong path count waWETH / weth");
+
+        IBatchRouter.SwapPathStep[][] memory pathsWrap = registry.getPaths(address(weth), address(waWETH));
+        assertEq(pathsWrap.length, 1, "Wrong path length weth / waWETH");
+        assertEq(pathsWrap[0].length, 1, "Wrong path[0] weth / waWETH steps length");
+        assertEq(pathsWrap[0][0].pool, address(waWETH), "Wrong path[0] weth / waWETH step pool");
+        assertEq(address(pathsWrap[0][0].tokenOut), address(waWETH), "Wrong path[0] weth / waWETH token out");
+        assertTrue(pathsWrap[0][0].isBuffer, "Wrong path[0] weth / waWETH step isBuffer");
+
+        // getPathAt returns the correct one
+        IBatchRouter.SwapPathStep[] memory pathWrap0 = registry.getPathAt(address(weth), address(waWETH), 0);
+        assertEq(
+            keccak256(abi.encode(pathWrap0)),
+            keccak256(abi.encode(pathsWrap[0])),
+            "weth / waWETH getPathAt mismatch"
+        );
+
+        IBatchRouter.SwapPathStep[][] memory pathsUnwrap = registry.getPaths(address(waWETH), address(weth));
+        assertEq(pathsUnwrap.length, 1, "Wrong path length waWETH / weth");
+        assertEq(pathsUnwrap[0].length, 1, "Wrong path[0] waWETH / weth steps length");
+        assertEq(pathsUnwrap[0][0].pool, address(waWETH), "Wrong path[0] waWETH / weth step pool");
+        assertEq(address(pathsUnwrap[0][0].tokenOut), address(weth), "Wrong path[0] waWETH / weth token out");
+        assertTrue(pathsUnwrap[0][0].isBuffer, "Wrong path[0] waWETH / weth step isBuffer");
+
+        // getPathAt returns the correct one
+        IBatchRouter.SwapPathStep[] memory pathUnwrap0 = registry.getPathAt(address(waWETH), address(weth), 0);
+        assertEq(
+            keccak256(abi.encode(pathUnwrap0)),
+            keccak256(abi.encode(pathsUnwrap[0])),
+            "waWETH / weth getPathAt mismatch"
+        );
+    }
+
+    function testRemovePathAtIndexPermissioned() external {
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        registry.removePathAtIndex(address(waDAI), address(waWETH), 0);
+    }
+
+    function testRemovePathAtIndex() external {
+        vm.startPrank(admin);
+        registry.addSimplePath(pool);
+        registry.addSimplePath(otherPool);
+        vm.stopPrank();
+
+        assertEq(registry.getPathCount(address(waDAI), address(waWETH)), 2, "Wrong path count waDAI / waWETH");
+        assertEq(
+            registry.getPathAt(address(waDAI), address(waWETH), 0)[0].pool,
+            address(pool),
+            "Wrong waDAI / waWETH path[0] pool"
+        );
+        assertEq(
+            registry.getPathAt(address(waDAI), address(waWETH), 1)[0].pool,
+            address(otherPool),
+            "Wrong waDAI / waWETH path[1] pool"
+        );
+
+        assertEq(registry.getPathCount(address(waWETH), address(waDAI)), 2, "Wrong path count waWETH / waDAI");
+        assertEq(
+            registry.getPathAt(address(waWETH), address(waDAI), 0)[0].pool,
+            address(pool),
+            "Wrong waWETH / waDAI path[0] pool"
+        );
+        assertEq(
+            registry.getPathAt(address(waWETH), address(waDAI), 1)[0].pool,
+            address(otherPool),
+            "Wrong waWETH / waDAI path[1] pool"
+        );
+
+        vm.expectEmit();
+        emit ITokenPairRegistry.PathRemoved(address(waWETH), address(waDAI), 1);
+
+        vm.prank(admin);
+        registry.removePathAtIndex(address(waWETH), address(waDAI), 0);
+        assertEq(
+            registry.getPathCount(address(waWETH), address(waDAI)),
+            1,
+            "Wrong path count waWETH / waDAI after remove"
+        );
+        assertEq(
+            registry.getPathCount(address(waDAI), address(waWETH)),
+            2,
+            "Wrong path count waDAI / waWETH after remove"
+        );
+
+        // First path was removed, and second path was moved to the first position.
+        assertEq(
+            registry.getPathAt(address(waWETH), address(waDAI), 0)[0].pool,
+            address(otherPool),
+            "Wrong waWETH / waDAI path[0] pool"
+        );
+        vm.expectRevert(stdError.indexOOBError);
+        registry.getPathAt(address(waWETH), address(waDAI), 1);
+    }
+
+    function testRemovePathAtIndexMultiHop() external {
+        address tokenIn = address(weth);
+        address tokenOut = address(dai);
+        IBatchRouter.SwapPathStep[] memory steps = new IBatchRouter.SwapPathStep[](3);
+
+        steps[0] = IBatchRouter.SwapPathStep({ pool: address(waWETH), tokenOut: waWETH, isBuffer: true });
+        steps[1] = IBatchRouter.SwapPathStep({ pool: address(pool), tokenOut: waDAI, isBuffer: false });
+        steps[2] = IBatchRouter.SwapPathStep({ pool: address(waDAI), tokenOut: dai, isBuffer: true });
+
+        vm.prank(admin);
+        registry.addPath(tokenIn, steps);
+
+        steps[1] = IBatchRouter.SwapPathStep({ pool: address(otherPool), tokenOut: waDAI, isBuffer: false });
+        vm.prank(admin);
+        registry.addPath(tokenIn, steps);
+
+        assertEq(registry.getPathCount(tokenIn, tokenOut), 2, "Wrong path count tokenIn / tokenOut");
+        assertEq(registry.getPaths(tokenIn, tokenOut).length, 2, "Wrong path length tokenIn / tokenOut");
+        assertEq(registry.getPathAt(tokenIn, tokenOut, 0).length, 3, "Wrong path[0] steps length tokenIn / tokenOut");
+        assertEq(registry.getPathAt(tokenIn, tokenOut, 1).length, 3, "Wrong path[1] steps length tokenIn / tokenOut");
+        assertEq(registry.getPathAt(tokenIn, tokenOut, 0)[1].pool, pool, "Wrong path[0][1] tokenIn / tokenOut pool");
+
+        vm.expectEmit();
+        emit ITokenPairRegistry.PathRemoved(address(tokenIn), address(tokenOut), 1);
+
+        vm.prank(admin);
+        registry.removePathAtIndex(address(tokenIn), address(tokenOut), 0);
+        assertEq(registry.getPathCount(tokenIn, tokenOut), 1, "Wrong path count tokenIn / tokenOut after remove");
+        assertEq(registry.getPaths(tokenIn, tokenOut).length, 1, "Wrong path length tokenIn / tokenOut after remove");
+        assertEq(
+            registry.getPathAt(tokenIn, tokenOut, 0).length,
+            3,
+            "Wrong path[0] steps length tokenIn / tokenOut after remove"
+        );
+        // First path is replaced deleted and replaced by the second one
+        assertEq(
+            registry.getPathAt(tokenIn, tokenOut, 0)[1].pool,
+            otherPool,
+            "Wrong path[0][1] tokenIn / tokenOut pool after remove"
+        );
+    }
+
+    function testRemoveSimplePathNonRegisteredPoolOrBuffer() external {
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(ITokenPairRegistry.InvalidSimplePath.selector, address(123)));
+        registry.removeSimplePath(address(123));
+    }
+
+    function testRemoveSimplePathPermissioned() external {
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
+        registry.removeSimplePath(pool);
+    }
+
+    function testRemoveSimplePath() external {
+        registry.getPaths(address(waWETH), address(waDAI));
+
+        vm.startPrank(admin);
+        registry.addSimplePath(pool);
+        vm.stopPrank();
+
+        registry.getPaths(address(waWETH), address(waDAI));
+
+        assertEq(registry.getPathCount(address(waDAI), address(waWETH)), 1, "Wrong path count waDAI / waWETH");
+        assertEq(registry.getPathCount(address(waWETH), address(waDAI)), 1, "Wrong path count waWETH / waDAI");
+
+        _expectEmitPathRemovedEvents(address(waDAI), address(waWETH));
+        vm.prank(admin);
+        registry.removeSimplePath(pool);
+        registry.getPaths(address(waWETH), address(waDAI));
+        assertEq(
+            registry.getPathCount(address(waWETH), address(waDAI)),
+            0,
+            "Wrong path count waWETH / waDAI after remove"
+        );
+        assertEq(
+            registry.getPathCount(address(waDAI), address(waWETH)),
+            0,
+            "Wrong path count waDAI / waWETH after remove"
+        );
+    }
+
+    function _expectEmitPathAddedEvents(address tokenA, address tokenB) internal {
+        // The order of the tokens determines the order of the events
+        (tokenA, tokenB) = address(tokenA) < address(tokenB)
+            ? (address(tokenA), address(tokenB))
+            : (address(tokenB), address(tokenA));
+        vm.expectEmit();
+        emit ITokenPairRegistry.PathAdded(address(tokenA), address(tokenB), 1);
+
+        vm.expectEmit();
+        emit ITokenPairRegistry.PathAdded(address(tokenB), address(tokenA), 1);
+    }
+
+    function _expectEmitPathRemovedEvents(address tokenA, address tokenB) internal {
+        // The order of the tokens determines the order of the events
+        (tokenA, tokenB) = address(tokenA) < address(tokenB)
+            ? (address(tokenA), address(tokenB))
+            : (address(tokenB), address(tokenA));
+        vm.expectEmit();
+        emit ITokenPairRegistry.PathRemoved(address(tokenA), address(tokenB), 0);
+
+        vm.expectEmit();
+        emit ITokenPairRegistry.PathRemoved(address(tokenB), address(tokenA), 0);
     }
 }

--- a/pkg/vault/test/foundry/utils/BaseERC4626BufferTest.sol
+++ b/pkg/vault/test/foundry/utils/BaseERC4626BufferTest.sol
@@ -44,7 +44,7 @@ abstract contract BaseERC4626BufferTest is BaseVaultTest {
 
     function createPool() internal virtual override returns (address newPool, bytes memory poolArgs) {
         string memory name = "ERC4626 Pool";
-        string memory symbol = "ERC4626P";
+        string memory symbol = "ERC4626";
 
         TokenConfig[] memory tokenConfig = getTokenConfig();
 


### PR DESCRIPTION
# Description

Add a small registry that maps token pairs --> swap path.
A buffer can also be considered a path for (underlying, wrapped) tokens; pools and buffers are treated equally.

Modifying the registry is permissioned (with owner + governance), and one pair might have multiple paths.

This version, unlike #1453, allows setting multi-hop paths. And as such, paths from (tokenA --> tokenB) are different from (tokenB --> tokenA), which requires storing both options individually.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
  - Some coverage missing
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #1439 