### PR TITLE
Adapt Gyro Library to Surge Hook

### DIFF
--- a/pkg/interfaces/contracts/pool-gyro/IGyroECLPPool.sol
+++ b/pkg/interfaces/contracts/pool-gyro/IGyroECLPPool.sol
@@ -81,6 +81,7 @@ interface IGyroECLPPool is IBasePool {
      * @param symbol Pool symbol
      * @param eclpParams Parameters to configure the E-CLP pool, with 18 decimals
      * @param derivedEclpParams Parameters calculated off-chain based on eclpParams. 38 decimals for higher precision
+     * @param version Pool version
      */
     struct GyroECLPPoolParams {
         string name;
@@ -153,4 +154,11 @@ interface IGyroECLPPool is IBasePool {
      * @return data A struct containing all immutable stable pool parameters
      */
     function getGyroECLPPoolImmutableData() external view returns (GyroECLPPoolImmutableData memory data);
+
+    /**
+     * @notice Get ECLP parameters relevant to swap/add/remove calculations.
+     * @return params A struct containing all ECLP parameters
+     * @return d A struct containing all derived ECLP parameters
+     */
+    function getECLPParams() external view returns (EclpParams memory params, DerivedEclpParams memory d);
 }

--- a/pkg/pool-gyro/contracts/GyroECLPPool.sol
+++ b/pkg/pool-gyro/contracts/GyroECLPPool.sol
@@ -139,17 +139,25 @@ contract GyroECLPPool is IGyroECLPPool, BalancerPoolToken, PoolInfo, Version {
             require(invariant.x <= GyroECLPMath._MAX_INVARIANT, GyroECLPMath.MaxInvariantExceeded());
         }
 
+        int256 newBalanceInt;
+
         if (tokenInIndex == 0) {
-            return
-                GyroECLPMath
-                    .calcXGivenY(balancesLiveScaled18[1].toInt256(), eclpParams, derivedECLPParams, invariant)
-                    .toUint256();
+            (newBalanceInt, , ) = GyroECLPMath.calcXGivenY(
+                balancesLiveScaled18[1].toInt256(),
+                eclpParams,
+                derivedECLPParams,
+                invariant
+            );
         } else {
-            return
-                GyroECLPMath
-                    .calcYGivenX(balancesLiveScaled18[0].toInt256(), eclpParams, derivedECLPParams, invariant)
-                    .toUint256();
+            (newBalanceInt, , ) = GyroECLPMath.calcYGivenX(
+                balancesLiveScaled18[0].toInt256(),
+                eclpParams,
+                derivedECLPParams,
+                invariant
+            );
         }
+
+        newBalance = newBalanceInt.toUint256();
     }
 
     /// @inheritdoc IBasePool
@@ -171,7 +179,7 @@ contract GyroECLPPool is IGyroECLPPool, BalancerPoolToken, PoolInfo, Version {
         }
 
         if (request.kind == SwapKind.EXACT_IN) {
-            uint256 amountOutScaled18 = GyroECLPMath.calcOutGivenIn(
+            (uint256 amountOutScaled18, , ) = GyroECLPMath.calcOutGivenIn(
                 request.balancesScaled18,
                 request.amountGivenScaled18,
                 tokenInIsToken0,
@@ -182,7 +190,7 @@ contract GyroECLPPool is IGyroECLPPool, BalancerPoolToken, PoolInfo, Version {
 
             return amountOutScaled18;
         } else {
-            uint256 amountInScaled18 = GyroECLPMath.calcInGivenOut(
+            (uint256 amountInScaled18, , ) = GyroECLPMath.calcInGivenOut(
                 request.balancesScaled18,
                 request.amountGivenScaled18,
                 tokenInIsToken0,
@@ -208,6 +216,7 @@ contract GyroECLPPool is IGyroECLPPool, BalancerPoolToken, PoolInfo, Version {
         (d.u, d.v, d.w, d.z, d.dSq) = (_u, _v, _w, _z, _dSq);
     }
 
+    /// @inheritdoc IGyroECLPPool
     function getECLPParams() external view returns (EclpParams memory params, DerivedEclpParams memory d) {
         return _reconstructECLPParams();
     }


### PR DESCRIPTION
# Description

To avoid code duplication, the new Surge Hook needs the offset parameters exposed in the function that computes the swap. It doesn't affect the pool math.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge
