### PR TITLE
Add factory version to oracle contracts

### DIFF
--- a/pkg/interfaces/contracts/standalone-utils/ILPOracleFactoryBase.sol
+++ b/pkg/interfaces/contracts/standalone-utils/ILPOracleFactoryBase.sol
@@ -26,6 +26,15 @@ interface ILPOracleFactoryBase {
     error OracleFactoryIsDisabled();
 
     /**
+     * @notice Returns a number representing the oracle version.
+     * @dev This is a number - not a JSON string like the factory version (and other contracts in the system
+     * derived from Version) - because the V3AggregatorInterface for oracles defines a numerical version.
+     *
+     * @return oracleVersion The oracle version number
+     */
+    function getOracleVersion() external view returns (uint256);
+
+    /**
      * @notice Creates a new oracle for the given pool.
      * @param pool The address of the pool
      * @param feeds The array of price feeds for the tokens in the pool

--- a/pkg/standalone-utils/contracts/LPOracleFactoryBase.sol
+++ b/pkg/standalone-utils/contracts/LPOracleFactoryBase.sol
@@ -10,23 +10,33 @@ import { ILPOracleBase } from "@balancer-labs/v3-interfaces/contracts/standalone
 import { IBasePool } from "@balancer-labs/v3-interfaces/contracts/vault/IBasePool.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 
-import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
 import { SingletonAuthentication } from "@balancer-labs/v3-vault/contracts/SingletonAuthentication.sol";
+import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
+import { Version } from "@balancer-labs/v3-solidity-utils/contracts/helpers/Version.sol";
 
 /**
  * @notice Base contract for deploying and managing pool oracles.
  * @dev The factories that inherit this contract must implement the `_create` function, which deploys a different
  * oracle, depending on the pool.
  */
-abstract contract LPOracleFactoryBase is ILPOracleFactoryBase, SingletonAuthentication {
+abstract contract LPOracleFactoryBase is ILPOracleFactoryBase, SingletonAuthentication, Version {
     uint256 internal _oracleVersion;
     bool internal _isDisabled;
 
     mapping(bytes32 oracleId => ILPOracleBase oracle) internal _oracles;
     mapping(ILPOracleBase oracle => bool creationFlag) internal _isOracleFromFactory;
 
-    constructor(IVault vault, uint256 oracleVersion) SingletonAuthentication(vault) {
+    constructor(
+        IVault vault,
+        string memory factoryVersion,
+        uint256 oracleVersion
+    ) SingletonAuthentication(vault) Version(factoryVersion) {
         _oracleVersion = oracleVersion;
+    }
+
+    /// @inheritdoc ILPOracleFactoryBase
+    function getOracleVersion() external view returns (uint256) {
+        return _oracleVersion;
     }
 
     /// @inheritdoc ILPOracleFactoryBase

--- a/pkg/standalone-utils/contracts/StableLPOracle.sol
+++ b/pkg/standalone-utils/contracts/StableLPOracle.sol
@@ -18,9 +18,7 @@ import { StableMath } from "@balancer-labs/v3-solidity-utils/contracts/math/Stab
 
 import { LPOracleBase } from "./LPOracleBase.sol";
 
-/**
- * @notice Oracle for stable pools.
- */
+/// @notice Oracle for stable pools.
 contract StableLPOracle is LPOracleBase {
     using FixedPoint for uint256;
     using SafeCast for *;

--- a/pkg/standalone-utils/contracts/StableLPOracleFactory.sol
+++ b/pkg/standalone-utils/contracts/StableLPOracleFactory.sol
@@ -24,7 +24,11 @@ contract StableLPOracleFactory is LPOracleFactoryBase {
      */
     event StableLPOracleCreated(IStablePool indexed pool, AggregatorV3Interface[] feeds, ILPOracleBase oracle);
 
-    constructor(IVault vault, uint256 oracleVersion) LPOracleFactoryBase(vault, oracleVersion) {
+    constructor(
+        IVault vault,
+        string memory factoryVersion,
+        uint256 oracleVersion
+    ) LPOracleFactoryBase(vault, factoryVersion, oracleVersion) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/standalone-utils/contracts/WeightedLPOracle.sol
+++ b/pkg/standalone-utils/contracts/WeightedLPOracle.sol
@@ -16,9 +16,7 @@ import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/Fixe
 
 import { LPOracleBase } from "./LPOracleBase.sol";
 
-/**
- * @notice Oracle for weighted pools.
- */
+/// @notice Oracle for weighted pools.
 contract WeightedLPOracle is IWeightedLPOracle, LPOracleBase {
     using FixedPoint for uint256;
     using SafeCast for *;

--- a/pkg/standalone-utils/contracts/WeightedLPOracleFactory.sol
+++ b/pkg/standalone-utils/contracts/WeightedLPOracleFactory.sol
@@ -25,7 +25,11 @@ contract WeightedLPOracleFactory is LPOracleFactoryBase {
      */
     event WeightedLPOracleCreated(IWeightedPool indexed pool, AggregatorV3Interface[] feeds, IWeightedLPOracle oracle);
 
-    constructor(IVault vault, uint256 oracleVersion) LPOracleFactoryBase(vault, oracleVersion) {
+    constructor(
+        IVault vault,
+        string memory factoryVersion,
+        uint256 oracleVersion
+    ) LPOracleFactoryBase(vault, factoryVersion, oracleVersion) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/standalone-utils/test/foundry/LPOracleFactoryBase.t.sol
+++ b/pkg/standalone-utils/test/foundry/LPOracleFactoryBase.t.sol
@@ -9,6 +9,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ILPOracleFactoryBase } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/ILPOracleFactoryBase.sol";
 import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
 import { ILPOracleBase } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/ILPOracleBase.sol";
+import { IVersion } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IVersion.sol";
 
 import { IBasePool } from "@balancer-labs/v3-interfaces/contracts/vault/IBasePool.sol";
 
@@ -17,6 +18,9 @@ import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVa
 import { FeedMock } from "../../contracts/test/FeedMock.sol";
 
 abstract contract LPOracleFactoryBaseTest is BaseVaultTest {
+    string constant ORACLE_FACTORY_VERSION = "Factory v1";
+    uint256 constant ORACLE_VERSION = 1;
+
     ILPOracleFactoryBase internal _factory;
 
     function setUp() public virtual override {
@@ -28,6 +32,14 @@ abstract contract LPOracleFactoryBaseTest is BaseVaultTest {
             IAuthentication(address(_factory)).getActionId(ILPOracleFactoryBase.disable.selector),
             admin
         );
+    }
+
+    function testOracleFactoryVersion() public view {
+        assertEq(IVersion(address(_factory)).version(), ORACLE_FACTORY_VERSION, "Wrong oracle factory version");
+    }
+
+    function testOracleVersion() public view {
+        assertEq(_factory.getOracleVersion(), ORACLE_VERSION, "Wrong oracle version");
     }
 
     function testCreateOracle() external {

--- a/pkg/standalone-utils/test/foundry/StableLPOracleFactory.t.sol
+++ b/pkg/standalone-utils/test/foundry/StableLPOracleFactory.t.sol
@@ -25,7 +25,6 @@ contract StableLPOracleFactoryTest is StablePoolContractsDeployer, LPOracleFacto
     using ArrayHelpers for *;
     using CastingHelpers for address[];
 
-    uint256 constant ORACLE_VERSION = 1;
     uint256 constant AMPLIFICATION_PARAMETER = 100;
 
     StablePoolFactory _stablePoolFactory;
@@ -90,6 +89,6 @@ contract StableLPOracleFactoryTest is StablePoolContractsDeployer, LPOracleFacto
     }
 
     function _createOracleFactory() internal override returns (ILPOracleFactoryBase) {
-        return ILPOracleFactoryBase(address(new StableLPOracleFactory(vault, ORACLE_VERSION)));
+        return ILPOracleFactoryBase(address(new StableLPOracleFactory(vault, ORACLE_FACTORY_VERSION, ORACLE_VERSION)));
     }
 }

--- a/pkg/standalone-utils/test/foundry/WeightedLPOracleFactory.t.sol
+++ b/pkg/standalone-utils/test/foundry/WeightedLPOracleFactory.t.sol
@@ -29,8 +29,6 @@ contract WeightedLPOracleFactoryTest is WeightedPoolContractsDeployer, LPOracleF
     using ArrayHelpers for *;
     using CastingHelpers for address[];
 
-    uint256 constant ORACLE_VERSION = 1;
-
     WeightedPoolFactory _weightedPoolFactory;
 
     function setUp() public virtual override {
@@ -99,6 +97,7 @@ contract WeightedLPOracleFactoryTest is WeightedPoolContractsDeployer, LPOracleF
     }
 
     function _createOracleFactory() internal override returns (ILPOracleFactoryBase) {
-        return ILPOracleFactoryBase(address(new WeightedLPOracleFactory(vault, ORACLE_VERSION)));
+        return
+            ILPOracleFactoryBase(address(new WeightedLPOracleFactory(vault, ORACLE_FACTORY_VERSION, ORACLE_VERSION)));
     }
 }


### PR DESCRIPTION
# Description

Adds factory versioning to oracle contracts (same as pool factories). We have an existing oracle version, which we also report. Follow the pool pattern in adding a getter to the factory for it, but the type cannot follow the Version convention (JSON string), as the oracle version is part of the V3AggregatorInterface, which defines it as a number.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Resolves #1469 
