### PR TITLE
Add remove liquidity recovery to CLR

### DIFF
--- a/pkg/interfaces/contracts/vault/ICompositeLiquidityRouter.sol
+++ b/pkg/interfaces/contracts/vault/ICompositeLiquidityRouter.sol
@@ -100,7 +100,7 @@ interface ICompositeLiquidityRouter is ICompositeLiquidityRouterQueries {
         address pool,
         uint256 exactBptAmountIn,
         uint256[] memory minAmountsOut
-    ) external payable returns (uint256[] memory amountsOut);
+    ) external returns (uint256[] memory amountsOut);
 
     /***************************************************************************
                                    Nested pools

--- a/pkg/interfaces/contracts/vault/ICompositeLiquidityRouter.sol
+++ b/pkg/interfaces/contracts/vault/ICompositeLiquidityRouter.sol
@@ -96,7 +96,7 @@ interface ICompositeLiquidityRouter is ICompositeLiquidityRouterQueries {
      * @param minAmountsOut Minimum amounts of tokens to be received, sorted in token registration order
      * @return amountsOut Actual amounts of tokens received, sorted in token registration order
      */
-    function removeLiquidityRecoveryFromERC4626Pool(
+    function removeLiquidityRecovery(
         address pool,
         uint256 exactBptAmountIn,
         uint256[] memory minAmountsOut
@@ -157,24 +157,5 @@ interface ICompositeLiquidityRouter is ICompositeLiquidityRouterQueries {
         address[] memory tokensToUnwrap,
         bool wethIsEth,
         bytes memory userData
-    ) external payable returns (uint256[] memory amountsOut);
-
-    /**
-     * @notice Removes liquidity from a nested pool in Recovery Mode.
-     * @dev A nested pool is one in which one or more tokens are BPTs from another pool (child pool). Since there are
-     * multiple pools involved, the token order is not well-defined, and must be specified by the caller. We will not
-     * unwrap any tokens, or use native ETH. All pools (parent and child) must be in Recovery Mode.
-     *
-     * @param parentPool The address of the parent pool (which contains BPTs of other pools)
-     * @param exactBptAmountIn The exact amount of `parentPool` tokens provided
-     * @param tokensOut An array with all tokens from the child pools, and all non-BPT parent tokens, in arbitrary order
-     * @param minAmountsOut An array with the minimum amountOut of each token, sorted in the same order as tokensOut
-     * @return amountsOut An array with the actual amountOut of each token, sorted in the same order as tokensOut
-     */
-    function removeLiquidityRecoveryNestedPool(
-        address parentPool,
-        uint256 exactBptAmountIn,
-        address[] memory tokensOut,
-        uint256[] memory minAmountsOut
     ) external payable returns (uint256[] memory amountsOut);
 }

--- a/pkg/interfaces/contracts/vault/ICompositeLiquidityRouter.sol
+++ b/pkg/interfaces/contracts/vault/ICompositeLiquidityRouter.sol
@@ -88,6 +88,20 @@ interface ICompositeLiquidityRouter is ICompositeLiquidityRouterQueries {
         bytes memory userData
     ) external payable returns (uint256[] memory amountsOut);
 
+    /**
+     * @notice Removes liquidity proportionally, burning an exact pool token amount. Only available in Recovery Mode.
+     * @dev Will not do any unwrapping or native ETH handling.
+     * @param pool Address of the liquidity pool
+     * @param exactBptAmountIn Exact amount of pool tokens provided
+     * @param minAmountsOut Minimum amounts of tokens to be received, sorted in token registration order
+     * @return amountsOut Actual amounts of tokens received, sorted in token registration order
+     */
+    function removeLiquidityRecoveryFromERC4626Pool(
+        address pool,
+        uint256 exactBptAmountIn,
+        uint256[] memory minAmountsOut
+    ) external payable returns (uint256[] memory amountsOut);
+
     /***************************************************************************
                                    Nested pools
     ***************************************************************************/
@@ -143,5 +157,24 @@ interface ICompositeLiquidityRouter is ICompositeLiquidityRouterQueries {
         address[] memory tokensToUnwrap,
         bool wethIsEth,
         bytes memory userData
+    ) external payable returns (uint256[] memory amountsOut);
+
+    /**
+     * @notice Removes liquidity from a nested pool in Recovery Mode.
+     * @dev A nested pool is one in which one or more tokens are BPTs from another pool (child pool). Since there are
+     * multiple pools involved, the token order is not well-defined, and must be specified by the caller. We will not
+     * unwrap any tokens, or use native ETH. All pools (parent and child) must be in Recovery Mode.
+     *
+     * @param parentPool The address of the parent pool (which contains BPTs of other pools)
+     * @param exactBptAmountIn The exact amount of `parentPool` tokens provided
+     * @param tokensOut An array with all tokens from the child pools, and all non-BPT parent tokens, in arbitrary order
+     * @param minAmountsOut An array with the minimum amountOut of each token, sorted in the same order as tokensOut
+     * @return amountsOut An array with the actual amountOut of each token, sorted in the same order as tokensOut
+     */
+    function removeLiquidityRecoveryNestedPool(
+        address parentPool,
+        uint256 exactBptAmountIn,
+        address[] memory tokensOut,
+        uint256[] memory minAmountsOut
     ) external payable returns (uint256[] memory amountsOut);
 }

--- a/pkg/interfaces/contracts/vault/ICompositeLiquidityRouterQueries.sol
+++ b/pkg/interfaces/contracts/vault/ICompositeLiquidityRouterQueries.sol
@@ -64,6 +64,20 @@ interface ICompositeLiquidityRouterQueries is ICompositeLiquidityRouterErrors {
         bytes memory userData
     ) external returns (uint256[] memory amountsOut);
 
+    /**
+     * @notice Queries a `removeLiquidityRecovery` operation without actually executing it.
+     * @dev It doesn't matter what the tokens are (e.g., ERC4626 or BPT); all are treated as regular ERC20 tokens.
+     * @param pool Address of the liquidity pool
+     * @param sender The sender passed to the operation
+     * @param exactBptAmountIn Exact amount of pool tokens provided for the query
+     * @return amountsOut Expected amounts of tokens to receive
+     */
+    function queryRemoveLiquidityRecovery(
+        address pool,
+        address sender,
+        uint256 exactBptAmountIn
+    ) external returns (uint256[] memory amountsOut);
+
     /***************************************************************************
                                    Nested pools
     ***************************************************************************/

--- a/pkg/interfaces/contracts/vault/ICompositeLiquidityRouterQueries.sol
+++ b/pkg/interfaces/contracts/vault/ICompositeLiquidityRouterQueries.sol
@@ -68,13 +68,11 @@ interface ICompositeLiquidityRouterQueries is ICompositeLiquidityRouterErrors {
      * @notice Queries a `removeLiquidityRecovery` operation without actually executing it.
      * @dev It doesn't matter what the tokens are (e.g., ERC4626 or BPT); all are treated as regular ERC20 tokens.
      * @param pool Address of the liquidity pool
-     * @param sender The sender passed to the operation
      * @param exactBptAmountIn Exact amount of pool tokens provided for the query
      * @return amountsOut Expected amounts of tokens to receive
      */
     function queryRemoveLiquidityRecovery(
         address pool,
-        address sender,
         uint256 exactBptAmountIn
     ) external returns (uint256[] memory amountsOut);
 

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -131,7 +131,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, CompositeLiquidi
     }
 
     /// @inheritdoc ICompositeLiquidityRouter
-    function removeLiquidityRecoveryFromERC4626Pool(
+    function removeLiquidityRecovery(
         address pool,
         uint256 exactBptAmountIn,
         uint256[] memory minAmountsOut
@@ -140,7 +140,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, CompositeLiquidi
             abi.decode(
                 _vault.unlock(
                     abi.encodeCall(
-                        CompositeLiquidityRouterHooks.removeLiquidityERC4626PoolRecoveryHook,
+                        CompositeLiquidityRouterHooks.removeLiquidityRecoveryHook,
                         (pool, msg.sender, exactBptAmountIn, minAmountsOut)
                     )
                 ),
@@ -213,24 +213,6 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, CompositeLiquidi
                         tokensOut,
                         tokensToUnwrap
                     )
-                )
-            ),
-            (uint256[])
-        );
-    }
-
-    /// @inheritdoc ICompositeLiquidityRouter
-    function removeLiquidityRecoveryNestedPool(
-        address parentPool,
-        uint256 exactBptAmountIn,
-        address[] memory tokensOut,
-        uint256[] memory minAmountsOut
-    ) external payable saveSender(msg.sender) returns (uint256[] memory amountsOut) {
-        amountsOut = abi.decode(
-            _vault.unlock(
-                abi.encodeCall(
-                    CompositeLiquidityRouterHooks.removeLiquidityRecoveryNestedPoolHook,
-                    (parentPool, msg.sender, exactBptAmountIn, tokensOut, minAmountsOut)
                 )
             ),
             (uint256[])

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -135,7 +135,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, CompositeLiquidi
         address pool,
         uint256 exactBptAmountIn,
         uint256[] memory minAmountsOut
-    ) external payable saveSender(msg.sender) returns (uint256[] memory) {
+    ) external payable returns (uint256[] memory) {
         return
             abi.decode(
                 _vault.unlock(

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -135,7 +135,7 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, CompositeLiquidi
         address pool,
         uint256 exactBptAmountIn,
         uint256[] memory minAmountsOut
-    ) external payable returns (uint256[] memory) {
+    ) external returns (uint256[] memory) {
         return
             abi.decode(
                 _vault.unlock(

--- a/pkg/vault/contracts/CompositeLiquidityRouter.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouter.sol
@@ -130,6 +130,24 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, CompositeLiquidi
             );
     }
 
+    /// @inheritdoc ICompositeLiquidityRouter
+    function removeLiquidityRecoveryFromERC4626Pool(
+        address pool,
+        uint256 exactBptAmountIn,
+        uint256[] memory minAmountsOut
+    ) external payable saveSender(msg.sender) returns (uint256[] memory) {
+        return
+            abi.decode(
+                _vault.unlock(
+                    abi.encodeCall(
+                        CompositeLiquidityRouterHooks.removeLiquidityERC4626PoolRecoveryHook,
+                        (pool, msg.sender, exactBptAmountIn, minAmountsOut)
+                    )
+                ),
+                (uint256[])
+            );
+    }
+
     /***************************************************************************
                                    Nested pools
     ***************************************************************************/
@@ -195,6 +213,24 @@ contract CompositeLiquidityRouter is ICompositeLiquidityRouter, CompositeLiquidi
                         tokensOut,
                         tokensToUnwrap
                     )
+                )
+            ),
+            (uint256[])
+        );
+    }
+
+    /// @inheritdoc ICompositeLiquidityRouter
+    function removeLiquidityRecoveryNestedPool(
+        address parentPool,
+        uint256 exactBptAmountIn,
+        address[] memory tokensOut,
+        uint256[] memory minAmountsOut
+    ) external payable saveSender(msg.sender) returns (uint256[] memory amountsOut) {
+        amountsOut = abi.decode(
+            _vault.unlock(
+                abi.encodeCall(
+                    CompositeLiquidityRouterHooks.removeLiquidityRecoveryNestedPoolHook,
+                    (parentPool, msg.sender, exactBptAmountIn, tokensOut, minAmountsOut)
                 )
             ),
             (uint256[])

--- a/pkg/vault/contracts/CompositeLiquidityRouterHooks.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouterHooks.sol
@@ -25,7 +25,7 @@ import {
 import { BatchRouterCommon } from "./BatchRouterCommon.sol";
 
 /// @notice Hooks for managing liquidity in composite pools.
-contract CompositeLiquidityRouterHooks is BatchRouterCommon {
+abstract contract CompositeLiquidityRouterHooks is BatchRouterCommon {
     using TransientEnumerableSet for TransientEnumerableSet.AddressSet;
     using TransientStorageHelpers for *;
 

--- a/pkg/vault/contracts/CompositeLiquidityRouterHooks.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouterHooks.sol
@@ -156,7 +156,7 @@ contract CompositeLiquidityRouterHooks is BatchRouterCommon {
      * @param minAmountsOut Minimum amounts of tokens to be received, sorted in token registration order
      * @return amountsOut Actual token amounts transferred in exchange for the BPT
      */
-    function removeLiquidityERC4626PoolRecoveryHook(
+    function removeLiquidityRecoveryHook(
         address pool,
         address sender,
         uint256 exactBptAmountIn,
@@ -589,90 +589,6 @@ contract CompositeLiquidityRouterHooks is BatchRouterCommon {
 
         if (EVMCallModeHelpers.isStaticCall() == false) {
             _settlePaths(params.sender, params.wethIsEth, _isAggregator);
-        }
-    }
-
-    function removeLiquidityRecoveryNestedPoolHook(
-        address parentPool,
-        address sender,
-        uint256 exactBptAmountIn,
-        address[] memory tokensOut,
-        uint256[] memory minAmountsOut
-    ) external nonReentrant onlyVault returns (uint256[] memory amountsOut) {
-        InputHelpers.ensureInputLengthMatch(tokensOut.length, minAmountsOut.length);
-
-        uint256[] memory parentPoolAmountsOut = _vault.removeLiquidityRecovery(
-            parentPool,
-            sender,
-            exactBptAmountIn,
-            minAmountsOut
-        );
-
-        IERC20[] memory parentPoolTokens = _vault.getPoolTokens(parentPool);
-        for (uint256 i = 0; i < parentPoolTokens.length; i++) {
-            address parentPoolToken = address(parentPoolTokens[i]);
-            uint256 parentPoolAmountOut = parentPoolAmountsOut[i];
-
-            if (_vault.isPoolRegistered(parentPoolToken)) {
-                // Token is a BPT, so remove liquidity from the child pool.
-
-                // We don't expect the sender to have BPT to burn. So, we flashloan tokens here (which should in
-                // practice just use the existing credit).
-                _vault.sendTo(IERC20(parentPoolToken), address(this), parentPoolAmountOut);
-
-                IERC20[] memory childPoolTokens = _vault.getPoolTokens(parentPoolToken);
-
-                // Router is an intermediary in this case. The Vault will burn tokens from the Router, so the Router
-                // is both owner and spender (which doesn't need approval).
-                uint256[] memory childPoolAmountsOut = _vault.removeLiquidityRecovery(
-                    parentPool,
-                    address(this),
-                    parentPoolAmountOut,
-                    new uint256[](childPoolTokens.length)
-                );
-
-                // Return amounts to user.
-                for (uint256 j = 0; j < childPoolTokens.length; j++) {
-                    _updateSwapTokensOut(address(childPoolTokens[j]), childPoolAmountsOut[j]);
-                }
-            } else {
-                // We never unwrap. If the token is not a BPT, return the amount to the user.
-                _updateSwapTokensOut(parentPoolToken, parentPoolAmountOut);
-            }
-        }
-
-        uint256 numTokensOut = tokensOut.length;
-
-        if (_currentSwapTokensOut().length() != numTokensOut) {
-            // If tokensOut length does not match transient tokens out length, the tokensOut array is wrong.
-            revert ICompositeLiquidityRouterErrors.WrongTokensOut(_currentSwapTokensOut().values(), tokensOut);
-        }
-
-        // The hook writes current swap token and token amounts out.
-        amountsOut = new uint256[](numTokensOut);
-
-        bool[] memory checkedTokenIndexes = new bool[](numTokensOut);
-        for (uint256 i = 0; i < numTokensOut; ++i) {
-            address tokenOut = tokensOut[i];
-            uint256 tokenIndex = _currentSwapTokensOut().indexOf(tokenOut);
-
-            if (_currentSwapTokensOut().contains(tokenOut) == false || checkedTokenIndexes[tokenIndex]) {
-                // If tokenOut is not in transient tokens out array or token is repeated, the tokensOut array is wrong.
-                revert ICompositeLiquidityRouterErrors.WrongTokensOut(_currentSwapTokensOut().values(), tokensOut);
-            }
-
-            // Note that the token in the transient array index has already been checked.
-            checkedTokenIndexes[tokenIndex] = true;
-
-            amountsOut[i] = _currentSwapTokenOutAmounts().tGet(tokenOut);
-
-            if (amountsOut[i] < minAmountsOut[i]) {
-                revert IVaultErrors.AmountOutBelowMin(IERC20(tokenOut), amountsOut[i], minAmountsOut[i]);
-            }
-        }
-
-        if (EVMCallModeHelpers.isStaticCall() == false) {
-            _settlePaths(sender, false, _isAggregator);
         }
     }
 

--- a/pkg/vault/contracts/CompositeLiquidityRouterQueries.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouterQueries.sol
@@ -31,6 +31,26 @@ contract CompositeLiquidityRouterQueries is ICompositeLiquidityRouterQueries, Co
         // solhint-disable-previous-line no-empty-blocks
     }
 
+    /// @inheritdoc ICompositeLiquidityRouterQueries
+    function queryRemoveLiquidityRecovery(
+        address pool,
+        address sender,
+        uint256 exactBptAmountIn
+    ) external saveSender(sender) returns (uint256[] memory) {
+        IERC20[] memory poolTokens = _vault.getPoolTokens(pool);
+
+        return
+            abi.decode(
+                _vault.quote(
+                    abi.encodeCall(
+                        CompositeLiquidityRouterHooks.removeLiquidityRecoveryHook,
+                        (pool, sender, exactBptAmountIn, new uint256[](poolTokens.length))
+                    )
+                ),
+                (uint256[])
+            );
+    }
+
     /*******************************************************************************
                                 ERC4626 Pools
     *******************************************************************************/

--- a/pkg/vault/contracts/CompositeLiquidityRouterQueries.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouterQueries.sol
@@ -34,9 +34,8 @@ abstract contract CompositeLiquidityRouterQueries is ICompositeLiquidityRouterQu
     /// @inheritdoc ICompositeLiquidityRouterQueries
     function queryRemoveLiquidityRecovery(
         address pool,
-        address sender,
         uint256 exactBptAmountIn
-    ) external saveSender(sender) returns (uint256[] memory) {
+    ) external returns (uint256[] memory) {
         IERC20[] memory poolTokens = _vault.getPoolTokens(pool);
 
         return
@@ -44,7 +43,7 @@ abstract contract CompositeLiquidityRouterQueries is ICompositeLiquidityRouterQu
                 _vault.quote(
                     abi.encodeCall(
                         CompositeLiquidityRouterHooks.removeLiquidityRecoveryHook,
-                        (pool, sender, exactBptAmountIn, new uint256[](poolTokens.length))
+                        (pool, address(this), exactBptAmountIn, new uint256[](poolTokens.length))
                     )
                 ),
                 (uint256[])

--- a/pkg/vault/contracts/CompositeLiquidityRouterQueries.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouterQueries.sol
@@ -32,10 +32,7 @@ abstract contract CompositeLiquidityRouterQueries is ICompositeLiquidityRouterQu
     }
 
     /// @inheritdoc ICompositeLiquidityRouterQueries
-    function queryRemoveLiquidityRecovery(
-        address pool,
-        uint256 exactBptAmountIn
-    ) external returns (uint256[] memory) {
+    function queryRemoveLiquidityRecovery(address pool, uint256 exactBptAmountIn) external returns (uint256[] memory) {
         IERC20[] memory poolTokens = _vault.getPoolTokens(pool);
 
         return

--- a/pkg/vault/contracts/CompositeLiquidityRouterQueries.sol
+++ b/pkg/vault/contracts/CompositeLiquidityRouterQueries.sol
@@ -20,7 +20,7 @@ import { CompositeLiquidityRouterHooks } from "./CompositeLiquidityRouterHooks.s
  * @dev Implements read-only query functions that allow off-chain components to estimate results of Vault interactions.
  * Designed to provide accurate previews of composite liquidity operations.
  */
-contract CompositeLiquidityRouterQueries is ICompositeLiquidityRouterQueries, CompositeLiquidityRouterHooks {
+abstract contract CompositeLiquidityRouterQueries is ICompositeLiquidityRouterQueries, CompositeLiquidityRouterHooks {
     constructor(
         IVault vault,
         IWETH weth,

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	23.141
-InitCode	25.026
+Bytecode	23.139
+InitCode	25.024

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	26.009* (2057 over)
-InitCode	28.065
+Bytecode	22.737
+InitCode	24.609

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	21.885
-InitCode	23.750
+Bytecode	26.009* (2057 over)
+InitCode	28.065

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	23.024
-InitCode	24.903
+Bytecode	23.141
+InitCode	25.026

--- a/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
+++ b/pkg/vault/test/.contract-sizes/CompositeLiquidityRouter
@@ -1,2 +1,2 @@
-Bytecode	22.737
-InitCode	24.609
+Bytecode	23.024
+InitCode	24.903

--- a/pkg/vault/test/foundry/CompositeLiquidityRouterERC4626Pool.t.sol
+++ b/pkg/vault/test/foundry/CompositeLiquidityRouterERC4626Pool.t.sol
@@ -977,7 +977,6 @@ contract CompositeLiquidityRouterERC4626PoolTest is BaseERC4626BufferTest {
         _prankStaticCall();
         uint256[] memory expectedWrappedAmountsOut = compositeLiquidityRouter.queryRemoveLiquidityRecovery(
             pool,
-            bob,
             exactBptAmountIn
         );
         vm.revertToState(snapshot);

--- a/pkg/vault/test/foundry/CompositeLiquidityRouterNestedPools.t.sol
+++ b/pkg/vault/test/foundry/CompositeLiquidityRouterNestedPools.t.sol
@@ -29,7 +29,7 @@ contract CompositeLiquidityRouterNestedPoolsTest is BaseERC4626BufferTest {
     using FixedPoint for uint256;
     using CastingHelpers for *;
     using ArrayHelpers for *;
-    
+
     address internal parentPool;
     address internal childPoolA;
     address internal childPoolB;


### PR DESCRIPTION
# Description

Add removing liquidity in recovery mode for the composite liquidity router.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
