### PR TITLE
Force version of forge

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:
-        version: 1.2.3
+        version: v1.2.3
     - name: Install lcov
       shell: bash
       run: sudo apt-get install lcov

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,6 +19,8 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true'
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: 1.2.3
     - name: Install lcov
       shell: bash
       run: sudo apt-get install lcov


### PR DESCRIPTION
# Description

vm.txGasPrice was failing in newer versions of forge. For now, we will force the version of forge, used by Github Actions, to 1.2.3.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge
