### PR TITLE
Timelock authorizer V3: port from V2

### DIFF
--- a/pkg/governance-scripts/contracts/TimelockAuthorizerMigrator.sol
+++ b/pkg/governance-scripts/contracts/TimelockAuthorizerMigrator.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-interfaces/contracts/vault/IBasicAuthorizer.sol";
+import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
+
+import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
+
+import "@balancer-labs/v2-vault/contracts/authorizer/TimelockAuthorizer.sol";
+
+contract TimelockAuthorizerMigrator {
+    bytes32
+        public constant GENERAL_PERMISSION_SPECIFIER = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+    // solhint-disable-previous-line max-line-length
+    address public constant EVERYWHERE = address(-1);
+    bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+
+    IVault public immutable vault;
+    address public immutable root;
+    IBasicAuthorizer public immutable oldAuthorizer;
+    TimelockAuthorizer public immutable newAuthorizer;
+    uint256 public immutable changeRootDelay;
+
+    uint256 private _lastScheduledExecutionId;
+
+    struct RoleData {
+        address grantee;
+        bytes32 role;
+        address target;
+    }
+
+    struct DelayData {
+        bytes32 actionId;
+        uint256 newDelay;
+    }
+
+    /**
+     * @dev Reverts if _rolesData contains a role for an account which doesn't hold the same role on the old Authorizer.
+     */
+    constructor(
+        address _root,
+        IBasicAuthorizer _oldAuthorizer,
+        IAuthorizerAdaptorEntrypoint _authorizerAdaptorEntrypoint,
+        uint256 _changeRootDelay,
+        RoleData[] memory _rolesData,
+        RoleData[] memory _grantersData,
+        RoleData[] memory _revokersData,
+        DelayData[] memory _executeDelaysData,
+        DelayData[] memory _grantDelaysData
+    ) {
+        // At creation, the migrator will be the root of the TimelockAuthorizer.
+        // Once the migration is complete, the root permission will be transferred to `_root`.
+        TimelockAuthorizer _newAuthorizer = new TimelockAuthorizer(
+            address(this),
+            _root,
+            _authorizerAdaptorEntrypoint,
+            _changeRootDelay
+        );
+        newAuthorizer = _newAuthorizer;
+        oldAuthorizer = _oldAuthorizer;
+        vault = _authorizerAdaptorEntrypoint.getVault();
+        root = _root;
+        changeRootDelay = _changeRootDelay;
+
+        for (uint256 i = 0; i < _rolesData.length; i++) {
+            RoleData memory roleData = _rolesData[i];
+            // We require that any permissions being copied from the old Authorizer must exist on the old Authorizer.
+            // This simplifies verification of the permissions being added to the new TimelockAuthorizer.
+            require(_oldAuthorizer.canPerform(roleData.role, roleData.grantee, roleData.target), "UNEXPECTED_ROLE");
+            _newAuthorizer.grantPermission(roleData.role, roleData.grantee, roleData.target);
+        }
+        for (uint256 i = 0; i < _grantersData.length; i++) {
+            // There's no concept of a "granter" on the old Authorizer so we cannot verify these onchain.
+            // We must manually verify that these permissions are set sensibly.
+            _newAuthorizer.addGranter(_grantersData[i].role, _grantersData[i].grantee, _grantersData[i].target);
+        }
+        for (uint256 i = 0; i < _revokersData.length; i++) {
+            // Similarly to granters, we must manually verify that these permissions are set sensibly.
+            _newAuthorizer.addRevoker(_revokersData[i].grantee, _revokersData[i].target);
+        }
+
+        // We're going to schedule multiple actions, and we want to make sure we later execute them all. However, since
+        // they're incrementing values all we need to do is store the last one, and then execute all ids up to that one
+        // (including it).
+        uint256 lastScheduledExecutionId = 0;
+
+        // Setting the initial value for a delay requires us to wait 3 days before we can complete setting it.
+        // We schedule them now to ensure that they're ready to execute once `changeRootDelay` has passed.
+        for (uint256 i = 0; i < _executeDelaysData.length; i++) {
+            // We're not wanting to set a delay greater than 1 month initially so fail early if we're doing so.
+            require(_executeDelaysData[i].newDelay <= 30 days, "UNEXPECTED_LARGE_DELAY");
+            lastScheduledExecutionId = _newAuthorizer.scheduleDelayChange(
+                _executeDelaysData[i].actionId,
+                _executeDelaysData[i].newDelay,
+                _arr(address(this))
+            );
+        }
+        for (uint256 i = 0; i < _grantDelaysData.length; i++) {
+            // We're not wanting to set a delay greater than 1 month initially so fail early if we're doing so.
+            require(_grantDelaysData[i].newDelay <= 30 days, "UNEXPECTED_LARGE_DELAY");
+
+            lastScheduledExecutionId = _newAuthorizer.scheduleGrantDelayChange(
+                _grantDelaysData[i].actionId,
+                _grantDelaysData[i].newDelay,
+                _arr(address(this))
+            );
+        }
+
+        _lastScheduledExecutionId = lastScheduledExecutionId;
+    }
+
+    /**
+     * @notice Executes the scheduled setup of delays on the new authorizer
+     */
+    function executeDelays() external {
+        for (uint256 i = 0; i <= _lastScheduledExecutionId; i++) {
+            newAuthorizer.execute(i);
+        }
+    }
+
+    /**
+     * @notice Complete the authorizer migration by updating the Vault to point to the new authorizer.
+     * @dev `root` must call `claimRoot` on `newAuthorizer` before we update the Vault to point at it.
+     */
+    function finalizeMigration() external {
+        // Safety check to avoid us migrating to a authorizer with an invalid root.
+        // `root` must call `claimRoot` on `newAuthorizer` before we update the Vault to point at it.
+        require(newAuthorizer.isRoot(root), "ROOT_NOT_CLAIMED_YET");
+
+        // Ensure the migrator contract has authority to change the vault's authorizer
+        bytes32 setAuthorizerId = IAuthentication(address(vault)).getActionId(IVault.setAuthorizer.selector);
+        bool canSetAuthorizer = oldAuthorizer.canPerform(setAuthorizerId, address(this), address(vault));
+        require(canSetAuthorizer, "MIGRATOR_CANNOT_SET_AUTHORIZER");
+
+        // Finally change the authorizer in the vault.
+        vault.setAuthorizer(newAuthorizer);
+    }
+
+    // Helper functions
+
+    function _arr(bytes32 a) internal pure returns (bytes32[] memory arr) {
+        arr = new bytes32[](1);
+        arr[0] = a;
+    }
+
+    function _arr(address a) internal pure returns (address[] memory arr) {
+        arr = new address[](1);
+        arr[0] = a;
+    }
+}

--- a/pkg/governance-scripts/test/TimelockAuthorizerMigrator.test.ts
+++ b/pkg/governance-scripts/test/TimelockAuthorizerMigrator.test.ts
@@ -1,0 +1,219 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import { advanceTime, DAY, WEEK } from '@balancer-labs/v2-helpers/src/time';
+import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { BigNumberish } from '@balancer-labs/v2-helpers/src/numbers';
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+
+describe('TimelockAuthorizerMigrator', () => {
+  let root: SignerWithAddress;
+  let user1: SignerWithAddress, user2: SignerWithAddress, user3: SignerWithAddress;
+  let granter1: SignerWithAddress, granter2: SignerWithAddress, granter3: SignerWithAddress;
+  let vault: Contract, oldAuthorizer: Contract, newAuthorizer: Contract, migrator: Contract;
+  let adaptorEntrypoint: Contract;
+
+  before('set up signers', async () => {
+    [, user1, user2, user3, granter1, granter2, granter3, root] = await ethers.getSigners();
+  });
+
+  interface RoleData {
+    grantee: string;
+    role: string;
+    target: string;
+  }
+
+  interface DelayData {
+    actionId: string;
+    newDelay: BigNumberish;
+  }
+
+  let rolesData: RoleData[];
+  let grantersData: RoleData[];
+  let revokersData: RoleData[];
+  let executeDelaysData: DelayData[];
+  let grantDelaysData: DelayData[];
+
+  const CHANGE_ROOT_DELAY = WEEK * 4;
+
+  const ROLE_1 = '0x0000000000000000000000000000000000000000000000000000000000000001';
+  const ROLE_2 = '0x0000000000000000000000000000000000000000000000000000000000000002';
+  const ROLE_3 = '0x0000000000000000000000000000000000000000000000000000000000000003';
+
+  sharedBeforeEach('set up vault', async () => {
+    oldAuthorizer = await deploy('v2-solidity-utils/MockBasicAuthorizer');
+    vault = await deploy('v2-vault/Vault', { args: [oldAuthorizer.address, ZERO_ADDRESS, 0, 0] });
+
+    const authorizerAdaptor = await deploy('v2-liquidity-mining/AuthorizerAdaptor', { args: [vault.address] });
+    adaptorEntrypoint = await deploy('v2-liquidity-mining/AuthorizerAdaptorEntrypoint', {
+      args: [authorizerAdaptor.address],
+    });
+  });
+
+  sharedBeforeEach('set up permissions', async () => {
+    const target = await deploy('v2-vault/MockAuthenticatedContract', { args: [vault.address] });
+    rolesData = [
+      { grantee: user1.address, role: ROLE_1, target: target.address },
+      { grantee: user2.address, role: ROLE_2, target: target.address },
+      { grantee: user3.address, role: ROLE_3, target: ZERO_ADDRESS },
+    ];
+    grantersData = [
+      { grantee: granter1.address, role: ROLE_1, target: target.address },
+      { grantee: granter2.address, role: ROLE_2, target: ZERO_ADDRESS },
+      { grantee: granter3.address, role: ROLE_3, target: target.address },
+    ];
+    revokersData = [
+      { grantee: user1.address, role: ROLE_1, target: target.address },
+      { grantee: granter1.address, role: ROLE_2, target: target.address },
+      { grantee: user3.address, role: ROLE_3, target: ZERO_ADDRESS },
+    ];
+    executeDelaysData = [
+      // We must set this delay first to satisfy the `DELAY_EXCEEDS_SET_AUTHORIZER` check.
+      { actionId: await actionId(vault, 'setAuthorizer'), newDelay: 30 * DAY },
+      { actionId: ROLE_1, newDelay: 14 * DAY },
+      { actionId: ROLE_2, newDelay: 7 * DAY },
+    ];
+    grantDelaysData = [
+      { actionId: ROLE_2, newDelay: 30 * DAY },
+      { actionId: ROLE_3, newDelay: 30 * DAY },
+    ];
+  });
+
+  sharedBeforeEach('grant roles on old Authorizer', async () => {
+    await oldAuthorizer.grantRolesToMany([ROLE_1, ROLE_2, ROLE_3], [user1.address, user2.address, user3.address]);
+  });
+
+  sharedBeforeEach('deploy migrator', async () => {
+    const args = [
+      root.address,
+      oldAuthorizer.address,
+      adaptorEntrypoint.address,
+      CHANGE_ROOT_DELAY,
+      rolesData,
+      grantersData,
+      revokersData,
+      executeDelaysData,
+      grantDelaysData,
+    ];
+    migrator = await deploy('TimelockAuthorizerMigrator', { args });
+    newAuthorizer = await deployedAt('TimelockAuthorizer', await migrator.newAuthorizer());
+    const setAuthorizerActionId = await actionId(vault, 'setAuthorizer');
+    await oldAuthorizer.grantRolesToMany([setAuthorizerActionId], [migrator.address]);
+  });
+
+  context('constructor', () => {
+    context('when attempting to migrate a role which does not exist on previous Authorizer', () => {
+      let tempAuthorizer: Contract;
+
+      sharedBeforeEach('set up vault', async () => {
+        tempAuthorizer = await deploy('v2-solidity-utils/MockBasicAuthorizer');
+      });
+
+      it('reverts', async () => {
+        const args = [
+          root.address,
+          tempAuthorizer.address,
+          adaptorEntrypoint.address,
+          CHANGE_ROOT_DELAY,
+          rolesData,
+          grantersData,
+          revokersData,
+          executeDelaysData,
+          grantDelaysData,
+        ];
+        await expect(deploy('TimelockAuthorizerMigrator', { args })).to.be.revertedWith('UNEXPECTED_ROLE');
+      });
+    });
+
+    it('migrates all roles properly', async () => {
+      for (const roleData of rolesData) {
+        expect(await newAuthorizer.hasPermission(roleData.role, roleData.grantee, roleData.target)).to.be.true;
+      }
+    });
+
+    it('sets up granters properly', async () => {
+      for (const granterData of grantersData) {
+        expect(await newAuthorizer.isGranter(granterData.role, granterData.grantee, granterData.target)).to.be.true;
+      }
+    });
+
+    it('sets up revokers properly', async () => {
+      for (const revokerData of revokersData) {
+        expect(await newAuthorizer.isRevoker(revokerData.grantee, revokerData.target)).to.be.true;
+      }
+    });
+
+    it('does not set the new authorizer immediately', async () => {
+      expect(await vault.getAuthorizer()).to.be.equal(oldAuthorizer.address);
+    });
+
+    it('sets the migrator as the current root', async () => {
+      expect(await newAuthorizer.isRoot(migrator.address)).to.be.true;
+    });
+
+    it('sets root as the pending root', async () => {
+      expect(await newAuthorizer.getPendingRoot()).to.equal(root.address);
+    });
+  });
+
+  context('executeDelays', () => {
+    context("when MINIMUM_CHANGE_DELAY_EXECUTION_DELAY hasn't passed", () => {
+      it('reverts', async () => {
+        await expect(migrator.executeDelays()).to.be.revertedWith('EXECUTION_NOT_YET_EXECUTABLE');
+      });
+    });
+
+    context('when MINIMUM_CHANGE_DELAY_EXECUTION_DELAY has passed', () => {
+      sharedBeforeEach('advance time', async () => {
+        const MINIMUM_CHANGE_DELAY_EXECUTION_DELAY = await newAuthorizer.MINIMUM_CHANGE_DELAY_EXECUTION_DELAY();
+        await advanceTime(MINIMUM_CHANGE_DELAY_EXECUTION_DELAY);
+      });
+
+      it('sets up delays properly', async () => {
+        await migrator.executeDelays();
+
+        for (const delayData of executeDelaysData) {
+          expect(await newAuthorizer.getActionIdDelay(delayData.actionId)).to.be.eq(delayData.newDelay);
+        }
+      });
+
+      it('sets up granter delays properly', async () => {
+        await migrator.executeDelays();
+
+        for (const delayData of grantDelaysData) {
+          expect(await newAuthorizer.getActionIdGrantDelay(delayData.actionId)).to.be.eq(delayData.newDelay);
+        }
+      });
+    });
+  });
+
+  context('finalizeMigration', () => {
+    sharedBeforeEach('advance time', async () => {
+      const MINIMUM_CHANGE_DELAY_EXECUTION_DELAY = await newAuthorizer.MINIMUM_CHANGE_DELAY_EXECUTION_DELAY();
+      await advanceTime(MINIMUM_CHANGE_DELAY_EXECUTION_DELAY);
+      await migrator.executeDelays();
+    });
+
+    context('when new root has not claimed ownership over TimelockAuthorizer', () => {
+      it('reverts', async () => {
+        await expect(migrator.finalizeMigration()).to.be.revertedWith('ROOT_NOT_CLAIMED_YET');
+      });
+    });
+
+    context('when new root has claimed ownership over TimelockAuthorizer', () => {
+      sharedBeforeEach('claim root', async () => {
+        await newAuthorizer.connect(root).claimRoot();
+      });
+
+      it('sets the new Authorizer on the Vault', async () => {
+        await migrator.finalizeMigration();
+
+        expect(await vault.getAuthorizer()).to.be.equal(newAuthorizer.address);
+      });
+    });
+  });
+});

--- a/pkg/interfaces/contracts/vault/ITimelockAuthorizer.sol
+++ b/pkg/interfaces/contracts/vault/ITimelockAuthorizer.sol
@@ -1,0 +1,676 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+/**
+ * @title Timelock Authorizer
+ * @author Balancer Labs
+ * @dev Authorizer with timelocks (delays).
+ *
+ * Users are allowed to perform actions if they have the permission to do so.
+ *
+ * This Authorizer implementation allows defining delays per action identifier. If a delay is set for an action, users
+ * are not allowed to execute it directly themselves. Instead, they schedule an execution that the Authorizer will
+ * run in the future.
+ *
+ * Glossary:
+ * - Action: Operation that can be performed on a target contract. These are identified by a unique bytes32 `actionId`
+ *   defined by each target contract following `IAuthentication.getActionId`.
+ * - Scheduled execution: The Authorizer can define a delay for an `actionId` to require that a specific
+ *   time window must pass before it can be executed. When a delay is set for an `actionId`, executions
+ *   must be scheduled. These executions are identified by an unsigned integer called `scheduledExecutionId`.
+ * - Permission: Accounts have or don't have permission to perform an action identified by its `actionId` on a specific
+ *   contract `where`. Note that if the action has a delay, then accounts with permission cannot perform the action
+ *   directly, but are instead allowed to schedule future executions for them.
+ *
+ * Note that the TimelockAuthorizer doesn't use reentrancy guard on its external functions.
+ * The only function which makes an external non-view call (and so could initate a reentrancy attack) is `execute`
+ * which executes a scheduled execution, protected by the Checks-Effects-Interactions pattern.
+ * In fact a number of the TimelockAuthorizer's functions may only be called through a scheduled execution so reentrancy
+ * is necessary in order to be able to call these.
+ */
+interface ITimelockAuthorizer {
+    struct ScheduledExecution {
+        address where;
+        bytes data;
+        bool executed;
+        bool canceled;
+        bool protected;
+        uint256 executableAt;
+        address scheduledBy;
+        uint256 scheduledAt;
+        address executedBy;
+        uint256 executedAt;
+        address canceledBy;
+        uint256 canceledAt;
+    }
+
+    /**
+     * @notice Emitted when a root change is scheduled.
+     */
+    event RootChangeScheduled(address indexed newRoot, uint256 indexed scheduledExecutionId);
+
+    /**
+     * @notice Emitted when an executor is added for a scheduled execution `scheduledExecutionId`.
+     */
+    event ExecutorAdded(uint256 indexed scheduledExecutionId, address indexed executor);
+
+    /**
+     * @notice Emitted when an account is added as a granter for `actionId` in `where`.
+     */
+    event GranterAdded(bytes32 indexed actionId, address indexed account, address indexed where);
+
+    /**
+     * @notice Emitted when an account is removed as a granter `actionId` in `where`.
+     */
+    event GranterRemoved(bytes32 indexed actionId, address indexed account, address indexed where);
+
+    /**
+     * @notice Emitted when `account` is added as a revoker in `where`.
+     */
+    event RevokerAdded(address indexed account, address indexed where);
+
+    /**
+     * @notice Emitted when an account is removed as a revoker in `where`.
+     */
+    event RevokerRemoved(address indexed account, address indexed where);
+
+    /**
+     * @notice Emitted when a canceler is added for a scheduled execution `scheduledExecutionId`.
+     */
+    event CancelerAdded(uint256 indexed scheduledExecutionId, address indexed canceler);
+
+    /**
+     * @notice Emitted when a canceler is removed for a scheduled execution `scheduledExecutionId`.
+     */
+    event CancelerRemoved(uint256 indexed scheduledExecutionId, address indexed canceler);
+
+    /**
+     * @notice Emitted when an execution `scheduledExecutionId` is executed.
+     */
+    event ExecutionExecuted(uint256 indexed scheduledExecutionId);
+
+    /**
+     * @notice Emitted when an execution `scheduledExecutionId` is canceled.
+     */
+    event ExecutionCanceled(uint256 indexed scheduledExecutionId);
+
+    /**
+     * @notice Emitted when a new `root` is set.
+     */
+    event RootSet(address indexed root);
+
+    /**
+     * @notice Emitted when a new `pendingRoot` is set. The new account must claim ownership for it to take effect.
+     */
+    event PendingRootSet(address indexed pendingRoot);
+
+    /**
+     * @notice Emitted when a revoke permission is scheduled.
+     */
+    event RevokePermissionScheduled(
+        bytes32 indexed actionId,
+        address indexed account,
+        address indexed where,
+        uint256 scheduledExecutionId
+    );
+
+    /**
+     * @notice Emitted when a grant permission is scheduled.
+     */
+    event GrantPermissionScheduled(
+        bytes32 indexed actionId,
+        address indexed account,
+        address indexed where,
+        uint256 scheduledExecutionId
+    );
+
+    /**
+     * @notice Emitted when a revoke delay change is scheduled.
+     */
+    event RevokeDelayChangeScheduled(
+        bytes32 indexed actionId,
+        uint256 indexed newDelay,
+        uint256 indexed scheduledExecutionId
+    );
+
+    /**
+     * @notice Emitted when a grant delay change is scheduled.
+     */
+    event GrantDelayChangeScheduled(
+        bytes32 indexed actionId,
+        uint256 indexed newDelay,
+        uint256 indexed scheduledExecutionId
+    );
+
+    /**
+     * @notice Emitted when a delay change is scheduled.
+     */
+    event DelayChangeScheduled(
+        bytes32 indexed actionId,
+        uint256 indexed newDelay,
+        uint256 indexed scheduledExecutionId
+    );
+
+    /**
+     * @notice Emitted when a new `delay` is set in order to perform action `actionId`.
+     */
+    event ActionDelaySet(bytes32 indexed actionId, uint256 delay);
+
+    /**
+     * @notice Emitted when a new execution `scheduledExecutionId` is scheduled.
+     */
+    event ExecutionScheduled(bytes32 indexed actionId, uint256 indexed scheduledExecutionId);
+
+    /**
+     * @notice Emitted when a new `delay` is set in order to grant permission to execute action `actionId`.
+     */
+    event GrantDelaySet(bytes32 indexed actionId, uint256 delay);
+
+    /**
+     * @notice Emitted when a new `delay` is set in order to revoke permission to execute action `actionId`.
+     */
+    event RevokeDelaySet(bytes32 indexed actionId, uint256 delay);
+
+    /**
+     * @notice Emitted when `account` is granted permission to perform action `actionId` in target `where`.
+     */
+    event PermissionGranted(bytes32 indexed actionId, address indexed account, address indexed where);
+
+    /**
+     * @notice Emitted when `account`'s permission to perform action `actionId` in target `where` is revoked.
+     */
+    event PermissionRevoked(bytes32 indexed actionId, address indexed account, address indexed where);
+
+    /**
+     * @notice A constant value for `scheduledExecutionId` that will match any execution Id.
+     * Cancelers assigned to this Id will be able to cancel *any* scheduled execution,
+     * which is very useful for e.g. emergency response dedicated teams that analyze these.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID() external view returns (uint256);
+
+    /**
+     * @notice A sentinel value for `where` that will match any address.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function EVERYWHERE() external view returns (address);
+
+    /**
+     * @notice We institute a maximum delay to ensure that actions cannot be accidentally/maliciously disabled through
+     *         setting an arbitrarily long delay.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function MAX_DELAY() external view returns (uint256);
+
+    /**
+     * @notice We need a minimum delay period to ensure that all delay changes may be properly scrutinised.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function MINIMUM_CHANGE_DELAY_EXECUTION_DELAY() external view returns (uint256);
+
+    /**
+     * @notice Returns true if `account` is the root.
+     */
+    function isRoot(address account) external view returns (bool);
+
+    /**
+     * @notice Returns true if `account` is the pending root.
+     */
+    function isPendingRoot(address account) external view returns (bool);
+
+    /**
+     * @notice Returns the delay required to transfer the root address.
+     */
+    function getRootTransferDelay() external view returns (uint256);
+
+    /**
+     * @notice Returns the vault address.
+     */
+    function getVault() external view returns (address);
+
+    /**
+     * @notice Returns the TimelockExecutionHelper address.
+     */
+    function getTimelockExecutionHelper() external view returns (address);
+
+    /**
+     * @notice Returns the root address.
+     */
+    function getRoot() external view returns (address);
+
+    /**
+     * @notice Returns the currently pending new root address.
+     */
+    function getPendingRoot() external view returns (address);
+
+    /**
+     * @notice Returns true if `account` is allowed to grant permissions for action `actionId` in target `where`.
+     */
+    function isGranter(
+        bytes32 actionId,
+        address account,
+        address where
+    ) external view returns (bool);
+
+    /**
+     * @notice Returns true if `account` is allowed to revoke permissions in target `where` for all actions.
+     */
+    function isRevoker(address account, address where) external view returns (bool);
+
+    /**
+     * @notice Returns the scheduled execution `scheduledExecutionId`.
+     */
+    function getScheduledExecution(uint256 scheduledExecutionId) external view returns (ScheduledExecution memory);
+
+    /**
+     * @notice Returns the lifetime count of scheduled executions. The most recent scheduled execution will always have
+     * a `scheduledExecutionId` of `getScheduledExecutionsCount() - 1`
+     */
+    function getScheduledExecutionsCount() external view returns (uint256);
+
+    /**
+     * @notice Returns multiple scheduled executions, in either chronological or reverse chronological order (if
+     * `reverseOrder` is true).
+     *
+     * This function will return at most `maxSize` items, starting at index `skip` (meaning the first entries are
+     * skipped). Note that when querying in reverse order, it is the newest entries that are skipped, not the oldest.
+     *
+     * The value of `skip` must be lower than the return value of `getScheduledExecutionsCount()`, which means that not
+     * all scheduled executions can be skipped, and at least one execution will always be returned (assuming there are
+     * any).
+     *
+     * Example calls:
+     *  - { skip: 0, reverseOrder: false } : returns up to `maxSize` of oldest entries, with the oldest at index 0
+     *  - { skip: 0, reverseOrder: true } : returns up to `maxSize` of the newest entries, with the newest at index 0
+     *  - { skip: 5, reverseOrder: false } : returns up to `maxSize` of the oldest entries, skipping the 5 oldest
+     *    entries, with the globally sixth oldest at index 0
+     *  - { skip: 5, reverseOrder: true } : returns up to `maxSize` of the newest entries, skipping the 5 newest
+     *    entries, with the globally sixth nexest at index 0
+     */
+    function getScheduledExecutions(
+        uint256 skip,
+        uint256 maxSize,
+        bool reverseOrder
+    ) external view returns (ITimelockAuthorizer.ScheduledExecution[] memory items);
+
+    /**
+     * @notice Returns true if `account` is an executor for `scheduledExecutionId`.
+     */
+    function isExecutor(uint256 scheduledExecutionId, address account) external view returns (bool);
+
+    /**
+     * @notice Returns true if execution `scheduledExecutionId` can be executed.
+     * Only true if it is not already executed or canceled, and if the execution delay has passed.
+     */
+    function canExecute(uint256 scheduledExecutionId) external view returns (bool);
+
+    /**
+     * @notice Returns true if `account` is an canceler for `scheduledExecutionId`.
+     */
+    function isCanceler(uint256 scheduledExecutionId, address account) external view returns (bool);
+
+    /**
+     * @notice Schedules an execution to change the root address to `newRoot`.
+     */
+    function scheduleRootChange(address newRoot, address[] memory executors) external returns (uint256);
+
+    /**
+     * @notice Returns the execution delay for action `actionId`.
+     */
+    function getActionIdDelay(bytes32 actionId) external view returns (uint256);
+
+    /**
+     * @notice Returns the execution delay for granting permission for action `actionId`.
+     */
+    function getActionIdGrantDelay(bytes32 actionId) external view returns (uint256);
+
+    /**
+     * @notice Returns the execution delay for revoking permission for action `actionId`.
+     */
+    function getActionIdRevokeDelay(bytes32 actionId) external view returns (uint256);
+
+    /**
+     * @notice Returns true if `account` has the permission defined by action `actionId` and target `where`.
+     * @dev This function is specific for the strict permission defined by the tuple `(actionId, where)`: `account` may
+     * instead hold the global permission for the action `actionId`, also granting them permission on `where`, but this
+     * function would return false regardless.
+     *
+     * For this reason, it's recommended to use `hasPermission` if checking whether `account` is allowed to perform
+     * a given action.
+     */
+    function isPermissionGrantedOnTarget(
+        bytes32 actionId,
+        address account,
+        address where
+    ) external view returns (bool);
+
+    /**
+     * @notice Returns true if `account` has permission over the action `actionId` in target `where`.
+     */
+    function hasPermission(
+        bytes32 actionId,
+        address account,
+        address where
+    ) external view returns (bool);
+
+    /**
+     * @notice Sets the pending root address to `pendingRoot`.
+     * @dev This function can never be called directly - it is only ever called as part of a scheduled execution by
+     * the TimelockExecutionHelper after after calling `scheduleRootChange`.
+     *
+     * Once set as the pending root, `pendingRoot` may then call `claimRoot` to become the new root.
+     */
+    function setPendingRoot(address pendingRoot) external;
+
+    /**
+     * @notice Transfers root powers from the current to the pending root address.
+     * @dev This function prevents accidentally transferring root to an invalid address.
+     * To become root, the pending root must call this function to ensure that it's able to interact with this contract.
+     */
+    function claimRoot() external;
+
+    /**
+     * @notice Executes a scheduled execution `scheduledExecutionId`. This is used to execute all scheduled executions,
+     * not only those that originate from `schedule`, but also internal TimelockAuthorizer functions such as
+     * `scheduleRootChange` or `scheduleDelayChange`.
+     *
+     * If any executors were set up when scheduling, `execute` can only be called by them. If none were set, the
+     * scheduled execution is said to be 'unprotected', and can be executed by anyone.
+     *
+     * Once executed, a scheduled execution cannot be executed again. It also cannot be executed if canceled.
+     *
+     * We mark this function as `nonReentrant` out of an abundance of caution, as in theory this and the Authorizer
+     * should be resilient to reentrant executions. The non-reentrancy check means that it is not possible to execute a
+     * scheduled execution during the execution of another scheduled execution - an unlikely and convoluted scenario
+     * that we explicitly forbid.
+     *
+     * Note that while `execute` is nonReentrant, other functions are not - indeed, we rely on reentrancy to e.g. call
+     * `setPendingRoot` or `setDelay`.
+     */
+    function execute(uint256 scheduledExecutionId) external returns (bytes memory result);
+
+    /**
+     * @notice Cancels a scheduled execution `scheduledExecutionId`, which prevents execution via `execute`. Canceling
+     * is irreversible. Scheduled executions that have already been executed cannot be canceled. This is the only way to
+     * prevent a scheduled execution from being executed (assuming there are willing executors).
+     *
+     * The caller must be a canceler, a permission which is managed by the `addCanceler` and `removeCanceler` functions.
+     * Note that root is always a canceler for all scheduled executions.
+     */
+    function cancel(uint256 scheduledExecutionId) external;
+
+    /**
+     * @notice Grants canceler status to `account` for scheduled execution `scheduledExecutionId`.
+     * @dev Only the root can add a canceler.
+     *
+     * Note that there are no delays associated with adding or removing cancelers. This is based on the assumption that
+     * any action which a malicious user could exploit to damage the protocol can be mitigated by root.
+     * Root can remove any canceler and reschedule any task
+     */
+    function addCanceler(uint256 scheduledExecutionId, address account) external;
+
+    /**
+     * @notice Remove canceler status from `account` for scheduled execution `scheduledExecutionId`.
+     * @dev Only the root can remove a canceler.
+     */
+    function removeCanceler(uint256 scheduledExecutionId, address account) external;
+
+    /**
+     * @notice Grants granter status to `account` for action `actionId` in target `where`.
+     * @dev Only the root can add granters.
+     *
+     * Note that there are no delays associated with adding or removing granters. This is based on the assumption that
+     * any action which a malicious user could exploit to damage the protocol will have a sufficiently long delay
+     * associated with either granting permission for or exercising that permission such that the root will be able to
+     * reestablish control and cancel either the granting or associated action before it can be executed, and then
+     * remove the granter.
+     *
+     * A malicious granter may also attempt to use their granter status to grant permission to multiple accounts, but
+     * they cannot add new granters. Therefore, the danger posed by a malicious granter is limited and self-
+     * contained. Root can mitigate the situation simply and completely by revoking first their granter status,
+     * and then any permissions granted by that account, knowing there cannot be any more.
+     */
+    function addGranter(
+        bytes32 actionId,
+        address account,
+        address where
+    ) external;
+
+    /**
+     * @notice Revokes granter status from `account` for action `actionId` in target `where`.
+     * @dev Only the root can remove granters.
+     *
+     * Note that there are no delays associated with removing granters. The only instance in which one might be useful
+     * is if we had contracts that were granters, and this was depended upon for operation of the system. This however
+     * doesn't seem like it will ever be required - granters are typically subDAOs.
+     *
+     * After removing a malicious granter, care should be taken to review their actions and remove any permissions
+     * granted by them, or cancel scheduled grants. This should be done *after* removing the granter, at which point
+     * they won't be able to create any more of these.
+     */
+    function removeGranter(
+        bytes32 actionId,
+        address account,
+        address where
+    ) external;
+
+    /**
+     * @notice Grants revoker status to `account` in target `where` for all actions.
+     * @dev Only the root can add revokers.
+     *
+     * Note that there are no delays associated with adding revokers. This is based on the assumption that any
+     * permissions for which revocation from key addresses would be dangerous (e.g. preventing the BalancerMinter from
+     * minting BAL) have sufficiently long delays associated with revoking them that the root will be able to
+     * reestablish control and cancel the revocation before the scheduled revocation can be executed.
+     *
+     * A malicious revoker cannot add new revokers, so root can simply revoke their status once.
+     */
+    function addRevoker(address account, address where) external;
+
+    /**
+     * @notice Removes revoker status from `account` in target `where` for all actions.
+     * @dev Only the root can remove revokers.
+     *
+     * Note that there are no delays associated with removing revokers.  The only instance in which one might be useful
+     * is if we had contracts that were revoker, and this was depended upon for operation of the system. This however
+     * doesn't seem like it will ever be required - revokers are typically subDAOs.
+     */
+    function removeRevoker(address account, address where) external;
+
+    /**
+     * @notice Sets a new delay `delay` for action `actionId`.
+     * @dev This function can never be called directly - it is only ever called as part of a scheduled execution by
+     * the TimelockExecutionHelper after after calling `scheduleDelayChange`.
+     */
+    function setDelay(bytes32 actionId, uint256 delay) external;
+
+    /**
+     * @notice Sets a new grant action delay `delay` for action `actionId`
+     * @dev This function can never be called directly - it is only ever called as part of a scheduled execution by
+     * the TimelockExecutor after after calling `scheduleGrantDelayChange`.
+     * Delay has to be shorter than the Authorizer delay.
+     */
+    function setGrantDelay(bytes32 actionId, uint256 delay) external;
+
+    /**
+     * @notice Sets a new revoke action delay `delay` for action `actionId`
+     * @dev This function can never be called directly - it is only ever called as part of a scheduled execution by
+     * the TimelockExecutor after after calling `scheduleRevokeDelayChange`.
+     * Delay has to be shorter than the Authorizer delay.
+     */
+    function setRevokeDelay(bytes32 actionId, uint256 delay) external;
+
+    /**
+     * @notice Schedules an execution to set the delay for `actionId`' to `newDelay`. This makes it impossible to
+     * execute `actionId` without an immutable public on-chain commitment for the execution at least `newDelay` seconds
+     * in advance.
+     *
+     * Critical actions that are expected to be performed by EOAs or multisigs are typically subject to such delays to
+     * allow for public scrutiny.
+     *
+     * How long it will take to make this change will depend on the current and new delays: if increasing by more than
+     * 5 days, then the time difference between the delays must pass. Otherwise, the minimum delay change execution
+     * delay of 5 days must pass instead.
+     *
+     * Only `executors` will be able to execute the scheduled execution, unless `executors` is an empty array, in which
+     * case any account can execute it.
+     *
+     * Avoid scheduling multiple delay changes for the same action at the same time, as this makes it harder to reason
+     * about the state of the system. If there is already a scheduled delay change and there is a desire to change the
+     * future delay to some other value, cancel the first scheduled change and schedule a new one.
+     *
+     * Only root can call this function, but other accounts may be granted permission to cancel the scheduled execution
+     * (including global cancelers).
+     */
+    function scheduleDelayChange(
+        bytes32 actionId,
+        uint256 newDelay,
+        address[] memory executors
+    ) external returns (uint256);
+
+    /**
+     * @notice Schedules an execution to set the delay for granting permission over `actionId` to `newDelay`. This makes
+     * it impossible to grant permission to execute `actionId` without an immutable public on-chain commitment for the
+     * granting at least `newDelay` seconds in advance.
+     *
+     * Critical actions that are expected to be performed by smart contracts are typically subject to such grant delays
+     * to allow for public scrutiny of new contracts that are granted the permission.
+     *
+     * How long it will take to make this change will depend on the current and new grant delays: if increasing by more
+     * than 5 days, then the time difference between the grant delays must pass. Otherwise, the minimum delay change
+     * execution delay of 5 days must pass instead.
+     *
+     * Only `executors` will be able to execute the scheduled execution, unless `executors` is an empty array, in which
+     * case any account can execute it.
+     *
+     * Avoid scheduling multiple grant delay changes for the same action at the same time, as this makes it harder to
+     * reason about the state of the system. If there is already a scheduled grant delay change and there is a desire to
+     * change the future grant delay to some other value, cancel the first scheduled change and schedule a new one.
+     *
+     * Only root can call this function, but other accounts may be granted permission to cancel the scheduled execution
+     * (including global cancelers).
+     */
+    function scheduleGrantDelayChange(
+        bytes32 actionId,
+        uint256 newDelay,
+        address[] memory executors
+    ) external returns (uint256);
+
+    /**
+     * @notice Schedules an execution to set the delay for revoking permission over `actionId` to `newDelay`. This makes
+     * it impossible to revoke permission to execute `actionId` without an immutable public on-chain commitment for the
+     * revoking at least `newDelay` seconds in advance.
+     *
+     * Critical actions that are performed by smart contracts and to which there is a long term commitment (e.g. minting
+     * of BAL as part of the Liquidity Mining Program) are typically subject to such revoke delays, making it impossible
+     * to disable the system without sufficient notice.
+     *
+     * How long it will take to make this change will depend on the current and new revoke delays: if increasing by more
+     * than 5 days, then the time difference between the revoke delays must pass. Otherwise, the minimum delay change
+     * execution delay of 5 days must pass instead.
+     *
+     * Only `executors` will be able to execute the scheduled execution, unless `executors` is an empty array, in which
+     * case any account can execute it.
+     *
+     * Avoid scheduling multiple revoke delay changes for the same action at the same time, as this makes it harder to
+     * reason about the state of the system. If there is already a scheduled revoke delay change and there is a desire
+     * to change the future grant delay to some other value, cancel the first scheduled change and schedule a new one.
+     *
+     * Only root can call this function, but other accounts may be granted permission to cancel the scheduled execution
+     * (including global cancelers).
+     */
+    function scheduleRevokeDelayChange(
+        bytes32 actionId,
+        uint256 newDelay,
+        address[] memory executors
+    ) external returns (uint256);
+
+    /**
+     * @notice Schedules an arbitrary execution of `data` in target `where`. Returns a scheduledExecutionId that can be
+     * used to call `execute`, `cancel`, and associated getters such as `getScheduledExecution`.
+     *
+     * If `executors` is an empty array, then any account in the network will be able to initiate the scheduled
+     * execution. If not, only accounts in the `executors` array will be able to call `execute`. It is not possible to
+     * change this after scheduling: the list of executors is immutable, and cannot be changed by any account (including
+     * root).
+     *
+     * The caller of the `schedule` function is automatically made a canceler for the scheduled execution, meaning they
+     * can call the `cancel` function for it. Other accounts, such as root, may also have or be granted permission to
+     * cancel any scheduled execution.
+     *
+     * This is the only way to execute actions in external contracts that have a delay associated with them. Calling
+     * said functions directly will cause `canPerform` to return false, even if the caller has permission. An account
+     * that has permission over an action with a delay cannot call it directly, and must instead schedule a delayed
+     * execution by calling this function.
+     */
+    function schedule(
+        address where,
+        bytes memory data,
+        address[] memory executors
+    ) external returns (uint256);
+
+    /**
+     * @notice Grants a permission to a single `account` at 'where' address.
+     * @dev This function can only be used for actions that have no grant delay. For those that do, use
+     * `scheduleGrantPermission` instead.
+     */
+    function grantPermission(
+        bytes32 actionId,
+        address account,
+        address where
+    ) external;
+
+    /**
+     * @notice Schedules a grant permission to `account` for action `actionId` in target `where`.
+     * See `schedule` comments.
+     */
+    function scheduleGrantPermission(
+        bytes32 actionId,
+        address account,
+        address where,
+        address[] memory executors
+    ) external returns (uint256);
+
+    /**
+     * @notice Revokes a permission from a single `account` at `where` address.
+     * @dev This function can only be used for actions that have no revoke delay. For those that do, use
+     * `scheduleRevokePermission` instead.
+     */
+    function revokePermission(
+        bytes32 actionId,
+        address account,
+        address where
+    ) external;
+
+    /**
+     * @notice Schedules a revoke permission from `account` for action `actionId` in target `where`.
+     * See `schedule` comments.
+     */
+    function scheduleRevokePermission(
+        bytes32 actionId,
+        address account,
+        address where,
+        address[] memory executors
+    ) external returns (uint256);
+
+    /**
+     * @notice Revokes a permission from the caller for `actionId` at `where` address
+     * @dev Note that the caller can always renounce permissions, even if revoking them would typically be
+     * subject to a delay.
+     */
+    function renouncePermission(bytes32 actionId, address where) external;
+}

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -1,0 +1,477 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IAuthorizerAdaptorEntrypoint.sol";
+import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
+import "@balancer-labs/v2-interfaces/contracts/vault/IAuthorizer.sol";
+
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/InputHelpers.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
+import "./TimelockExecutionHelper.sol";
+import "./TimelockAuthorizerManagement.sol";
+
+/**
+ * See ITimelockAuthorizer.
+ */
+contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
+    // solhint-disable-next-line const-name-snakecase
+    uint256 private constant _MAX_DELAY = 2 * (365 days);
+
+    // solhint-disable-next-line const-name-snakecase
+    uint256 private constant _MINIMUM_CHANGE_DELAY_EXECUTION_DELAY = 5 days;
+
+    IAuthorizerAdaptorEntrypoint private immutable _authorizerAdaptorEntrypoint;
+    IAuthorizerAdaptor private immutable _authorizerAdaptor;
+
+    // action id => delay
+    mapping(bytes32 => uint256) private _grantDelays;
+    // action id => delay
+    mapping(bytes32 => uint256) private _revokeDelays;
+
+    // External permissions
+    // actionId -> account -> where -> isGranted
+    mapping(bytes32 => mapping(address => mapping(address => bool))) private _isPermissionGranted;
+    // actionId -> delay (in seconds)
+    mapping(bytes32 => uint256) private _delaysPerActionId;
+
+    constructor(
+        address initialRoot,
+        address nextRoot,
+        IAuthorizerAdaptorEntrypoint authorizerAdaptorEntrypoint,
+        uint256 rootTransferDelay
+    ) TimelockAuthorizerManagement(initialRoot, nextRoot, authorizerAdaptorEntrypoint.getVault(), rootTransferDelay) {
+        _authorizerAdaptor = authorizerAdaptorEntrypoint.getAuthorizerAdaptor();
+        _authorizerAdaptorEntrypoint = authorizerAdaptorEntrypoint;
+    }
+
+    // solhint-disable-next-line func-name-mixedcase
+    function MAX_DELAY() public pure override returns (uint256) {
+        return _MAX_DELAY;
+    }
+
+    // solhint-disable-next-line func-name-mixedcase
+    function MINIMUM_CHANGE_DELAY_EXECUTION_DELAY() public pure override returns (uint256) {
+        return _MINIMUM_CHANGE_DELAY_EXECUTION_DELAY;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function getActionIdDelay(bytes32 actionId) external view override returns (uint256) {
+        return _delaysPerActionId[actionId];
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function getActionIdGrantDelay(bytes32 actionId) external view override returns (uint256) {
+        return _grantDelays[actionId];
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function getActionIdRevokeDelay(bytes32 actionId) external view override returns (uint256) {
+        return _revokeDelays[actionId];
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function isPermissionGrantedOnTarget(
+        bytes32 actionId,
+        address account,
+        address where
+    ) external view override returns (bool) {
+        return _isPermissionGranted[actionId][account][where];
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function hasPermission(
+        bytes32 actionId,
+        address account,
+        address where
+    ) public view override returns (bool) {
+        return _isPermissionGranted[actionId][account][where] || _isPermissionGranted[actionId][account][EVERYWHERE()];
+    }
+
+    /**
+     * @inheritdoc IAuthorizer
+     */
+    function canPerform(
+        bytes32 actionId,
+        address account,
+        address where
+    ) public view override returns (bool) {
+        if (msg.sender == address(_authorizerAdaptor)) {
+            // The situation where the caller is the `AuthorizerAdaptor` is a special case, as due to a bug it can be
+            // tricked into passing an incorrect `actionId` value, potentially resulting in escalation of privileges.
+            //
+            // To remedy this we force all calls to the `AuthorizerAdaptor` to be made through a singleton entrypoint
+            // contract, called the `AuthorizerAdaptorEntrypoint`. This contract correctly checks whether `account` can
+            // perform `actionId` on `where`, and then forwards the call onto the `AuthorizerAdaptor` to execute.
+            //
+            // The authorizer then rejects calls to the `AuthorizerAdaptor` which aren't made through the entrypoint,
+            // and approves all calls made through it (since the entrypoint will have already performed any necessary
+            // permission checks).
+            return account == address(_authorizerAdaptorEntrypoint);
+        }
+
+        // Actions with no delay can only be performed by accounts that have the associated permission.
+        // However, actions with a non-zero delay cannot be performed by permissioned accounts: they can only be made by
+        // the TimelockAuthorizerExecutionHelper, which works alongisde the TimelockAuthorizer itself to ensure that
+        // executions have been properly scheduled in advance by an authorized party via the `schedule` function.
+        return
+            _delaysPerActionId[actionId] == 0
+                ? hasPermission(actionId, account, where)
+                : account == getTimelockExecutionHelper();
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function setDelay(bytes32 actionId, uint256 delay) external override onlyScheduled {
+        // If changing the `setAuthorizer` delay itself, then we don't need to compare it to its current value for
+        // validity.
+        if (actionId != IAuthentication(getVault()).getActionId(IVault.setAuthorizer.selector)) {
+            require(_isDelayShorterThanSetAuthorizer(delay), "DELAY_EXCEEDS_SET_AUTHORIZER");
+        }
+
+        _delaysPerActionId[actionId] = delay;
+        emit ActionDelaySet(actionId, delay);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function setGrantDelay(bytes32 actionId, uint256 delay) external override onlyScheduled {
+        require(_isDelayShorterThanSetAuthorizer(delay), "DELAY_EXCEEDS_SET_AUTHORIZER");
+
+        _grantDelays[actionId] = delay;
+        emit GrantDelaySet(actionId, delay);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function setRevokeDelay(bytes32 actionId, uint256 delay) external override onlyScheduled {
+        require(_isDelayShorterThanSetAuthorizer(delay), "DELAY_EXCEEDS_SET_AUTHORIZER");
+
+        _revokeDelays[actionId] = delay;
+        emit RevokeDelaySet(actionId, delay);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function scheduleDelayChange(
+        bytes32 actionId,
+        uint256 newDelay,
+        address[] memory executors
+    ) external override returns (uint256) {
+        require(isRoot(msg.sender), "SENDER_IS_NOT_ROOT");
+        require(newDelay <= MAX_DELAY(), "DELAY_TOO_LARGE");
+
+        uint256 executionDelay = _getDelayChangeExecutionDelay(_delaysPerActionId[actionId], newDelay);
+
+        bytes memory data = abi.encodeWithSelector(this.setDelay.selector, actionId, newDelay);
+        // TODO: add custom event
+
+        // Since this can only be called by root, which is always a canceler for all scheduled executions, we don't
+        // bother creating any new cancelers.
+        uint256 scheduledExecutionId = _scheduleWithDelay(address(this), data, executionDelay, executors);
+        emit DelayChangeScheduled(actionId, newDelay, scheduledExecutionId);
+        return scheduledExecutionId;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function scheduleGrantDelayChange(
+        bytes32 actionId,
+        uint256 newDelay,
+        address[] memory executors
+    ) external override returns (uint256) {
+        require(isRoot(msg.sender), "SENDER_IS_NOT_ROOT");
+        require(newDelay <= MAX_DELAY(), "DELAY_TOO_LARGE");
+
+        uint256 executionDelay = _getDelayChangeExecutionDelay(_grantDelays[actionId], newDelay);
+
+        bytes memory data = abi.encodeWithSelector(this.setGrantDelay.selector, actionId, newDelay);
+
+        // Since this can only be called by root, which is always a canceler for all scheduled executions, we don't
+        // bother creating any new cancelers.
+        uint256 scheduledExecutionId = _scheduleWithDelay(address(this), data, executionDelay, executors);
+        emit GrantDelayChangeScheduled(actionId, newDelay, scheduledExecutionId);
+        return scheduledExecutionId;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function scheduleRevokeDelayChange(
+        bytes32 actionId,
+        uint256 newDelay,
+        address[] memory executors
+    ) external override returns (uint256) {
+        require(isRoot(msg.sender), "SENDER_IS_NOT_ROOT");
+        require(newDelay <= MAX_DELAY(), "DELAY_TOO_LARGE");
+
+        uint256 executionDelay = _getDelayChangeExecutionDelay(_revokeDelays[actionId], newDelay);
+
+        bytes memory data = abi.encodeWithSelector(this.setRevokeDelay.selector, actionId, newDelay);
+
+        // Since this can only be called by root, which is always a canceler for all scheduled executions, we don't
+        // bother creating any new cancelers.
+        uint256 scheduledExecutionId = _scheduleWithDelay(address(this), data, executionDelay, executors);
+        emit RevokeDelayChangeScheduled(actionId, newDelay, scheduledExecutionId);
+        return scheduledExecutionId;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function schedule(
+        address where,
+        bytes memory data,
+        address[] memory executors
+    ) external override returns (uint256) {
+        // Allowing scheduling arbitrary calls into the TimelockAuthorizer is dangerous.
+        //
+        // It is expected that only the `root` account can initiate a root transfer as this condition is enforced
+        // by the `scheduleRootChange` function which is the expected method of scheduling a call to `setPendingRoot`.
+        // If a call to `setPendingRoot` could be scheduled using this function as well as `scheduleRootChange` then
+        // accounts other than `root` could initiate a root transfer (provided they had the necessary permission).
+        // Similarly, `setDelay` can only be called if scheduled via `scheduleDelayChange`.
+        //
+        // For this reason we disallow this function from scheduling calls to functions on the Authorizer to ensure that
+        // these actions can only be scheduled through specialised functions.
+        require(where != address(this), "CANNOT_SCHEDULE_AUTHORIZER_ACTIONS");
+
+        // We also disallow the TimelockExecutionHelper from attempting to call into itself. Otherwise the above
+        // protection could be bypassed by wrapping a call to `setPendingRoot` inside of a call, causing the
+        // TimelockExecutionHelper to reenter itself, essentially hiding the fact that `where == address(this)` inside
+        // `data`.
+        //
+        // Note: The TimelockExecutionHelper only accepts calls from the TimelockAuthorizer (i.e. not from itself) so
+        // this scenario should be impossible: but this check is cheap so we enforce it here as well anyway.
+        require(where != getTimelockExecutionHelper(), "ATTEMPTING_EXECUTION_HELPER_REENTRANCY");
+
+        // We require data to have a function selector
+        require(data.length >= 4, "DATA_TOO_SHORT");
+        // The bytes4 type is left-aligned and padded with zeros: we make use of that property to build the selector
+        bytes4 selector = bytes4(data[0]) | (bytes4(data[1]) >> 8) | (bytes4(data[2]) >> 16) | (bytes4(data[3]) >> 24);
+
+        bytes32 actionId = IAuthentication(where).getActionId(selector);
+        require(hasPermission(actionId, msg.sender, where), "SENDER_DOES_NOT_HAVE_PERMISSION");
+
+        uint256 delay = _delaysPerActionId[actionId];
+        require(delay > 0, "DELAY_IS_NOT_SET");
+
+        uint256 scheduledExecutionId = _scheduleWithDelay(where, data, delay, executors);
+
+        emit ExecutionScheduled(actionId, scheduledExecutionId);
+
+        // Accounts that schedule executions are automatically made cancelers for them, so that they can manage their
+        // actions. We check that they are not already a canceler since e.g. root may schedule executions (and root is
+        // always a global canceler).
+        if (!isCanceler(scheduledExecutionId, msg.sender)) {
+            _addCanceler(scheduledExecutionId, msg.sender);
+        }
+        return scheduledExecutionId;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function grantPermission(
+        bytes32 actionId,
+        address account,
+        address where
+    ) external override {
+        if (_grantDelays[actionId] == 0) {
+            require(isGranter(actionId, msg.sender, where), "SENDER_IS_NOT_GRANTER");
+        } else {
+            // Some actions may have delays associated with granting them - these permissions cannot be granted
+            // directly, even if the caller is a granter, and must instead be scheduled for future execution via
+            // `scheduleGrantPermission`.
+            require(msg.sender == getTimelockExecutionHelper(), "GRANT_MUST_BE_SCHEDULED");
+        }
+
+        require(!hasPermission(actionId, account, where), "PERMISSION_ALREADY_GRANTED");
+        // Note that it is possible for `account` to have permission for an `actionId` in some specific `where`, and
+        // then be granted permission over `EVERYWHERE`, resulting in 'duplicate' permissions. This is not an issue per
+        // se, but removing these permissions status will require undoing these actions in inverse order.
+        // To avoid these issues, it is recommended to revoke any prior prermissions over specific contracts before
+        // granting an account a global permissions.
+
+        _isPermissionGranted[actionId][account][where] = true;
+        emit PermissionGranted(actionId, account, where);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function scheduleGrantPermission(
+        bytes32 actionId,
+        address account,
+        address where,
+        address[] memory executors
+    ) external override returns (uint256) {
+        require(isGranter(actionId, msg.sender, where), "SENDER_IS_NOT_GRANTER");
+
+        uint256 delay = _grantDelays[actionId];
+        require(delay > 0, "ACTION_HAS_NO_GRANT_DELAY");
+
+        bytes memory data = abi.encodeWithSelector(this.grantPermission.selector, actionId, account, where);
+
+        uint256 scheduledExecutionId = _scheduleWithDelay(address(this), data, delay, executors);
+        emit GrantPermissionScheduled(actionId, account, where, scheduledExecutionId);
+        // Granters that schedule executions are automatically made cancelers for them, so that they can manage their
+        // action. We check that they are not already a canceler since e.g. root may schedule grants (and root is
+        // always a global canceler).
+        if (!isCanceler(scheduledExecutionId, msg.sender)) {
+            _addCanceler(scheduledExecutionId, msg.sender);
+        }
+        return scheduledExecutionId;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function revokePermission(
+        bytes32 actionId,
+        address account,
+        address where
+    ) external override {
+        if (_revokeDelays[actionId] == 0) {
+            require(isRevoker(msg.sender, where), "SENDER_IS_NOT_REVOKER");
+        } else {
+            // Some actions may have delays associated with revoking them - these permissions cannot be revoked
+            // directly, even if the caller is a revoker, and must instead be scheduled for future execution via
+            // `scheduleRevokePermission`.
+            require(msg.sender == getTimelockExecutionHelper(), "REVOKE_MUST_BE_SCHEDULED");
+        }
+        _revokePermission(actionId, account, where);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function scheduleRevokePermission(
+        bytes32 actionId,
+        address account,
+        address where,
+        address[] memory executors
+    ) external override returns (uint256) {
+        require(isRevoker(msg.sender, where), "SENDER_IS_NOT_REVOKER");
+
+        uint256 delay = _revokeDelays[actionId];
+        require(delay > 0, "ACTION_HAS_NO_REVOKE_DELAY");
+
+        bytes memory data = abi.encodeWithSelector(this.revokePermission.selector, actionId, account, where);
+
+        uint256 scheduledExecutionId = _scheduleWithDelay(address(this), data, delay, executors);
+        emit RevokePermissionScheduled(actionId, account, where, scheduledExecutionId);
+        // Revokers that schedule executions are automatically made cancelers for them, so that they can manage their
+        // action. We check that they are not already a canceler since e.g. root may schedule revokes (and root is
+        // always a global canceler).
+        if (!isCanceler(scheduledExecutionId, msg.sender)) {
+            _addCanceler(scheduledExecutionId, msg.sender);
+        }
+        return scheduledExecutionId;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function renouncePermission(bytes32 actionId, address where) external override {
+        _revokePermission(actionId, msg.sender, where);
+    }
+
+    /**
+     * @dev Revokes a permission from `account` for `actionId` at `where` address.
+     *
+     * This performs no permission checks on `msg.sender` of any kind. The caller of this function should perform
+     * any appropriate checks.
+     */
+    function _revokePermission(
+        bytes32 actionId,
+        address account,
+        address where
+    ) private {
+        require(hasPermission(actionId, account, where), "PERMISSION_NOT_GRANTED");
+
+        if (_isPermissionGranted[actionId][account][EVERYWHERE()]) {
+            // If an account has global permission, then it must explicitly lose this global privilege. This prevents
+            // scenarios where an account has their permission revoked over a specific contract, but they can still
+            // use it (including in that contract!) because they have global permission.
+            // There's an edge case in which an account could have both specific and global permission, and still have
+            // permission over some contracts after losing global privilege. This is considered an unlikely scenario,
+            // and would require manual removal of the specific permissions even after removal of the global one.
+            require(where == EVERYWHERE(), "ACCOUNT_HAS_GLOBAL_PERMISSION");
+        }
+
+        _isPermissionGranted[actionId][account][where] = false;
+        emit PermissionRevoked(actionId, account, where);
+    }
+
+    function _getDelayChangeExecutionDelay(uint256 currentDelay, uint256 newDelay) private pure returns (uint256) {
+        // The delay change is scheduled so that it's never possible to execute an action in a shorter time than the
+        // current delay.
+        //
+        // If we're reducing the action's delay then we must first wait for the difference between the two delays.
+        // This means that if we immediately schedule the action for execution once the delay is reduced, then
+        // these two delays combined will result in the original delay.
+        // For example, if an action's delay is 20 days and we wish to reduce it to 5 days, we need to wait 15 days
+        // before the new shorter delay is effective, to make it impossible to execute the action before the full
+        // original 20-day delay period has elapsed.
+        //
+        // If we're increasing the delay on an action, we could in principle execute this change immediately, since the
+        // larger delay would fulfill the original constraint imposed by the first delay.
+        // For example, if we wish to increase the delay of an action from 5 days to 20 days, there is no need to wait
+        // as it would not be possible to execute the action with a delay shorter than the initial 5 days at any point.
+        //
+        // However, not requiring a delay to increase an action's delay creates an issue: it would be possible to
+        // effectively disable actions by setting huge delays (e.g. 2 years) for them. Because of this, all delay
+        // changes are subject to a minimum execution delay, to allow for proper scrutiny of these potentially
+        // dangerous actions.
+
+        return
+            newDelay < currentDelay
+                ? Math.max(currentDelay - newDelay, MINIMUM_CHANGE_DELAY_EXECUTION_DELAY())
+                : MINIMUM_CHANGE_DELAY_EXECUTION_DELAY();
+    }
+
+    /**
+     * @notice Checks if a `delay` is shorter than `setAuthorizer` action delay.
+     *
+     * @dev No delay can be greater than the current delay for changing the Authorizer itself (`IVault.setAuthorizer`).
+     * Otherwise, it'd be possible to execute the action with a shorter delay by simply replacing
+     * the TimelockAuthorizer with a different contract that didn't enforce these delays.
+     * Note that it is still possible for an action to end up with a delay longer than `setAuthorizer` if
+     * e.g. `setAuthorizer`'s delay was to ever be decreased, but this is not expected to happen. The following
+     * check is therefore simply a way to try to prevent user error, but is not infallible.
+     */
+    function _isDelayShorterThanSetAuthorizer(uint256 delay) private view returns (bool) {
+        bytes32 setAuthorizerActionId = IAuthentication(getVault()).getActionId(IVault.setAuthorizer.selector);
+        return delay <= _delaysPerActionId[setAuthorizerActionId];
+    }
+}

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
@@ -1,0 +1,560 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IAuthorizerAdaptorEntrypoint.sol";
+import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
+import "@balancer-labs/v2-interfaces/contracts/vault/IAuthorizer.sol";
+import "@balancer-labs/v2-interfaces/contracts/vault/ITimelockAuthorizer.sol";
+
+import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
+import "./TimelockExecutionHelper.sol";
+
+// Scheduled executions are time based and are expected to be on the order of days, so any time changes or manipulation
+// on the order of seconds or minutes is irrelevant.
+// solhint-disable not-rely-on-time
+
+/**
+ * @title Timelock Authorizer Management
+ * @author Balancer Labs
+ * @dev TimelockAuthorizerManagement is a parent class for TimelockAuthorizer introduced to bring more
+ * clarity and readability into TimelockAuthorizer smart contract. It handles logic for handling a root change
+ * (`setPendingRoot` and 'claimRoot'), scheduling and executing actions (`_scheduleWithDelay`, `execute`, and
+ * `cancel`), and managing roles (`addRevoker`, `addGranter`, `addCanceler`).
+ *
+ * See `ITimelockAuthorizer`.
+ */
+abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer {
+    using Address for address;
+
+    // solhint-disable-next-line const-name-snakecase
+    address private constant _EVERYWHERE = address(-1);
+
+    // solhint-disable-next-line const-name-snakecase
+    uint256 internal constant _GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID = type(uint256).max;
+
+    TimelockExecutionHelper private immutable _executionHelper;
+    IAuthentication private immutable _vault;
+    uint256 private immutable _rootTransferDelay;
+
+    // Authorizer permissions
+    address private _root;
+    address private _pendingRoot;
+
+    // scheduled execution id => account => is executor
+    mapping(uint256 => mapping(address => bool)) private _isExecutor;
+
+    // action id => account => where => is granter
+    mapping(bytes32 => mapping(address => mapping(address => bool))) private _isGranter;
+    // account => where => is revoker
+    mapping(address => mapping(address => bool)) private _isRevoker;
+    // scheduled execution id => account => is canceler
+    mapping(uint256 => mapping(address => bool)) private _isCanceler;
+
+    ITimelockAuthorizer.ScheduledExecution[] private _scheduledExecutions;
+
+    /**
+     * @dev Prevents a TimelockAuthorizer function from being called directly, making it only possible to call it by
+     * scheduling a delayed execution.
+     *
+     * Each function that has this modifier applied to it should have an associated function that performs proper
+     * permission validation and then schedules a call.
+     */
+    modifier onlyScheduled() {
+        // Checking that we're being called by the TimelockExecutionHelper is a sufficient check, given that:
+        //
+        //  1) The TimelockExecutionHelper can only make external calls (and cause this modifier to not revert) if
+        //     called by the TimelockAuthorizer.
+        //
+        //  2) The TimelockAuthorizer only makes external non-view calls in a single place: when the `execute` function
+        //    is called by an executor. This is the only possible time it could call the TimelockExecutionHelper.
+        //
+        //  3) `execute` can only be called after scheduling a delayed execution.
+        //
+        //  4) Scheduled delayed executions either target the TimelockAuthorizer directly (such as in
+        //    `scheduleRootChange` or `scheduleDelayChange`), in which case this modifier will not revert (as intended,
+        //    given those functions check proper permissions), or explictly forbid targeting the TimelockAuthorizer
+        //    (in the `schedule` function), making it impossible for the TimelockExecutionHelper to call into it.
+        require(msg.sender == address(_executionHelper), "CAN_ONLY_BE_SCHEDULED");
+        _;
+    }
+
+    constructor(
+        address initialRoot,
+        address nextRoot,
+        IAuthentication vault,
+        uint256 rootTransferDelay
+    ) {
+        _setRoot(initialRoot);
+        // By setting `nextRoot` as the pending root, it can immediately call `claimRoot` and replace `initialRoot`,
+        // skipping the root transfer delay for the very first root transfer. This is very useful in schemes where a
+        // migrator contract is the initial root and performs some initial setup, and then needs to transfer this
+        // permission to some other account.
+        _setPendingRoot(nextRoot);
+
+        _vault = vault;
+        _executionHelper = new TimelockExecutionHelper();
+        _rootTransferDelay = rootTransferDelay;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function EVERYWHERE() public pure override returns (address) {
+        return _EVERYWHERE;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID() public pure override returns (uint256) {
+        return _GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function isRoot(address account) public view override returns (bool) {
+        return account == _root;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function isPendingRoot(address account) public view override returns (bool) {
+        return account == _pendingRoot;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function getRootTransferDelay() public view override returns (uint256) {
+        return _rootTransferDelay;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function getVault() public view override returns (address) {
+        return address(_vault);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function getTimelockExecutionHelper() public view override returns (address) {
+        return address(_executionHelper);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function getRoot() external view override returns (address) {
+        return _root;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function getPendingRoot() external view override returns (address) {
+        return _pendingRoot;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function isGranter(
+        bytes32 actionId,
+        address account,
+        address where
+    ) public view override returns (bool) {
+        return _isGranter[actionId][account][where] || _isGranter[actionId][account][EVERYWHERE()] || isRoot(account);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function isRevoker(address account, address where) public view override returns (bool) {
+        return _isRevoker[account][where] || _isRevoker[account][EVERYWHERE()] || isRoot(account);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function getScheduledExecution(uint256 scheduledExecutionId)
+        external
+        view
+        override
+        returns (ITimelockAuthorizer.ScheduledExecution memory)
+    {
+        return _scheduledExecutions[scheduledExecutionId];
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function getScheduledExecutionsCount() external view override returns (uint256) {
+        return _scheduledExecutions.length;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function getScheduledExecutions(
+        uint256 skip,
+        uint256 maxSize,
+        bool reverseOrder
+    ) external view override returns (ITimelockAuthorizer.ScheduledExecution[] memory) {
+        require(skip < _scheduledExecutions.length, "SKIP_VALUE_TOO_LARGE");
+        require(maxSize > 0, "ZERO_MAX_SIZE_VALUE");
+
+        uint256 remaining = _scheduledExecutions.length - skip;
+        uint256 size = Math.min(remaining, maxSize);
+        ITimelockAuthorizer.ScheduledExecution[] memory items = new ITimelockAuthorizer.ScheduledExecution[](size);
+
+        for (uint256 i = 0; i < size; i++) {
+            if (!reverseOrder) {
+                // In chronological order we simply skip the first (older) entries
+                items[i] = _scheduledExecutions[skip + i];
+            } else {
+                // In reverse order we go back to front, skipping the last (newer) entries. Note that `remaining` will
+                // equal the total count if `skip` is 0, meaning we'd start with the newest entry.
+                items[i] = _scheduledExecutions[remaining - 1 - i];
+            }
+        }
+
+        return items;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function isExecutor(uint256 scheduledExecutionId, address account) public view override returns (bool) {
+        return _isExecutor[scheduledExecutionId][account];
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function canExecute(uint256 scheduledExecutionId) external view override returns (bool) {
+        require(scheduledExecutionId < _scheduledExecutions.length, "EXECUTION_DOES_NOT_EXIST");
+
+        ITimelockAuthorizer.ScheduledExecution storage scheduledExecution = _scheduledExecutions[scheduledExecutionId];
+        return
+            !scheduledExecution.executed &&
+            !scheduledExecution.canceled &&
+            block.timestamp >= scheduledExecution.executableAt;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function isCanceler(uint256 scheduledExecutionId, address account) public view override returns (bool) {
+        return
+            _isCanceler[scheduledExecutionId][account] ||
+            _isCanceler[GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID()][account] ||
+            isRoot(account);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function scheduleRootChange(address newRoot, address[] memory executors) external override returns (uint256) {
+        require(isRoot(msg.sender), "SENDER_IS_NOT_ROOT");
+        bytes memory data = abi.encodeWithSelector(this.setPendingRoot.selector, newRoot);
+
+        // Since this can only be called by root, which is always a canceler for all scheduled executions, we don't
+        // bother creating any new cancelers.
+        uint256 scheduledExecutionId = _scheduleWithDelay(address(this), data, getRootTransferDelay(), executors);
+
+        emit RootChangeScheduled(newRoot, scheduledExecutionId);
+        return scheduledExecutionId;
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function setPendingRoot(address pendingRoot) external override onlyScheduled {
+        _setPendingRoot(pendingRoot);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function claimRoot() external override {
+        address pendingRoot = _pendingRoot;
+        require(msg.sender == pendingRoot, "SENDER_IS_NOT_PENDING_ROOT");
+
+        // Complete the root transfer and reset the pending root.
+        _setRoot(pendingRoot);
+        _setPendingRoot(address(0));
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function execute(uint256 scheduledExecutionId) external override returns (bytes memory result) {
+        require(scheduledExecutionId < _scheduledExecutions.length, "EXECUTION_DOES_NOT_EXIST");
+
+        ITimelockAuthorizer.ScheduledExecution storage scheduledExecution = _scheduledExecutions[scheduledExecutionId];
+        require(!scheduledExecution.executed, "EXECUTION_ALREADY_EXECUTED");
+        require(!scheduledExecution.canceled, "EXECUTION_ALREADY_CANCELED");
+
+        require(block.timestamp >= scheduledExecution.executableAt, "EXECUTION_NOT_YET_EXECUTABLE");
+
+        if (scheduledExecution.protected) {
+            // Protected scheduled executions can only be executed by a set of accounts designated by the original
+            // scheduler.
+            require(isExecutor(scheduledExecutionId, msg.sender), "SENDER_IS_NOT_EXECUTOR");
+        }
+
+        scheduledExecution.executed = true;
+        scheduledExecution.executedBy = msg.sender;
+        scheduledExecution.executedAt = block.timestamp;
+
+        // Note that this is the only place in the entire contract we perform a non-view call to an external contract,
+        // i.e. this is the only context in which this contract can be re-entered, and by this point we've already
+        // completed all state transitions (in other words, we follow the Checks-Effects-Interactions pattern).
+        // This results in the scheduled execution being marked as 'executed' during its execution, but that should not
+        // be an issue.
+        result = _executionHelper.execute(scheduledExecution.where, scheduledExecution.data);
+        emit ExecutionExecuted(scheduledExecutionId);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function cancel(uint256 scheduledExecutionId) external override {
+        require(scheduledExecutionId < _scheduledExecutions.length, "EXECUTION_DOES_NOT_EXIST");
+
+        ITimelockAuthorizer.ScheduledExecution storage scheduledExecution = _scheduledExecutions[scheduledExecutionId];
+
+        require(!scheduledExecution.executed, "EXECUTION_ALREADY_EXECUTED");
+        require(!scheduledExecution.canceled, "EXECUTION_ALREADY_CANCELED");
+
+        require(isCanceler(scheduledExecutionId, msg.sender), "SENDER_IS_NOT_CANCELER");
+
+        scheduledExecution.canceled = true;
+        scheduledExecution.canceledBy = msg.sender;
+        scheduledExecution.canceledAt = block.timestamp;
+
+        emit ExecutionCanceled(scheduledExecutionId);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function addCanceler(uint256 scheduledExecutionId, address account) external override {
+        require(isRoot(msg.sender), "SENDER_IS_NOT_ROOT");
+        _addCanceler(scheduledExecutionId, account);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function removeCanceler(uint256 scheduledExecutionId, address account) external override {
+        require(isRoot(msg.sender), "SENDER_IS_NOT_ROOT");
+
+        // The root account is always a canceler, and this cannot be revoked.
+        require(!isRoot(account), "CANNOT_REMOVE_ROOT_CANCELER");
+
+        require(isCanceler(scheduledExecutionId, account), "ACCOUNT_IS_NOT_CANCELER");
+
+        if (_isCanceler[GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID()][account]) {
+            // If an account is a global canceler, then it must explicitly lose this global privilege. This prevents
+            // scenarios where an account has their canceler status revoked over a specific scheduled execution id, but
+            // they can still cancel it because they have global permission.
+            // There's an edge case in which an account could have both specific and global cancel privilege, and still
+            // be able to cancel some scheduled executions after losing global privilege. This is considered an unlikely
+            // scenario, and would require manual removal of the specific canceler privileges even after removal
+            // of the global one.
+            require(scheduledExecutionId == GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID(), "ACCOUNT_IS_GLOBAL_CANCELER");
+        }
+
+        _isCanceler[scheduledExecutionId][account] = false;
+        emit CancelerRemoved(scheduledExecutionId, account);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function addGranter(
+        bytes32 actionId,
+        address account,
+        address where
+    ) external override {
+        require(isRoot(msg.sender), "SENDER_IS_NOT_ROOT");
+
+        require(!isGranter(actionId, account, where), "ACCOUNT_IS_ALREADY_GRANTER");
+        // Note that it is possible for `account` to be a granter for an `actionId` in some specific `where`, and
+        // then be granted permission over `EVERYWHERE`, resulting in 'duplicate' permissions. This is not an issue per
+        // se, but removing this granter status will require undoing these actions in inverse order.
+        // To avoid these issues, it is recommended to revoke any prior granter status over specific contracts before
+        // making an account a global granter.
+
+        _isGranter[actionId][account][where] = true;
+        emit GranterAdded(actionId, account, where);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function removeGranter(
+        bytes32 actionId,
+        address account,
+        address where
+    ) external override {
+        require(isRoot(msg.sender), "SENDER_IS_NOT_ROOT");
+
+        require(isGranter(actionId, account, where), "ACCOUNT_IS_NOT_GRANTER");
+
+        require(!isRoot(account), "CANNOT_REMOVE_ROOT_GRANTER");
+
+        // On top of requiring that the account is currently a granter, we prevent attempts to revoke permission over a
+        // single contract from global granters. As mentioned in `addGranter`, it is possible for an account to have
+        // both global and specific permissions over a given contract: in this case, the global permission must be
+        // removed before the specific ones can be addressed.
+        if (_isGranter[actionId][account][EVERYWHERE()]) {
+            require(where == EVERYWHERE(), "GRANTER_IS_GLOBAL");
+        }
+
+        _isGranter[actionId][account][where] = false;
+        emit GranterRemoved(actionId, account, where);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function addRevoker(address account, address where) external override {
+        require(isRoot(msg.sender), "SENDER_IS_NOT_ROOT");
+
+        require(!isRevoker(account, where), "ACCOUNT_IS_ALREADY_REVOKER");
+        // Note that it's possible for the `account` to be a revoker in a specific `where`, and
+        // later receive permission over `EVERYWHERE()`, resulting in 'duplicate' permissions. While this isn't
+        // necessarily an issue, removing the revoker status will require undoing the actions in reverse order.
+        // To avoid these issues, it's recommended to remove any prior revoker status over specific contracts before
+        // granting an account global revoker.
+
+        _isRevoker[account][where] = true;
+        emit RevokerAdded(account, where);
+    }
+
+    /**
+     * @inheritdoc ITimelockAuthorizer
+     */
+    function removeRevoker(address account, address where) external override {
+        require(isRoot(msg.sender), "SENDER_IS_NOT_ROOT");
+
+        require(isRevoker(account, where), "ACCOUNT_IS_NOT_REVOKER");
+
+        require(!isRoot(account), "CANNOT_REMOVE_ROOT_REVOKER");
+
+        // On top of requiring that the account is currently a revoker, we prevent attempts to remove permission over a
+        // single contract from global revokers. As mentioned in `addRevoker`, it is possible for an account to have
+        // both global and specific permissions over a given contract: in this case, the global permission must be
+        // removed before the specific ones can be addressed.
+        if (_isRevoker[account][EVERYWHERE()]) {
+            require(where == EVERYWHERE(), "REVOKER_IS_GLOBAL");
+        }
+
+        _isRevoker[account][where] = false;
+        emit RevokerRemoved(account, where);
+    }
+
+    /**
+     * @dev Schedules an execution of `data` at contract `where` with a `delay`
+     * allowing only `executors` to invoke the action after the delay.
+     *
+     * This performs no permission checks on `msg.sender` of any kind. The caller of this function should perform
+     * any appropriate checks.
+     */
+    function _scheduleWithDelay(
+        address where,
+        bytes memory data,
+        uint256 delay,
+        address[] memory executors
+    ) internal returns (uint256 scheduledExecutionId) {
+        scheduledExecutionId = _scheduledExecutions.length;
+
+        uint256 executableAt = block.timestamp + delay;
+        bool protected = executors.length > 0;
+
+        _scheduledExecutions.push(
+            ITimelockAuthorizer.ScheduledExecution({
+                where: where,
+                data: data,
+                executed: false,
+                canceled: false,
+                protected: protected,
+                executableAt: executableAt,
+                scheduledBy: msg.sender,
+                scheduledAt: block.timestamp,
+                executedBy: address(0),
+                executedAt: 0,
+                canceledBy: address(0),
+                canceledAt: 0
+            })
+        );
+
+        for (uint256 i = 0; i < executors.length; i++) {
+            require(!_isExecutor[scheduledExecutionId][executors[i]], "DUPLICATE_EXECUTORS");
+            _isExecutor[scheduledExecutionId][executors[i]] = true;
+            emit ExecutorAdded(scheduledExecutionId, executors[i]);
+        }
+    }
+
+    /**
+     * @dev Sets the root address to `root`.
+     */
+    function _setRoot(address root) internal {
+        _root = root;
+        emit RootSet(root);
+    }
+
+    /**
+     * @dev Does not check that caller is root
+     *
+     * See `addCanceler` comments.
+     */
+    function _addCanceler(uint256 scheduledExecutionId, address account) internal {
+        require(!isCanceler(scheduledExecutionId, account), "ACCOUNT_IS_ALREADY_CANCELER");
+
+        if (scheduledExecutionId != GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID()) {
+            // It is not possible to predict future execution ids (because they'll depend on the order of scheduled
+            // actions), so it is never a good idea to add cancelers for executions that don't yet exist.
+            require(scheduledExecutionId < _scheduledExecutions.length, "EXECUTION_DOES_NOT_EXIST");
+
+            // It is also pointless to add a canceler for a scheduled execution that has already been executed or
+            // canceled, so we disallow this to provide more information to a caller that would attempt this.
+            ScheduledExecution storage execution = _scheduledExecutions[scheduledExecutionId];
+            require(!execution.executed && !execution.canceled, "EXECUTION_IS_NOT_PENDING");
+        }
+
+        _isCanceler[scheduledExecutionId][account] = true;
+        emit CancelerAdded(scheduledExecutionId, account);
+    }
+
+    /**
+     * @dev Sets the pending root address to `pendingRoot`.
+     */
+    function _setPendingRoot(address pendingRoot) internal {
+        _pendingRoot = pendingRoot;
+        emit PendingRootSet(pendingRoot);
+    }
+}

--- a/pkg/vault/contracts/authorizer/TimelockExecutionHelper.sol
+++ b/pkg/vault/contracts/authorizer/TimelockExecutionHelper.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
+
+import "@balancer-labs/v2-interfaces/contracts/vault/IAuthorizer.sol";
+
+import "./TimelockAuthorizer.sol";
+
+/**
+ * @dev Helper contract that is used by the TimelockAuthorizer to execute scheduled executions.
+ *
+ * This contract always has permission to call any permissioned function in any contract, as long as they have a delay.
+ * That is, `canPerform` always returns true for the ExecutionHelper for delayed executions. Additionally, native
+ * Timelock scheduled functions (such as setDelay or setPendingRoot) can also only be called by the ExecutionHelper.
+ *
+ * The ExecutionHelper features a single function, `execute`, which then performs an arbitrary function call on any
+ * address. This is how functions that have delays associated are called. However, only the TimelockAuthorizer itself
+ * can call `execute`, and will only do so once a valid execution has been scheduled by a properly authorized party, and
+ * the delay in question has passed.
+ *
+ * Therefore, any function called by the ExecutionHelper originates from an `execute` call, which in turn originates
+ * from the TimelockAuthorizer having completed all permission and delay validation.
+ */
+contract TimelockExecutionHelper is ReentrancyGuard {
+    TimelockAuthorizer private immutable _authorizer;
+
+    constructor() {
+        // This contract is expected to never be deployed directly, and instead to be created by the TimelockAuthorizer
+        // as part of its construction.
+        _authorizer = TimelockAuthorizer(msg.sender);
+    }
+
+    function getAuthorizer() external view returns (IAuthorizer) {
+        return _authorizer;
+    }
+
+    /**
+     * @dev Calls `target` with `data`. Because the ExecutionHelper is authorized to call any permission function that
+     * has a delay, this is a very powerful call. However, only the TimelockAuthorizer can initiate it, and it should
+     * only do so after having validated that the conditions to perform a delayed execution have been met.
+     *
+     * We mark this function as `nonReentrant` out of an abundance of caution, as in theory this and the Authorizer
+     * should be resilient to reentrant executions. The non-reentrancy check means that it is not possible to execute a
+     * scheduled execution during the execution of another scheduled execution - an unlikely and convoluted scenario
+     * that we knowingly forbid.
+     */
+    function execute(address target, bytes memory data) external nonReentrant returns (bytes memory) {
+        require(msg.sender == address(_authorizer), "SENDER_IS_NOT_AUTHORIZER");
+        return Address.functionCall(target, data);
+    }
+}

--- a/pkg/vault/contracts/test/MockAuthenticatedContract.sol
+++ b/pkg/vault/contracts/test/MockAuthenticatedContract.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthentication.sol";
+
+/*
+ * @author Balancer Labs
+ * @title MockAuthenticatedContract
+ * @notice Generic authenticated contract
+ * @dev A general purpose contract that can be used for testing permissioned functions in a more abstract way,
+ * to test Authorizer functionality independent of specific Vault functions.
+ */
+contract MockAuthenticatedContract is SingletonAuthentication {
+    event ProtectedFunctionCalled(bytes data);
+    event SecondProtectedFunctionCalled(bytes data);
+
+    constructor(IVault vault) SingletonAuthentication(vault) {}
+
+    function protectedFunction(bytes calldata data) external authenticate returns (bytes memory) {
+        emit ProtectedFunctionCalled(data);
+        return data;
+    }
+
+    function secondProtectedFunction(bytes calldata data) external authenticate returns (bytes memory) {
+        emit SecondProtectedFunctionCalled(data);
+        return data;
+    }
+}

--- a/pkg/vault/test/authorizer/TimelockAuthorizerActors.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerActors.test.ts
@@ -1,0 +1,777 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import TimelockAuthorizer from '@balancer-labs/v2-helpers/src/models/authorizer/TimelockAuthorizer';
+import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import { advanceTime, DAY, MONTH } from '@balancer-labs/v2-helpers/src/time';
+
+describe('TimelockAuthorizer actors', () => {
+  let vault: Vault;
+  let authorizer: TimelockAuthorizer;
+  let root: SignerWithAddress,
+    nextRoot: SignerWithAddress,
+    account: SignerWithAddress,
+    canceler: SignerWithAddress,
+    other: SignerWithAddress;
+
+  before('setup signers', async () => {
+    [, root, nextRoot, account, canceler, other] = await ethers.getSigners();
+  });
+
+  const GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID = MAX_UINT256;
+
+  const ACTION_1 = '0x0000000000000000000000000000000000000000000000000000000000000001';
+  const ACTION_2 = '0x0000000000000000000000000000000000000000000000000000000000000002';
+
+  const WHERE_1 = ethers.Wallet.createRandom().address;
+  const WHERE_2 = ethers.Wallet.createRandom().address;
+
+  const EVERYWHERE = TimelockAuthorizer.EVERYWHERE;
+
+  sharedBeforeEach('deploy authorizer', async () => {
+    vault = await Vault.create({
+      admin: root,
+      nextAdmin: nextRoot.address,
+    });
+
+    authorizer = new TimelockAuthorizer(vault.authorizer, root);
+  });
+
+  describe('granters', () => {
+    describe('addGranter', () => {
+      context('in a specific contract', () => {
+        it('root is already a granter', async () => {
+          expect(await authorizer.isGranter(ACTION_1, root, WHERE_1)).to.be.true;
+          expect(await authorizer.isGranter(ACTION_2, root, WHERE_1)).to.be.true;
+        });
+
+        it('account is granter for that action only in that contract', async () => {
+          await authorizer.addGranter(ACTION_1, account, WHERE_1, { from: root });
+
+          expect(await authorizer.isGranter(ACTION_1, account, WHERE_1)).to.be.true;
+          expect(await authorizer.isGranter(ACTION_1, account, WHERE_2)).to.be.false;
+          expect(await authorizer.isGranter(ACTION_1, account, EVERYWHERE)).to.be.false;
+        });
+
+        it('account is not granter for any other action anywhere', async () => {
+          await authorizer.addGranter(ACTION_1, account, WHERE_1, { from: root });
+
+          expect(await authorizer.isGranter(ACTION_2, account, WHERE_1)).to.be.false;
+          expect(await authorizer.isGranter(ACTION_2, account, WHERE_2)).to.be.false;
+          expect(await authorizer.isGranter(ACTION_2, account, EVERYWHERE)).to.be.false;
+        });
+
+        it('emits a GranterAdded event', async () => {
+          const receipt = await (await authorizer.addGranter(ACTION_1, account, WHERE_1, { from: root })).wait();
+          expectEvent.inReceipt(receipt, 'GranterAdded', {
+            actionId: ACTION_1,
+            account: account.address,
+            where: WHERE_1,
+          });
+        });
+
+        it('reverts if the account is already a granter', async () => {
+          await authorizer.addGranter(ACTION_1, account, WHERE_1, { from: root });
+          await expect(authorizer.addGranter(ACTION_1, account, WHERE_1, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_ALREADY_GRANTER'
+          );
+        });
+
+        it('reverts if the account is already a global granter', async () => {
+          await authorizer.addGranter(ACTION_1, account, EVERYWHERE, { from: root });
+          await expect(authorizer.addGranter(ACTION_1, account, WHERE_1, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_ALREADY_GRANTER'
+          );
+        });
+
+        it('reverts if the account is root', async () => {
+          await expect(authorizer.addGranter(ACTION_1, root, WHERE_1, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_ALREADY_GRANTER'
+          );
+        });
+
+        it('reverts if the caller is not root', async () => {
+          await expect(authorizer.addGranter(ACTION_1, account, WHERE_1, { from: other })).to.be.revertedWith(
+            'SENDER_IS_NOT_ROOT'
+          );
+        });
+      });
+
+      context('in any contract', () => {
+        it('root is already a granter', async () => {
+          expect(await authorizer.isGranter(ACTION_1, root, EVERYWHERE)).to.be.true;
+          expect(await authorizer.isGranter(ACTION_2, root, EVERYWHERE)).to.be.true;
+        });
+
+        it('account is granter for that action in any contract', async () => {
+          await authorizer.addGranter(ACTION_1, account, EVERYWHERE, { from: root });
+
+          expect(await authorizer.isGranter(ACTION_1, account, WHERE_1)).to.be.true;
+          expect(await authorizer.isGranter(ACTION_1, account, WHERE_2)).to.be.true;
+          expect(await authorizer.isGranter(ACTION_1, account, EVERYWHERE)).to.be.true;
+        });
+
+        it('account is not granter for any other action anywhere', async () => {
+          await authorizer.addGranter(ACTION_1, account, EVERYWHERE, { from: root });
+
+          expect(await authorizer.isGranter(ACTION_2, account, WHERE_1)).to.be.false;
+          expect(await authorizer.isGranter(ACTION_2, account, WHERE_2)).to.be.false;
+          expect(await authorizer.isGranter(ACTION_2, account, EVERYWHERE)).to.be.false;
+        });
+
+        it('emits a GranterAdded event', async () => {
+          const receipt = await (await authorizer.addGranter(ACTION_1, account, EVERYWHERE, { from: root })).wait();
+          expectEvent.inReceipt(receipt, 'GranterAdded', {
+            actionId: ACTION_1,
+            account: account.address,
+            where: EVERYWHERE,
+          });
+        });
+
+        it('does not revert if the account is already a granter in a specific contract', async () => {
+          await authorizer.addGranter(ACTION_1, account, WHERE_1, { from: root });
+
+          const receipt = await (await authorizer.addGranter(ACTION_1, account, EVERYWHERE, { from: root })).wait();
+          expectEvent.inReceipt(receipt, 'GranterAdded', {
+            actionId: ACTION_1,
+            account: account.address,
+            where: EVERYWHERE,
+          });
+        });
+
+        it('reverts if the account is already a global granter', async () => {
+          await authorizer.addGranter(ACTION_1, account, EVERYWHERE, { from: root });
+          await expect(authorizer.addGranter(ACTION_1, account, EVERYWHERE, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_ALREADY_GRANTER'
+          );
+        });
+
+        it('reverts if the account is root', async () => {
+          await expect(authorizer.addGranter(ACTION_1, root, EVERYWHERE, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_ALREADY_GRANTER'
+          );
+        });
+
+        it('reverts if the caller is not root', async () => {
+          await expect(authorizer.addGranter(ACTION_1, account, EVERYWHERE, { from: other })).to.be.revertedWith(
+            'SENDER_IS_NOT_ROOT'
+          );
+        });
+      });
+    });
+
+    describe('removeGranter', () => {
+      context('in a specific contract', () => {
+        it('account is not a granter for that action anywhere', async () => {
+          await authorizer.addGranter(ACTION_1, account, WHERE_1, { from: root });
+          await authorizer.removeGranter(ACTION_1, account, WHERE_1, { from: root });
+
+          expect(await authorizer.isGranter(ACTION_1, account, WHERE_1)).to.be.false;
+          expect(await authorizer.isGranter(ACTION_1, account, WHERE_2)).to.be.false;
+          expect(await authorizer.isGranter(ACTION_1, account, EVERYWHERE)).to.be.false;
+        });
+
+        it('account is not a granter for any other action', async () => {
+          await authorizer.addGranter(ACTION_1, account, WHERE_1, { from: root });
+          await authorizer.removeGranter(ACTION_1, account, WHERE_1, { from: root });
+
+          expect(await authorizer.isGranter(ACTION_2, account, WHERE_1)).to.be.false;
+          expect(await authorizer.isGranter(ACTION_2, account, WHERE_2)).to.be.false;
+          expect(await authorizer.isGranter(ACTION_2, account, EVERYWHERE)).to.be.false;
+        });
+
+        it('emits a GranterRemoved event', async () => {
+          await authorizer.addGranter(ACTION_1, account, WHERE_1, { from: root });
+
+          const receipt = await (await authorizer.removeGranter(ACTION_1, account, WHERE_1, { from: root })).wait();
+          expectEvent.inReceipt(receipt, 'GranterRemoved', {
+            actionId: ACTION_1,
+            account: account.address,
+            where: WHERE_1,
+          });
+        });
+
+        it('reverts if the account is not a granter', async () => {
+          await expect(authorizer.removeGranter(ACTION_1, account, WHERE_1, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_NOT_GRANTER'
+          );
+        });
+
+        it('reverts if the account is a global granter', async () => {
+          await authorizer.addGranter(ACTION_1, account, EVERYWHERE, { from: root });
+          await expect(authorizer.removeGranter(ACTION_1, account, WHERE_1, { from: root })).to.be.revertedWith(
+            'GRANTER_IS_GLOBAL'
+          );
+        });
+
+        it('reverts if the account is root', async () => {
+          await expect(authorizer.removeGranter(ACTION_1, root, WHERE_1, { from: root })).to.be.revertedWith(
+            'CANNOT_REMOVE_ROOT_GRANTER'
+          );
+        });
+
+        it('reverts if the caller is not root', async () => {
+          await authorizer.addGranter(ACTION_1, account, WHERE_1, { from: root });
+          await expect(authorizer.removeGranter(ACTION_1, account, WHERE_1, { from: other })).to.be.revertedWith(
+            'SENDER_IS_NOT_ROOT'
+          );
+        });
+      });
+
+      context('in any contract', () => {
+        it('account is not a granter for that action on any contract', async () => {
+          await authorizer.addGranter(ACTION_1, account, EVERYWHERE, { from: root });
+          await authorizer.removeGranter(ACTION_1, account, EVERYWHERE, { from: root });
+
+          expect(await authorizer.isGranter(ACTION_1, account, WHERE_1)).to.be.false;
+          expect(await authorizer.isGranter(ACTION_1, account, EVERYWHERE)).to.be.false;
+        });
+
+        it('account is not a granter for that any other action anywhere', async () => {
+          await authorizer.addGranter(ACTION_1, account, EVERYWHERE, { from: root });
+          await authorizer.removeGranter(ACTION_1, account, EVERYWHERE, { from: root });
+
+          expect(await authorizer.isGranter(ACTION_2, account, WHERE_1)).to.be.false;
+          expect(await authorizer.isGranter(ACTION_2, account, EVERYWHERE)).to.be.false;
+        });
+
+        it('emits a GranterRemoved event', async () => {
+          await authorizer.addGranter(ACTION_1, account, EVERYWHERE, { from: root });
+
+          const receipt = await (await authorizer.removeGranter(ACTION_1, account, EVERYWHERE, { from: root })).wait();
+          expectEvent.inReceipt(receipt, 'GranterRemoved', {
+            actionId: ACTION_1,
+            account: account.address,
+            where: EVERYWHERE,
+          });
+        });
+
+        it('reverts if the account is not a global granter', async () => {
+          await expect(authorizer.removeGranter(ACTION_1, account, EVERYWHERE, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_NOT_GRANTER'
+          );
+        });
+
+        it('reverts if the account is a granter in a specific contract', async () => {
+          await authorizer.addGranter(ACTION_1, account, WHERE_1, { from: root });
+          await expect(authorizer.removeGranter(ACTION_1, account, EVERYWHERE, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_NOT_GRANTER'
+          );
+        });
+
+        it('preserves granter status if account was granter over both a specific contract and globally', async () => {
+          await authorizer.addGranter(ACTION_1, account, WHERE_1, { from: root });
+          await authorizer.addGranter(ACTION_1, account, EVERYWHERE, { from: root });
+
+          expect(await authorizer.isGranter(ACTION_1, account, WHERE_1)).to.be.true;
+          expect(await authorizer.isGranter(ACTION_1, account, EVERYWHERE)).to.be.true;
+
+          await authorizer.removeGranter(ACTION_1, account, EVERYWHERE, { from: root });
+
+          expect(await authorizer.isGranter(ACTION_1, account, WHERE_1)).to.be.true;
+          expect(await authorizer.isGranter(ACTION_1, account, EVERYWHERE)).to.be.false;
+
+          await authorizer.removeGranter(ACTION_1, account, WHERE_1, { from: root });
+
+          expect(await authorizer.isGranter(ACTION_1, account, WHERE_1)).to.be.false;
+          expect(await authorizer.isGranter(ACTION_1, account, EVERYWHERE)).to.be.false;
+        });
+
+        it('reverts if the account is root', async () => {
+          await expect(authorizer.removeGranter(ACTION_1, root, EVERYWHERE, { from: root })).to.be.revertedWith(
+            'CANNOT_REMOVE_ROOT_GRANTER'
+          );
+        });
+
+        it('reverts if the caller is not root', async () => {
+          await authorizer.addGranter(ACTION_1, account, EVERYWHERE, { from: root });
+          await expect(authorizer.removeGranter(ACTION_1, account, EVERYWHERE, { from: other })).to.be.revertedWith(
+            'SENDER_IS_NOT_ROOT'
+          );
+        });
+      });
+    });
+  });
+
+  describe('revokers', () => {
+    describe('addRevoker', () => {
+      context('in a specific contract', () => {
+        it('root is already a revoker', async () => {
+          expect(await authorizer.isRevoker(root, WHERE_1)).to.be.true;
+          expect(await authorizer.isRevoker(root, WHERE_2)).to.be.true;
+        });
+
+        it('account is a revoker only in that contract', async () => {
+          await authorizer.addRevoker(account, WHERE_1, { from: root });
+
+          expect(await authorizer.isRevoker(account, WHERE_1)).to.be.true;
+          expect(await authorizer.isRevoker(account, WHERE_2)).to.be.false;
+          expect(await authorizer.isRevoker(account, EVERYWHERE)).to.be.false;
+        });
+
+        it('emits a RevokerAdded event', async () => {
+          const receipt = await (await authorizer.addRevoker(account, WHERE_1, { from: root })).wait();
+          expectEvent.inReceipt(receipt, 'RevokerAdded', {
+            account: account.address,
+            where: WHERE_1,
+          });
+        });
+
+        it('reverts if account is already a revoker', async () => {
+          await authorizer.addRevoker(account, WHERE_1, { from: root });
+          await expect(authorizer.addRevoker(account, WHERE_1, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_ALREADY_REVOKER'
+          );
+        });
+
+        it('reverts if account is already a global revoker', async () => {
+          await authorizer.addRevoker(account, EVERYWHERE, { from: root });
+          await expect(authorizer.addRevoker(account, WHERE_1, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_ALREADY_REVOKER'
+          );
+        });
+
+        it('reverts if the account is root', async () => {
+          await expect(authorizer.addRevoker(root, WHERE_1, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_ALREADY_REVOKER'
+          );
+        });
+
+        it('reverts if the caller is not root', async () => {
+          await expect(authorizer.addRevoker(account, WHERE_1, { from: other })).to.be.revertedWith(
+            'SENDER_IS_NOT_ROOT'
+          );
+        });
+      });
+
+      context('in any contract', () => {
+        it('root is already a revoker', async () => {
+          expect(await authorizer.isRevoker(root, EVERYWHERE)).to.be.true;
+        });
+
+        it('account is a revoker in any contract', async () => {
+          await authorizer.addRevoker(account, EVERYWHERE, { from: root });
+
+          expect(await authorizer.isRevoker(account, WHERE_1)).to.be.true;
+          expect(await authorizer.isRevoker(account, WHERE_2)).to.be.true;
+          expect(await authorizer.isRevoker(account, EVERYWHERE)).to.be.true;
+        });
+
+        it('emits a RevokerAdded event', async () => {
+          const receipt = await (await authorizer.addRevoker(account, EVERYWHERE, { from: root })).wait();
+          expectEvent.inReceipt(receipt, 'RevokerAdded', {
+            account: account.address,
+            where: EVERYWHERE,
+          });
+        });
+
+        it('does not revert if account is already revoker in a specific contract', async () => {
+          await authorizer.addRevoker(account, WHERE_1, { from: root });
+
+          const receipt = await (await authorizer.addRevoker(account, EVERYWHERE, { from: root })).wait();
+          expectEvent.inReceipt(receipt, 'RevokerAdded', {
+            account: account.address,
+            where: EVERYWHERE,
+          });
+        });
+
+        it('reverts if account already is a global revoker', async () => {
+          await authorizer.addRevoker(account, EVERYWHERE, { from: root });
+          await expect(authorizer.addRevoker(account, EVERYWHERE, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_ALREADY_REVOKER'
+          );
+        });
+
+        it('reverts if the account is root', async () => {
+          await expect(authorizer.addRevoker(root, EVERYWHERE, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_ALREADY_REVOKER'
+          );
+        });
+
+        it('reverts if the caller is not root', async () => {
+          await expect(authorizer.addRevoker(account, EVERYWHERE, { from: other })).to.be.revertedWith(
+            'SENDER_IS_NOT_ROOT'
+          );
+        });
+      });
+    });
+
+    describe('removeRevoker', () => {
+      context('in a specific contract', () => {
+        it('account is not a revoker anywhere', async () => {
+          await authorizer.addRevoker(account, WHERE_1, { from: root });
+          await authorizer.removeRevoker(account, WHERE_1, { from: root });
+
+          expect(await authorizer.isRevoker(account, WHERE_1)).to.be.false;
+          expect(await authorizer.isRevoker(account, WHERE_2)).to.be.false;
+          expect(await authorizer.isRevoker(account, EVERYWHERE)).to.be.false;
+        });
+
+        it('emits a RevokerRemoved event', async () => {
+          await authorizer.addRevoker(account, WHERE_1, { from: root });
+
+          const receipt = await (await authorizer.removeRevoker(account, WHERE_1, { from: root })).wait();
+          expectEvent.inReceipt(receipt, 'RevokerRemoved', {
+            account: account.address,
+            where: WHERE_1,
+          });
+        });
+
+        it('reverts if the account is not a revoker', async () => {
+          await expect(authorizer.removeRevoker(account, WHERE_1, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_NOT_REVOKER'
+          );
+        });
+
+        it('reverts if the account is a global revoker', async () => {
+          await authorizer.addRevoker(account, EVERYWHERE, { from: root });
+          await expect(authorizer.removeRevoker(account, WHERE_1, { from: root })).to.be.revertedWith(
+            'REVOKER_IS_GLOBAL'
+          );
+        });
+
+        it('reverts if the account is root', async () => {
+          await expect(authorizer.removeRevoker(root, WHERE_1, { from: root })).to.be.revertedWith(
+            'CANNOT_REMOVE_ROOT_REVOKER'
+          );
+        });
+
+        it('reverts if the caller is not root', async () => {
+          await authorizer.addRevoker(account, WHERE_1, { from: root });
+          await expect(authorizer.removeRevoker(account, WHERE_1, { from: other })).to.be.revertedWith(
+            'SENDER_IS_NOT_ROOT'
+          );
+        });
+      });
+
+      context('in any contract', () => {
+        it('account is not a revoker for any contract', async () => {
+          await authorizer.addRevoker(account, EVERYWHERE, { from: root });
+          await authorizer.removeRevoker(account, EVERYWHERE, { from: root });
+
+          expect(await authorizer.isRevoker(account, WHERE_1)).to.be.false;
+          expect(await authorizer.isRevoker(account, EVERYWHERE)).to.be.false;
+        });
+
+        it('emits a RevokerRemoved event', async () => {
+          await authorizer.addRevoker(account, EVERYWHERE, { from: root });
+
+          const receipt = await (await authorizer.removeRevoker(account, EVERYWHERE, { from: root })).wait();
+          expectEvent.inReceipt(receipt, 'RevokerRemoved', {
+            account: account.address,
+            where: EVERYWHERE,
+          });
+        });
+
+        it('reverts if the account is not a global revoker', async () => {
+          await expect(authorizer.removeRevoker(account, EVERYWHERE, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_NOT_REVOKER'
+          );
+        });
+
+        it('reverts if the account is a revoker in a specific contract', async () => {
+          await authorizer.addRevoker(account, WHERE_1, { from: root });
+          await expect(authorizer.removeRevoker(account, EVERYWHERE, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_NOT_REVOKER'
+          );
+        });
+
+        it('preserves revoker status if it was received over both a specific contract and globally', async () => {
+          await authorizer.addRevoker(account, WHERE_1, { from: root });
+          await authorizer.addRevoker(account, EVERYWHERE, { from: root });
+
+          expect(await authorizer.isRevoker(account, WHERE_1)).to.be.true;
+          expect(await authorizer.isRevoker(account, EVERYWHERE)).to.be.true;
+
+          await authorizer.removeRevoker(account, EVERYWHERE, { from: root });
+
+          expect(await authorizer.isRevoker(account, WHERE_1)).to.be.true;
+          expect(await authorizer.isRevoker(account, EVERYWHERE)).to.be.false;
+
+          await authorizer.removeRevoker(account, WHERE_1, { from: root });
+
+          expect(await authorizer.isRevoker(account, WHERE_1)).to.be.false;
+          expect(await authorizer.isRevoker(account, EVERYWHERE)).to.be.false;
+        });
+
+        it('reverts if the account is root', async () => {
+          await expect(authorizer.removeRevoker(root, EVERYWHERE, { from: root })).to.be.revertedWith(
+            'CANNOT_REMOVE_ROOT_REVOKER'
+          );
+        });
+
+        it('reverts if the caller is not root', async () => {
+          await authorizer.addRevoker(account, EVERYWHERE, { from: root });
+          await expect(authorizer.removeRevoker(account, EVERYWHERE, { from: other })).to.be.revertedWith(
+            'SENDER_IS_NOT_ROOT'
+          );
+        });
+      });
+    });
+  });
+
+  describe('cancelers', () => {
+    let executionId: number;
+    let otherExecutionId: number;
+
+    sharedBeforeEach('schedule actions', async () => {
+      // It is only possible to create cancelers for specific scheduled execution ids if they exist, so we must
+      // first schedule them.
+
+      // The only action that is simple to schedule and execute on a clean system is setting a delay for the
+      // `setAuthorizer`, since not having that delay prevents other delays from being set. We schedule two
+      // calls to that function.
+
+      const setAuthorizerAction = await actionId(vault.instance, 'setAuthorizer');
+      executionId = await authorizer.scheduleDelayChange(setAuthorizerAction, DAY, [], { from: root });
+      otherExecutionId = await authorizer.scheduleDelayChange(setAuthorizerAction, DAY, [], { from: root });
+    });
+
+    describe('addCanceler', () => {
+      context('for a specific scheduled execution id', () => {
+        it('root is a canceler', async () => {
+          expect(await authorizer.isCanceler(executionId, root)).to.be.true;
+        });
+
+        it('can add canceler for a specific execution id', async () => {
+          expect(await authorizer.isCanceler(executionId, canceler)).to.be.false;
+
+          await authorizer.addCanceler(executionId, canceler, { from: root });
+
+          expect(await authorizer.isCanceler(executionId, canceler)).to.be.true;
+          // test that canceler has only a specific permission
+          expect(await authorizer.isCanceler(otherExecutionId, canceler)).to.be.false;
+        });
+
+        it('emits an event', async () => {
+          const receipt = await authorizer.addCanceler(executionId, canceler, { from: root });
+
+          expectEvent.inReceipt(await receipt.wait(), 'CancelerAdded', { scheduledExecutionId: executionId });
+        });
+
+        it('cannot be added twice', async () => {
+          await authorizer.addCanceler(executionId, canceler, { from: root });
+
+          await expect(authorizer.addCanceler(executionId, canceler, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_ALREADY_CANCELER'
+          );
+        });
+
+        it('reverts if the sender is not the root', async () => {
+          await expect(authorizer.addCanceler(executionId, canceler, { from: other })).to.be.revertedWith(
+            'SENDER_IS_NOT_ROOT'
+          );
+        });
+
+        it('reverts if the scheduled execution does not exist', async () => {
+          await expect(authorizer.addCanceler(42, canceler, { from: root })).to.be.revertedWith(
+            'EXECUTION_DOES_NOT_EXIST'
+          );
+        });
+
+        it('reverts if the scheduled execution was executed', async () => {
+          await advanceTime(MONTH);
+          await authorizer.execute(executionId);
+
+          await expect(authorizer.addCanceler(executionId, canceler, { from: root })).to.be.revertedWith(
+            'EXECUTION_IS_NOT_PENDING'
+          );
+        });
+
+        it('reverts if the scheduled execution was canceled', async () => {
+          await authorizer.cancel(executionId, { from: root });
+
+          await expect(authorizer.addCanceler(executionId, canceler, { from: root })).to.be.revertedWith(
+            'EXECUTION_IS_NOT_PENDING'
+          );
+        });
+      });
+
+      context('for any scheduled execution id', () => {
+        it('root is a canceler', async () => {
+          expect(await authorizer.isCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, root)).to.be.true;
+        });
+
+        it('cannot add root as a canceler', async () => {
+          await expect(
+            authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, root, { from: root })
+          ).to.be.revertedWith('ACCOUNT_IS_ALREADY_CANCELER');
+        });
+
+        it('can add canceler for any execution id', async () => {
+          await authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
+
+          expect(await authorizer.isCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler)).to.be.true;
+          // check that the canceler can cancel any action
+          expect(await authorizer.isCanceler(executionId, canceler)).to.be.true;
+          expect(await authorizer.isCanceler(otherExecutionId, canceler)).to.be.true;
+        });
+
+        it('emits an event', async () => {
+          const receipt = await authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, {
+            from: root,
+          });
+
+          expectEvent.inReceipt(await receipt.wait(), 'CancelerAdded', {
+            scheduledExecutionId: GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID,
+          });
+        });
+
+        it('can add specific canceler and then a global', async () => {
+          let receipt = await authorizer.addCanceler(executionId, canceler, { from: root });
+          expectEvent.inReceipt(await receipt.wait(), 'CancelerAdded', {
+            scheduledExecutionId: executionId,
+          });
+          receipt = await authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
+          expectEvent.inReceipt(await receipt.wait(), 'CancelerAdded', {
+            scheduledExecutionId: GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID,
+          });
+
+          expect(await authorizer.isCanceler(executionId, canceler)).to.be.true;
+          expect(await authorizer.isCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler)).to.be.true;
+        });
+
+        it('cannot be added twice', async () => {
+          await authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
+
+          await expect(
+            authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root })
+          ).to.be.revertedWith('ACCOUNT_IS_ALREADY_CANCELER');
+        });
+
+        it('reverts if the sender is not the root', async () => {
+          await expect(
+            authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: other })
+          ).to.be.revertedWith('SENDER_IS_NOT_ROOT');
+        });
+      });
+    });
+
+    describe('removeCanceler', () => {
+      context('for a specific scheduled execution id', () => {
+        it('can remove canceler for a specific execution id', async () => {
+          await authorizer.addCanceler(executionId, canceler, { from: root });
+          await authorizer.removeCanceler(executionId, canceler, { from: root });
+
+          expect(await authorizer.isCanceler(executionId, canceler)).to.be.false;
+        });
+
+        it('emits an event', async () => {
+          await authorizer.addCanceler(executionId, canceler, { from: root });
+          const receipt = await authorizer.removeCanceler(executionId, canceler, { from: root });
+
+          expectEvent.inReceipt(await receipt.wait(), 'CancelerRemoved', {
+            scheduledExecutionId: executionId,
+            canceler: canceler.address,
+          });
+        });
+
+        it('cannot remove if not canceler', async () => {
+          await expect(authorizer.removeCanceler(executionId, canceler, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_NOT_CANCELER'
+          );
+        });
+
+        it('cannot remove root', async () => {
+          await expect(authorizer.removeCanceler(executionId, root, { from: root })).to.be.revertedWith(
+            'CANNOT_REMOVE_ROOT_CANCELER'
+          );
+        });
+
+        it('cannot remove global canceler for a specific execution id', async () => {
+          await authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
+          await expect(authorizer.removeCanceler(executionId, canceler, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_GLOBAL_CANCELER'
+          );
+        });
+
+        it('cannot be removed twice', async () => {
+          await authorizer.addCanceler(executionId, canceler, { from: root });
+          await authorizer.removeCanceler(executionId, canceler, { from: root });
+
+          await expect(authorizer.removeCanceler(executionId, canceler, { from: root })).to.be.revertedWith(
+            'ACCOUNT_IS_NOT_CANCELER'
+          );
+        });
+
+        it('reverts if the sender is not the root', async () => {
+          await expect(authorizer.removeCanceler(executionId, canceler, { from: canceler })).to.be.revertedWith(
+            'SENDER_IS_NOT_ROOT'
+          );
+        });
+      });
+
+      context('for any scheduled execution id', () => {
+        it('can remove canceler for any execution id', async () => {
+          await authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
+
+          await authorizer.removeCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
+
+          expect(await authorizer.isCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler)).to.be.false;
+        });
+
+        it('emits an event', async () => {
+          await authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
+          const receipt = await authorizer.removeCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, {
+            from: root,
+          });
+
+          expectEvent.inReceipt(await receipt.wait(), 'CancelerRemoved', {
+            scheduledExecutionId: GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID,
+            canceler: canceler.address,
+          });
+        });
+
+        it('cannot remove if not a canceler', async () => {
+          await expect(
+            authorizer.removeCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, other, { from: root })
+          ).to.be.revertedWith('ACCOUNT_IS_NOT_CANCELER');
+        });
+
+        it('cannot remove the root', async () => {
+          await expect(
+            authorizer.removeCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, root, { from: root })
+          ).to.be.revertedWith('CANNOT_REMOVE_ROOT_CANCELER');
+        });
+
+        it('cannot be removed twice', async () => {
+          await authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
+          await authorizer.removeCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
+
+          await expect(
+            authorizer.removeCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root })
+          ).to.be.revertedWith('ACCOUNT_IS_NOT_CANCELER');
+        });
+
+        it('can remove canceler for any execution id', async () => {
+          await authorizer.addCanceler(executionId, canceler, { from: root });
+          await authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
+
+          expect(await authorizer.isCanceler(executionId, canceler)).to.be.true;
+          expect(await authorizer.isCanceler(otherExecutionId, canceler)).to.be.true;
+
+          await authorizer.removeCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
+
+          expect(await authorizer.isCanceler(executionId, canceler)).to.be.true;
+          expect(await authorizer.isCanceler(otherExecutionId, canceler)).to.be.false;
+
+          await authorizer.removeCanceler(executionId, canceler, { from: root });
+
+          expect(await authorizer.isCanceler(executionId, canceler)).to.be.false;
+          expect(await authorizer.isCanceler(otherExecutionId, canceler)).to.be.false;
+        });
+
+        it('reverts if the sender is not the root', async () => {
+          await expect(
+            authorizer.removeCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: canceler })
+          ).to.be.revertedWith('SENDER_IS_NOT_ROOT');
+        });
+      });
+    });
+  });
+});

--- a/pkg/vault/test/authorizer/TimelockAuthorizerDelays.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerDelays.test.ts
@@ -1,0 +1,650 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import TimelockAuthorizer from '@balancer-labs/v2-helpers/src/models/authorizer/TimelockAuthorizer';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import { advanceTime, currentTimestamp, DAY, MONTH } from '@balancer-labs/v2-helpers/src/time';
+import { randomAddress, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import { range } from 'lodash';
+
+describe('TimelockAuthorizer delays', () => {
+  let authorizer: TimelockAuthorizer, vault: Contract;
+
+  let root: SignerWithAddress, other: SignerWithAddress;
+
+  before('setup signers', async () => {
+    [, root, other] = await ethers.getSigners();
+  });
+
+  const ACTION_1 = '0x0000000000000000000000000000000000000000000000000000000000000001';
+  const ACTION_2 = '0x0000000000000000000000000000000000000000000000000000000000000002';
+
+  const MINIMUM_EXECUTION_DELAY = 5 * DAY;
+
+  sharedBeforeEach('deploy authorizer', async () => {
+    let authorizerContract: Contract;
+
+    ({ instance: vault, authorizer: authorizerContract } = await Vault.create({
+      admin: root,
+      nextAdmin: ZERO_ADDRESS,
+    }));
+
+    authorizer = new TimelockAuthorizer(authorizerContract, root);
+  });
+
+  sharedBeforeEach('set delay to set authorizer', async () => {
+    const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
+    // setAuthorizer must have a delay larger or equal than the one we intend to set - it is invalid to set any delays
+    // larger than setAuthorizer's.
+    // We set a very large setAuthorizer delay so that we have flexibility in choosing both previous and new delay
+    // values in the tests.
+    await authorizer.scheduleAndExecuteDelayChange(setAuthorizerAction, DAY * 365, { from: root });
+  });
+
+  describe('scheduleDelayChange', () => {
+    const ACTION_DELAY = DAY;
+
+    function itSchedulesTheDelayChangeCorrectly(expectedExecutionDelay: number) {
+      it('schedules a delay change', async () => {
+        const id = await authorizer.scheduleDelayChange(ACTION_1, ACTION_DELAY, [], { from: root });
+
+        const { executed, data, where, executableAt } = await authorizer.getScheduledExecution(id);
+        expect(executed).to.be.false;
+        expect(data).to.be.equal(
+          authorizer.instance.interface.encodeFunctionData('setDelay', [ACTION_1, ACTION_DELAY])
+        );
+        expect(where).to.be.equal(authorizer.address);
+        expect(executableAt).to.equal((await currentTimestamp()).add(expectedExecutionDelay));
+      });
+
+      it('increases the scheduled execution count', async () => {
+        const countBefore = await authorizer.instance.getScheduledExecutionsCount();
+        await authorizer.scheduleDelayChange(ACTION_1, ACTION_DELAY, [], { from: root });
+
+        const countAfter = await authorizer.instance.getScheduledExecutionsCount();
+
+        expect(countAfter).to.equal(countBefore.add(1));
+      });
+
+      it('stores scheduler information', async () => {
+        const id = await authorizer.scheduleDelayChange(ACTION_1, ACTION_DELAY, [], { from: root });
+
+        const scheduledExecution = await authorizer.getScheduledExecution(id);
+        expect(scheduledExecution.scheduledBy).to.equal(root.address);
+        expect(scheduledExecution.scheduledAt).to.equal(await currentTimestamp());
+      });
+
+      it('stores empty executor and canceler information', async () => {
+        const id = await authorizer.scheduleDelayChange(ACTION_1, ACTION_DELAY, [], { from: root });
+
+        const scheduledExecution = await authorizer.getScheduledExecution(id);
+        expect(scheduledExecution.executedBy).to.equal(ZERO_ADDRESS);
+        expect(scheduledExecution.executedAt).to.equal(0);
+        expect(scheduledExecution.canceledBy).to.equal(ZERO_ADDRESS);
+        expect(scheduledExecution.canceledAt).to.equal(0);
+      });
+
+      it('execution can be unprotected', async () => {
+        const id = await authorizer.scheduleDelayChange(ACTION_1, ACTION_DELAY, [], { from: root });
+        const execution = await authorizer.getScheduledExecution(id);
+
+        expect(execution.protected).to.be.false;
+      });
+
+      it('execution can be protected', async () => {
+        const executors = range(4).map(randomAddress);
+        const id = await authorizer.scheduleDelayChange(ACTION_1, ACTION_DELAY, executors, { from: root });
+        const execution = await authorizer.getScheduledExecution(id);
+
+        expect(execution.protected).to.be.true;
+        await Promise.all(
+          executors.map(async (executor) => expect(await authorizer.isExecutor(id, executor)).to.be.true)
+        );
+      });
+
+      it('root can cancel the execution', async () => {
+        const id = await authorizer.scheduleDelayChange(ACTION_1, ACTION_DELAY, [], { from: root });
+        expect(await authorizer.isCanceler(id, root)).to.be.true;
+
+        const receipt = await authorizer.cancel(id, { from: root });
+        expectEvent.inReceipt(await receipt.wait(), 'ExecutionCanceled', { scheduledExecutionId: id });
+      });
+
+      it('can be executed after the expected delay', async () => {
+        const id = await authorizer.scheduleDelayChange(ACTION_1, ACTION_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        const receipt = await authorizer.execute(id);
+        expectEvent.inReceipt(await receipt.wait(), 'ExecutionExecuted', { scheduledExecutionId: id });
+      });
+
+      it('sets the new action delay when executed', async () => {
+        const id = await authorizer.scheduleDelayChange(ACTION_1, ACTION_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        await authorizer.execute(id);
+
+        expect(await authorizer.delay(ACTION_1)).to.be.equal(ACTION_DELAY);
+      });
+
+      it('does not set any other action delay when executed', async () => {
+        const previousAction2Delay = await authorizer.delay(ACTION_2);
+
+        const id = await authorizer.scheduleDelayChange(ACTION_1, ACTION_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        await authorizer.execute(id);
+
+        expect(await authorizer.delay(ACTION_2)).to.be.equal(previousAction2Delay);
+      });
+
+      it('does not set the grant action delay when executed', async () => {
+        const previousGrantDelay = await authorizer.getActionIdGrantDelay(ACTION_1);
+
+        const id = await authorizer.scheduleDelayChange(ACTION_1, ACTION_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        await authorizer.execute(id);
+
+        expect(await authorizer.getActionIdGrantDelay(ACTION_1)).to.be.equal(previousGrantDelay);
+      });
+
+      it('does not set the revoke action delay when executed', async () => {
+        const previousRevokeDelay = await authorizer.getActionIdRevokeDelay(ACTION_1);
+
+        const id = await authorizer.scheduleDelayChange(ACTION_1, ACTION_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        await authorizer.execute(id);
+
+        expect(await authorizer.getActionIdRevokeDelay(ACTION_1)).to.be.equal(previousRevokeDelay);
+      });
+
+      it('emits an event', async () => {
+        const id = await authorizer.scheduleDelayChange(ACTION_1, ACTION_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        const receipt = await authorizer.execute(id);
+        expectEvent.inReceipt(await receipt.wait(), 'ActionDelaySet', { actionId: ACTION_1, delay: ACTION_DELAY });
+      });
+    }
+
+    context('when the delay is being increased', () => {
+      // When increasing the delay, the execution delay should always be the MINIMUM_EXECUTION_DELAY.
+
+      context('when there was no previous delay', () => {
+        itSchedulesTheDelayChangeCorrectly(MINIMUM_EXECUTION_DELAY);
+      });
+
+      context('when there was a previous delay set', () => {
+        sharedBeforeEach('set a previous smaller delay', async () => {
+          await authorizer.scheduleAndExecuteDelayChange(ACTION_1, ACTION_DELAY / 2, { from: root });
+        });
+
+        itSchedulesTheDelayChangeCorrectly(MINIMUM_EXECUTION_DELAY);
+      });
+    });
+
+    context('when the delay is being decreased', () => {
+      // When the delay is decreased, the execution delay should be the larger of the delay difference and
+      // MINIMUM_EXECUTION_DELAY.
+
+      context('when the previous delay was close to the new one', () => {
+        const previousDelay = ACTION_DELAY + DAY;
+
+        sharedBeforeEach(async () => {
+          await authorizer.scheduleAndExecuteDelayChange(ACTION_1, previousDelay, { from: root });
+        });
+
+        itSchedulesTheDelayChangeCorrectly(MINIMUM_EXECUTION_DELAY);
+      });
+
+      context('when the previous delay was much larger than the new one', () => {
+        const previousDelay = ACTION_DELAY + MONTH;
+
+        sharedBeforeEach(async () => {
+          await authorizer.scheduleAndExecuteDelayChange(ACTION_1, previousDelay, { from: root });
+        });
+
+        itSchedulesTheDelayChangeCorrectly(previousDelay - ACTION_DELAY);
+      });
+    });
+
+    describe('error scenarios', () => {
+      it('reverts if the sender is not root', async () => {
+        await expect(authorizer.scheduleDelayChange(ACTION_1, DAY, [], { from: other })).to.be.revertedWith(
+          'SENDER_IS_NOT_ROOT'
+        );
+      });
+
+      it('reverts if the new delay is more than 2 years', async () => {
+        await expect(
+          authorizer.scheduleDelayChange(ACTION_1, DAY * 365 * 2 + 1, [], { from: root })
+        ).to.be.revertedWith('DELAY_TOO_LARGE');
+      });
+
+      it('reverts if setDelay is called directly', async () => {
+        await expect(authorizer.instance.setDelay(ACTION_1, DAY)).to.be.revertedWith('CAN_ONLY_BE_SCHEDULED');
+      });
+
+      it('reverts if the delay is greater than the setAuthorizer delay', async () => {
+        const setAuthorizerDelay = await authorizer.delay(await actionId(vault, 'setAuthorizer'));
+        const id = await authorizer.scheduleDelayChange(ACTION_1, setAuthorizerDelay.add(1), [], { from: root });
+
+        // This condition is only tested at the time the delay is actually set (in case e.g. there was a scheduled action
+        // to change setAuthorizer's delay), so we must attempt to execute the action to get the expected revert.
+        await advanceTime(MINIMUM_EXECUTION_DELAY);
+        await expect(authorizer.execute(id)).to.be.revertedWith('DELAY_EXCEEDS_SET_AUTHORIZER');
+      });
+    });
+  });
+
+  describe('scheduleGrantDelayChange', () => {
+    const ACTION_GRANT_DELAY = DAY;
+
+    function itSchedulesTheGrantDelayChangeCorrectly(expectedExecutionDelay: number) {
+      it('schedules a grant delay change', async () => {
+        const id = await authorizer.scheduleGrantDelayChange(ACTION_1, ACTION_GRANT_DELAY, [], { from: root });
+
+        const { executed, data, where, executableAt } = await authorizer.getScheduledExecution(id);
+
+        expect(executed).to.be.false;
+        expect(data).to.be.equal(
+          authorizer.instance.interface.encodeFunctionData('setGrantDelay', [ACTION_1, ACTION_GRANT_DELAY])
+        );
+        expect(where).to.be.equal(authorizer.address);
+        expect(executableAt).to.equal((await currentTimestamp()).add(expectedExecutionDelay));
+      });
+
+      it('increases the scheduled execution count', async () => {
+        const countBefore = await authorizer.instance.getScheduledExecutionsCount();
+        await authorizer.scheduleGrantDelayChange(ACTION_1, ACTION_GRANT_DELAY, [], { from: root });
+
+        const countAfter = await authorizer.instance.getScheduledExecutionsCount();
+
+        expect(countAfter).to.equal(countBefore.add(1));
+      });
+
+      it('stores scheduler information', async () => {
+        const id = await authorizer.scheduleGrantDelayChange(ACTION_1, ACTION_GRANT_DELAY, [], { from: root });
+
+        const scheduledExecution = await authorizer.getScheduledExecution(id);
+        expect(scheduledExecution.scheduledBy).to.equal(root.address);
+        expect(scheduledExecution.scheduledAt).to.equal(await currentTimestamp());
+      });
+
+      it('stores empty executor and canceler information', async () => {
+        const id = await authorizer.scheduleGrantDelayChange(ACTION_1, ACTION_GRANT_DELAY, [], { from: root });
+
+        const scheduledExecution = await authorizer.getScheduledExecution(id);
+        expect(scheduledExecution.executedBy).to.equal(ZERO_ADDRESS);
+        expect(scheduledExecution.executedAt).to.equal(0);
+        expect(scheduledExecution.canceledBy).to.equal(ZERO_ADDRESS);
+        expect(scheduledExecution.canceledAt).to.equal(0);
+      });
+
+      it('execution can be unprotected', async () => {
+        const id = await authorizer.scheduleGrantDelayChange(ACTION_1, ACTION_GRANT_DELAY, [], { from: root });
+        const execution = await authorizer.getScheduledExecution(id);
+
+        expect(execution.protected).to.be.false;
+      });
+
+      it('execution can be protected', async () => {
+        const executors = range(4).map(() => ethers.Wallet.createRandom().address);
+        const id = await authorizer.scheduleGrantDelayChange(ACTION_1, ACTION_GRANT_DELAY, executors, { from: root });
+        const execution = await authorizer.getScheduledExecution(id);
+
+        expect(execution.protected).to.be.true;
+        await Promise.all(
+          executors.map(async (executor) => expect(await authorizer.isExecutor(id, executor)).to.be.true)
+        );
+      });
+
+      it('root can cancel the execution', async () => {
+        const id = await authorizer.scheduleGrantDelayChange(ACTION_1, ACTION_GRANT_DELAY, [], { from: root });
+        expect(await authorizer.isCanceler(id, root)).to.be.true;
+
+        const receipt = await authorizer.cancel(id, { from: root });
+        expectEvent.inReceipt(await receipt.wait(), 'ExecutionCanceled', { scheduledExecutionId: id });
+      });
+
+      it('can be executed after the expected delay', async () => {
+        const id = await authorizer.scheduleGrantDelayChange(ACTION_1, ACTION_GRANT_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        const receipt = await authorizer.execute(id);
+        expectEvent.inReceipt(await receipt.wait(), 'ExecutionExecuted', { scheduledExecutionId: id });
+      });
+
+      it('sets the new grant action delay when executed', async () => {
+        const id = await authorizer.scheduleGrantDelayChange(ACTION_1, ACTION_GRANT_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        await authorizer.execute(id);
+
+        expect(await authorizer.getActionIdGrantDelay(ACTION_1)).to.be.equal(ACTION_GRANT_DELAY);
+      });
+
+      it('does not set any other action grant delay when executed', async () => {
+        const previousAction2GrantDelay = await authorizer.getActionIdGrantDelay(ACTION_2);
+
+        const id = await authorizer.scheduleGrantDelayChange(ACTION_1, ACTION_GRANT_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        await authorizer.execute(id);
+
+        expect(await authorizer.getActionIdGrantDelay(ACTION_2)).to.be.equal(previousAction2GrantDelay);
+      });
+
+      it('does not set the action delay when executed', async () => {
+        const previousActionDelay = await authorizer.delay(ACTION_1);
+
+        const id = await authorizer.scheduleGrantDelayChange(ACTION_1, ACTION_GRANT_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        await authorizer.execute(id);
+
+        expect(await authorizer.delay(ACTION_1)).to.be.equal(previousActionDelay);
+      });
+
+      it('does not set the revoke action delay when executed', async () => {
+        const previousActionDelay = await authorizer.getActionIdRevokeDelay(ACTION_1);
+
+        const id = await authorizer.scheduleGrantDelayChange(ACTION_1, ACTION_GRANT_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        await authorizer.execute(id);
+
+        expect(await authorizer.getActionIdRevokeDelay(ACTION_1)).to.be.equal(previousActionDelay);
+      });
+
+      it('emits an event', async () => {
+        const id = await authorizer.scheduleGrantDelayChange(ACTION_1, ACTION_GRANT_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        const receipt = await authorizer.execute(id);
+        expectEvent.inReceipt(await receipt.wait(), 'GrantDelaySet', {
+          actionId: ACTION_1,
+          delay: ACTION_GRANT_DELAY,
+        });
+      });
+    }
+
+    context('when the delay is being increased', () => {
+      // When incrasing the delay, the execution delay should always be the MINIMUM_EXECUTION_DELAY.
+
+      context('when there was no previous delay', () => {
+        itSchedulesTheGrantDelayChangeCorrectly(MINIMUM_EXECUTION_DELAY);
+      });
+
+      context('when there was a previous delay set', () => {
+        sharedBeforeEach('set a previous smaller delay', async () => {
+          await authorizer.scheduleAndExecuteGrantDelayChange(ACTION_1, ACTION_GRANT_DELAY / 2, { from: root });
+        });
+
+        itSchedulesTheGrantDelayChangeCorrectly(MINIMUM_EXECUTION_DELAY);
+      });
+    });
+
+    context('when the delay is being decreased', () => {
+      // When the delay is decreased, the execution delay should be the larger of the delay difference and
+      // MINIMUM_EXECUTION_DELAY.
+
+      context('when the previous delay was close to the new one', () => {
+        const previousDelay = ACTION_GRANT_DELAY + DAY;
+
+        sharedBeforeEach(async () => {
+          await authorizer.scheduleAndExecuteGrantDelayChange(ACTION_1, previousDelay, { from: root });
+        });
+
+        itSchedulesTheGrantDelayChangeCorrectly(MINIMUM_EXECUTION_DELAY);
+      });
+
+      context('when the previous delay was much larger than the new one', () => {
+        const previousDelay = ACTION_GRANT_DELAY + MONTH;
+
+        sharedBeforeEach(async () => {
+          await authorizer.scheduleAndExecuteGrantDelayChange(ACTION_1, previousDelay, { from: root });
+        });
+
+        itSchedulesTheGrantDelayChangeCorrectly(previousDelay - ACTION_GRANT_DELAY);
+      });
+    });
+
+    describe('error scenarios', () => {
+      it('reverts if the sender is not root', async () => {
+        await expect(authorizer.scheduleGrantDelayChange(ACTION_1, DAY, [], { from: other })).to.be.revertedWith(
+          'SENDER_IS_NOT_ROOT'
+        );
+      });
+
+      it('reverts if the new delay is more than 2 years', async () => {
+        await expect(
+          authorizer.scheduleGrantDelayChange(ACTION_1, DAY * 365 * 2 + 1, [], { from: root })
+        ).to.be.revertedWith('DELAY_TOO_LARGE');
+      });
+
+      it('reverts if setGrantDelay is called directly', async () => {
+        await expect(authorizer.instance.setGrantDelay(ACTION_1, DAY)).to.be.revertedWith('CAN_ONLY_BE_SCHEDULED');
+      });
+
+      it('reverts if the delay is greater than the setAuthorizer delay', async () => {
+        const setAuthorizerDelay = await authorizer.delay(await actionId(vault, 'setAuthorizer'));
+        const id = await authorizer.scheduleGrantDelayChange(ACTION_1, setAuthorizerDelay.add(1), [], { from: root });
+
+        // This condition is only tested at the time the delay is actually set (in case e.g. there was a scheduled action
+        // to change setAuthorizer's delay), so we must attempt to execute the action to get the expected revert.
+        await advanceTime(MINIMUM_EXECUTION_DELAY);
+        await expect(authorizer.execute(id)).to.be.revertedWith('DELAY_EXCEEDS_SET_AUTHORIZER');
+      });
+    });
+  });
+
+  describe('scheduleRevokeDelayChange', () => {
+    const ACTION_REVOKE_DELAY = DAY;
+
+    function itSchedulesTheRevokeDelayChangeCorrectly(expectedExecutionDelay: number) {
+      it('schedules a revoke delay change', async () => {
+        const id = await authorizer.scheduleRevokeDelayChange(ACTION_1, ACTION_REVOKE_DELAY, [], { from: root });
+
+        const { executed, data, where, executableAt } = await authorizer.getScheduledExecution(id);
+
+        expect(executed).to.be.false;
+        expect(data).to.be.equal(
+          authorizer.instance.interface.encodeFunctionData('setRevokeDelay', [ACTION_1, ACTION_REVOKE_DELAY])
+        );
+        expect(where).to.be.equal(authorizer.address);
+        expect(executableAt).to.equal((await currentTimestamp()).add(expectedExecutionDelay));
+      });
+
+      it('increases the scheduled execution count', async () => {
+        const countBefore = await authorizer.instance.getScheduledExecutionsCount();
+        await authorizer.scheduleRevokeDelayChange(ACTION_1, ACTION_REVOKE_DELAY, [], { from: root });
+
+        const countAfter = await authorizer.instance.getScheduledExecutionsCount();
+
+        expect(countAfter).to.equal(countBefore.add(1));
+      });
+
+      it('stores scheduler information', async () => {
+        const id = await authorizer.scheduleRevokeDelayChange(ACTION_1, ACTION_REVOKE_DELAY, [], { from: root });
+
+        const scheduledExecution = await authorizer.getScheduledExecution(id);
+        expect(scheduledExecution.scheduledBy).to.equal(root.address);
+        expect(scheduledExecution.scheduledAt).to.equal(await currentTimestamp());
+      });
+
+      it('stores empty executor and canceler information', async () => {
+        const id = await authorizer.scheduleRevokeDelayChange(ACTION_1, ACTION_REVOKE_DELAY, [], { from: root });
+
+        const scheduledExecution = await authorizer.getScheduledExecution(id);
+        expect(scheduledExecution.executedBy).to.equal(ZERO_ADDRESS);
+        expect(scheduledExecution.executedAt).to.equal(0);
+        expect(scheduledExecution.canceledBy).to.equal(ZERO_ADDRESS);
+        expect(scheduledExecution.canceledAt).to.equal(0);
+      });
+
+      it('execution can be unprotected', async () => {
+        const id = await authorizer.scheduleRevokeDelayChange(ACTION_1, ACTION_REVOKE_DELAY, [], { from: root });
+        const execution = await authorizer.getScheduledExecution(id);
+
+        expect(execution.protected).to.be.false;
+      });
+
+      it('execution can be protected', async () => {
+        const executors = range(4).map(() => ethers.Wallet.createRandom().address);
+        const id = await authorizer.scheduleRevokeDelayChange(ACTION_1, ACTION_REVOKE_DELAY, executors, { from: root });
+        const execution = await authorizer.getScheduledExecution(id);
+
+        expect(execution.protected).to.be.true;
+        await Promise.all(
+          executors.map(async (executor) => expect(await authorizer.isExecutor(id, executor)).to.be.true)
+        );
+      });
+
+      it('root can cancel the execution', async () => {
+        const id = await authorizer.scheduleRevokeDelayChange(ACTION_1, ACTION_REVOKE_DELAY, [], { from: root });
+        expect(await authorizer.isCanceler(id, root)).to.be.true;
+
+        const receipt = await authorizer.cancel(id, { from: root });
+        expectEvent.inReceipt(await receipt.wait(), 'ExecutionCanceled', { scheduledExecutionId: id });
+      });
+
+      it('can be executed after the expected delay', async () => {
+        const id = await authorizer.scheduleRevokeDelayChange(ACTION_1, ACTION_REVOKE_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        const receipt = await authorizer.execute(id);
+        expectEvent.inReceipt(await receipt.wait(), 'ExecutionExecuted', { scheduledExecutionId: id });
+      });
+
+      it('sets the new revoke action delay when executed', async () => {
+        const id = await authorizer.scheduleRevokeDelayChange(ACTION_1, ACTION_REVOKE_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        await authorizer.execute(id);
+
+        expect(await authorizer.getActionIdRevokeDelay(ACTION_1)).to.be.equal(ACTION_REVOKE_DELAY);
+      });
+
+      it('does not set any other action revoke delay when executed', async () => {
+        const previousAction2RevokeDelay = await authorizer.getActionIdRevokeDelay(ACTION_2);
+
+        const id = await authorizer.scheduleRevokeDelayChange(ACTION_1, ACTION_REVOKE_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        await authorizer.execute(id);
+
+        expect(await authorizer.getActionIdRevokeDelay(ACTION_2)).to.be.equal(previousAction2RevokeDelay);
+      });
+
+      it('does not set the action delay when executed', async () => {
+        const previousActionDelay = await authorizer.delay(ACTION_1);
+
+        const id = await authorizer.scheduleRevokeDelayChange(ACTION_1, ACTION_REVOKE_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        await authorizer.execute(id);
+
+        expect(await authorizer.delay(ACTION_1)).to.be.equal(previousActionDelay);
+      });
+
+      it('does not set the grant action delay when executed', async () => {
+        const previousActionDelay = await authorizer.getActionIdGrantDelay(ACTION_1);
+
+        const id = await authorizer.scheduleRevokeDelayChange(ACTION_1, ACTION_REVOKE_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        await authorizer.execute(id);
+
+        expect(await authorizer.getActionIdGrantDelay(ACTION_1)).to.be.equal(previousActionDelay);
+      });
+
+      it('emits an event', async () => {
+        const id = await authorizer.scheduleRevokeDelayChange(ACTION_1, ACTION_REVOKE_DELAY, [], { from: root });
+
+        await advanceTime(expectedExecutionDelay);
+        const receipt = await authorizer.execute(id);
+        expectEvent.inReceipt(await receipt.wait(), 'RevokeDelaySet', {
+          actionId: ACTION_1,
+          delay: ACTION_REVOKE_DELAY,
+        });
+      });
+    }
+
+    context('when the delay is being increased', () => {
+      // When incrasing the delay, the execution delay should always be the MINIMUM_EXECUTION_DELAY.
+
+      context('when there was no previous delay', () => {
+        itSchedulesTheRevokeDelayChangeCorrectly(MINIMUM_EXECUTION_DELAY);
+      });
+
+      context('when there was a previous delay set', () => {
+        sharedBeforeEach('set a previous smaller delay', async () => {
+          await authorizer.scheduleAndExecuteRevokeDelayChange(ACTION_1, ACTION_REVOKE_DELAY / 2, { from: root });
+        });
+
+        itSchedulesTheRevokeDelayChangeCorrectly(MINIMUM_EXECUTION_DELAY);
+      });
+    });
+
+    context('when the delay is being decreased', () => {
+      // When the delay is decreased, the execution delay should be the larger of the delay difference and
+      // MINIMUM_EXECUTION_DELAY.
+
+      context('when the previous delay was close to the new one', () => {
+        const previousDelay = ACTION_REVOKE_DELAY + DAY;
+
+        sharedBeforeEach(async () => {
+          await authorizer.scheduleAndExecuteRevokeDelayChange(ACTION_1, previousDelay, { from: root });
+        });
+
+        itSchedulesTheRevokeDelayChangeCorrectly(MINIMUM_EXECUTION_DELAY);
+      });
+
+      context('when the previous delay was much larger than the new one', () => {
+        const previousDelay = ACTION_REVOKE_DELAY + MONTH;
+
+        sharedBeforeEach(async () => {
+          await authorizer.scheduleAndExecuteRevokeDelayChange(ACTION_1, previousDelay, { from: root });
+        });
+
+        itSchedulesTheRevokeDelayChangeCorrectly(previousDelay - ACTION_REVOKE_DELAY);
+      });
+    });
+
+    describe('error scenarios', () => {
+      it('reverts if the sender is not root', async () => {
+        await expect(authorizer.scheduleRevokeDelayChange(ACTION_1, DAY, [], { from: other })).to.be.revertedWith(
+          'SENDER_IS_NOT_ROOT'
+        );
+      });
+
+      it('reverts if the new delay is more than 2 years', async () => {
+        await expect(
+          authorizer.scheduleRevokeDelayChange(ACTION_1, DAY * 365 * 2 + 1, [], { from: root })
+        ).to.be.revertedWith('DELAY_TOO_LARGE');
+      });
+
+      it('reverts if setRevokeDelay is called directly', async () => {
+        await expect(authorizer.instance.setRevokeDelay(ACTION_1, DAY)).to.be.revertedWith('CAN_ONLY_BE_SCHEDULED');
+      });
+
+      it('reverts if the delay is greater than the setAuthorizer delay', async () => {
+        const setAuthorizerDelay = await authorizer.delay(await actionId(vault, 'setAuthorizer'));
+        const id = await authorizer.scheduleRevokeDelayChange(ACTION_1, setAuthorizerDelay.add(1), [], { from: root });
+
+        // This condition is only tested at the time the delay is actually set (in case e.g. there was a scheduled action
+        // to change setAuthorizer's delay), so we must attempt to execute the action to get the expected revert.
+        await advanceTime(MINIMUM_EXECUTION_DELAY);
+        await expect(authorizer.execute(id)).to.be.revertedWith('DELAY_EXCEEDS_SET_AUTHORIZER');
+      });
+    });
+  });
+});

--- a/pkg/vault/test/authorizer/TimelockAuthorizerExecute.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerExecute.test.ts
@@ -1,0 +1,671 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import TimelockAuthorizer from '@balancer-labs/v2-helpers/src/models/authorizer/TimelockAuthorizer';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import { advanceTime, currentTimestamp, DAY } from '@balancer-labs/v2-helpers/src/time';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+import { MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+
+describe('TimelockAuthorizer execute', () => {
+  let authorizer: TimelockAuthorizer, vault: Contract, authenticatedContract: Contract;
+  let root: SignerWithAddress,
+    nextRoot: SignerWithAddress,
+    user: SignerWithAddress,
+    executor: SignerWithAddress,
+    canceler: SignerWithAddress,
+    other: SignerWithAddress,
+    account: SignerWithAddress;
+
+  const EVERYWHERE = TimelockAuthorizer.EVERYWHERE;
+  const GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID = MAX_UINT256;
+
+  before('setup signers', async () => {
+    [, root, nextRoot, executor, canceler, account, user, other] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy authorizer', async () => {
+    let authorizerContract: Contract;
+
+    ({ instance: vault, authorizer: authorizerContract } = await Vault.create({
+      admin: root,
+      nextAdmin: nextRoot.address,
+    }));
+
+    authorizer = new TimelockAuthorizer(authorizerContract, root);
+    authenticatedContract = await deploy('MockAuthenticatedContract', { args: [vault.address] });
+  });
+
+  describe('schedule', () => {
+    const delay = DAY * 5;
+    const functionData = '0x0123456789abcdef';
+
+    let action: string, data: string;
+    let anotherAuthenticatedContract: Contract;
+
+    sharedBeforeEach('deploy sample instances', async () => {
+      anotherAuthenticatedContract = await deploy('MockAuthenticatedContract', { args: [vault.address] });
+    });
+
+    sharedBeforeEach('set authorizer permission delay', async () => {
+      // We must set a delay for the `setAuthorizer` function as well to be able to give one to `protectedFunction`,
+      // which it must have in order to be able to schedule calls to it.
+      const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
+      await authorizer.scheduleAndExecuteDelayChange(setAuthorizerAction, 2 * delay, { from: root });
+    });
+
+    sharedBeforeEach('set action', async () => {
+      action = await actionId(authenticatedContract, 'protectedFunction');
+    });
+
+    sharedBeforeEach('grant permission', async () => {
+      await authorizer.grantPermission(action, user, authenticatedContract, { from: root });
+    });
+
+    sharedBeforeEach('set delay for action', async () => {
+      await authorizer.scheduleAndExecuteDelayChange(action, delay, { from: root });
+    });
+
+    const schedule = async (
+      where: Contract,
+      executors: SignerWithAddress[] | undefined = undefined
+    ): Promise<number> => {
+      data = authenticatedContract.interface.encodeFunctionData('protectedFunction', [functionData]);
+      return authorizer.schedule(where, data, executors || [], { from: user });
+    };
+
+    it('increases the scheduled execution count', async () => {
+      const countBefore = await authorizer.instance.getScheduledExecutionsCount();
+      await schedule(authenticatedContract);
+      const countAfter = await authorizer.instance.getScheduledExecutionsCount();
+
+      expect(countAfter).to.equal(countBefore.add(1));
+    });
+
+    it('stores scheduler information', async () => {
+      const id = await schedule(authenticatedContract);
+
+      const scheduledExecution = await authorizer.getScheduledExecution(id);
+      expect(scheduledExecution.scheduledBy).to.equal(user.address);
+      expect(scheduledExecution.scheduledAt).to.equal(await currentTimestamp());
+    });
+
+    it('stores empty executor and canceler information', async () => {
+      const id = await schedule(authenticatedContract);
+
+      const scheduledExecution = await authorizer.getScheduledExecution(id);
+      expect(scheduledExecution.executedBy).to.equal(ZERO_ADDRESS);
+      expect(scheduledExecution.executedAt).to.equal(0);
+      expect(scheduledExecution.canceledBy).to.equal(ZERO_ADDRESS);
+      expect(scheduledExecution.canceledAt).to.equal(0);
+    });
+
+    it('schedules a non-protected execution', async () => {
+      const id = await schedule(authenticatedContract);
+
+      const scheduledExecution = await authorizer.getScheduledExecution(id);
+      expect(scheduledExecution.executed).to.be.false;
+      expect(scheduledExecution.data).to.be.equal(data);
+      expect(scheduledExecution.where).to.be.equal(authenticatedContract.address);
+      expect(scheduledExecution.protected).to.be.false;
+      expect(scheduledExecution.executableAt).to.be.at.eq((await currentTimestamp()).add(delay));
+    });
+
+    it('can schedule with a global permission', async () => {
+      await authorizer.revokePermission(action, user, authenticatedContract, { from: root });
+      await authorizer.grantPermission(action, user, EVERYWHERE, { from: root });
+      const id = await schedule(authenticatedContract);
+
+      const scheduledExecution = await authorizer.getScheduledExecution(id);
+      expect(scheduledExecution.executed).to.be.false;
+      expect(scheduledExecution.data).to.be.equal(data);
+      expect(scheduledExecution.where).to.be.equal(authenticatedContract.address);
+      expect(scheduledExecution.protected).to.be.false;
+      expect(scheduledExecution.executableAt).to.be.at.eq((await currentTimestamp()).add(delay));
+    });
+
+    it('receives canceler status', async () => {
+      const id = await schedule(authenticatedContract);
+
+      expect(await authorizer.isCanceler(id, user)).to.be.true;
+    });
+
+    it('can cancel the action immediately', async () => {
+      const id = await schedule(authenticatedContract);
+      // should not revert
+      const receipt = await authorizer.cancel(id, { from: user });
+      expectEvent.inReceipt(await receipt.wait(), 'ExecutionCanceled', { scheduledExecutionId: id });
+    });
+
+    it('schedules the protected execution', async () => {
+      const id = await schedule(authenticatedContract, [executor]);
+
+      const scheduledExecution = await authorizer.getScheduledExecution(id);
+      expect(scheduledExecution.executed).to.be.false;
+      expect(scheduledExecution.data).to.be.equal(data);
+      expect(scheduledExecution.where).to.be.equal(authenticatedContract.address);
+      expect(scheduledExecution.protected).to.be.true;
+      expect(scheduledExecution.executableAt).to.be.at.eq((await currentTimestamp()).add(delay));
+    });
+
+    it('emits ExecutorAdded events', async () => {
+      const executors = [executor];
+      const receipt = await authorizer.instance.connect(user).schedule(
+        authenticatedContract.address,
+        data,
+        executors.map((e) => e.address)
+      );
+
+      for (const executor of executors) {
+        expectEvent.inReceipt(await receipt.wait(), 'ExecutorAdded', { executor: executor.address });
+      }
+    });
+
+    it('emits ExecutionScheduled event', async () => {
+      const receipt = await authorizer.instance.connect(user).schedule(authenticatedContract.address, data, []);
+
+      // There is no getter to fetch _scheduledExecutions.length so we don't know what the next scheduledExecutionId is
+      // that is why we hardcore value `2`
+      expectEvent.inReceipt(await receipt.wait(), 'ExecutionScheduled', { scheduledExecutionId: 2 });
+    });
+
+    it('reverts if an executor is specified twice', async () => {
+      await expect(schedule(authenticatedContract, [executor, executor])).to.be.revertedWith('DUPLICATE_EXECUTORS');
+    });
+
+    it('reverts if there is no delay set', async () => {
+      action = await actionId(authenticatedContract, 'secondProtectedFunction');
+      await authorizer.grantPermission(action, user, authenticatedContract, { from: root });
+
+      await expect(
+        authorizer.instance
+          .connect(user)
+          .schedule(
+            authenticatedContract.address,
+            authenticatedContract.interface.encodeFunctionData('secondProtectedFunction', [functionData]),
+            []
+          )
+      ).to.be.revertedWith('DELAY_IS_NOT_SET');
+    });
+
+    it('reverts if the sender has permissions for another contract', async () => {
+      await expect(schedule(anotherAuthenticatedContract)).to.be.revertedWith('SENDER_DOES_NOT_HAVE_PERMISSION');
+    });
+
+    it('reverts if the sender has permissions for another action', async () => {
+      action = await actionId(authenticatedContract, 'secondProtectedFunction');
+      await authorizer.scheduleAndExecuteDelayChange(action, delay, { from: root });
+      await expect(
+        authorizer.instance
+          .connect(user)
+          .schedule(
+            authenticatedContract.address,
+            authenticatedContract.interface.encodeFunctionData('secondProtectedFunction', [functionData]),
+            []
+          )
+      ).to.be.revertedWith('SENDER_DOES_NOT_HAVE_PERMISSION');
+    });
+
+    it('reverts if the sender does not have permission', async () => {
+      await expect(
+        authorizer.instance
+          .connect(other)
+          .schedule(
+            authenticatedContract.address,
+            authenticatedContract.interface.encodeFunctionData('protectedFunction', [functionData]),
+            []
+          )
+      ).to.be.revertedWith('SENDER_DOES_NOT_HAVE_PERMISSION');
+    });
+
+    it('reverts if the target is the authorizer', async () => {
+      const where = authorizer.instance;
+      await expect(schedule(where)).to.be.revertedWith('CANNOT_SCHEDULE_AUTHORIZER_ACTIONS');
+    });
+
+    it('reverts the target is the execution helper', async () => {
+      const where = await authorizer.instance.getTimelockExecutionHelper();
+      await expect(schedule(where)).to.be.revertedWith('ATTEMPTING_EXECUTION_HELPER_REENTRANCY');
+    });
+
+    it('reverts if schedule for EOA', async () => {
+      // we do not specify reason here because call to an EOA results in the following error:
+      // Transaction reverted without a reason
+
+      await expect(authorizer.schedule(other.address, functionData, [], { from: user })).to.be.reverted;
+    });
+
+    it('reverts if data is less than 4 bytes', async () => {
+      await expect(authorizer.schedule(authenticatedContract.address, '0x00', [], { from: user })).to.be.revertedWith(
+        'DATA_TOO_SHORT'
+      );
+    });
+  });
+
+  describe('execute', () => {
+    const delay = DAY;
+    const functionData = '0x0123456789abcdef';
+
+    sharedBeforeEach('grant protected function permission with delay', async () => {
+      // We must set a delay for the `setAuthorizer` function as well to be able to give one to `protectedFunction`,
+      // which it must have in order to be able to schedule calls to it.
+      const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
+      await authorizer.scheduleAndExecuteDelayChange(setAuthorizerAction, delay, { from: root });
+
+      const protectedFunctionAction = await actionId(authenticatedContract, 'protectedFunction');
+      await authorizer.scheduleAndExecuteDelayChange(protectedFunctionAction, delay, { from: root });
+      await authorizer.grantPermission(protectedFunctionAction, user, authenticatedContract, { from: root });
+    });
+
+    const schedule = async (executors: SignerWithAddress[] | undefined = undefined): Promise<number> => {
+      const data = authenticatedContract.interface.encodeFunctionData('protectedFunction', [functionData]);
+      return authorizer.schedule(authenticatedContract, data, executors || [], { from: user });
+    };
+
+    it('can execute an action', async () => {
+      const id = await schedule();
+      await advanceTime(delay);
+      const receipt = await authorizer.execute(id, { from: executor });
+
+      expectEvent.inIndirectReceipt(await receipt.wait(), authenticatedContract.interface, 'ProtectedFunctionCalled', {
+        data: functionData,
+      });
+    });
+
+    it('action is marked as executed', async () => {
+      const id = await schedule();
+      await advanceTime(delay);
+      await authorizer.execute(id, { from: executor });
+
+      const scheduledExecution = await authorizer.getScheduledExecution(id);
+      expect(scheduledExecution.executed).to.be.true;
+    });
+
+    it('stores executor information', async () => {
+      const id = await schedule();
+      await advanceTime(delay);
+      await authorizer.execute(id, { from: executor });
+
+      const scheduledExecution = await authorizer.getScheduledExecution(id);
+      expect(scheduledExecution.executedBy).to.equal(executor.address);
+      expect(scheduledExecution.executedAt).to.equal(await currentTimestamp());
+    });
+
+    it('stores empty canceler information', async () => {
+      const id = await schedule();
+      await advanceTime(delay);
+      await authorizer.execute(id, { from: executor });
+
+      const scheduledExecution = await authorizer.getScheduledExecution(id);
+      expect(scheduledExecution.canceledBy).to.equal(ZERO_ADDRESS);
+      expect(scheduledExecution.canceledAt).to.equal(0);
+    });
+
+    it('execute returns a correct result', async () => {
+      const id = await schedule();
+      await advanceTime(delay);
+      const ret = await authorizer.instance.connect(executor).callStatic.execute(id);
+
+      // we have to slice first 4 selector bytes from the input data to get the return data
+      expect(ret).to.be.eq(
+        '0x' + authenticatedContract.interface.encodeFunctionData('protectedFunction', [functionData]).slice(10)
+      );
+    });
+
+    context('when the action is protected', () => {
+      it('all executors can execute', async () => {
+        const id = await schedule([executor, account]);
+        await advanceTime(delay);
+
+        expect(await authorizer.isExecutor(id, executor)).to.be.true;
+        expect(await authorizer.isExecutor(id, account)).to.be.true;
+
+        const receipt = await authorizer.execute(id, { from: account });
+        expectEvent.inIndirectReceipt(
+          await receipt.wait(),
+          authenticatedContract.interface,
+          'ProtectedFunctionCalled',
+          {
+            data: functionData,
+          }
+        );
+      });
+
+      it('other cannot execute', async () => {
+        const id = await schedule([executor]);
+        await advanceTime(delay);
+
+        await expect(authorizer.execute(id, { from: other })).to.be.revertedWith('SENDER_IS_NOT_EXECUTOR');
+      });
+    });
+
+    it('can be executed by anyone if not protected', async () => {
+      const id = await schedule();
+      await advanceTime(delay);
+
+      const receipt = await authorizer.execute(id);
+
+      const scheduledExecution = await authorizer.getScheduledExecution(id);
+      expect(scheduledExecution.executed).to.be.true;
+
+      expectEvent.inIndirectReceipt(await receipt.wait(), authenticatedContract.interface, 'ProtectedFunctionCalled', {
+        data: functionData,
+      });
+    });
+
+    it('emits an event', async () => {
+      const id = await schedule();
+      await advanceTime(delay);
+      const receipt = await authorizer.execute(id, { from: executor });
+
+      expectEvent.inReceipt(await receipt.wait(), 'ExecutionExecuted', {
+        scheduledExecutionId: id,
+      });
+    });
+
+    it('cannot be executed twice', async () => {
+      const id = await schedule();
+      await advanceTime(delay);
+      await authorizer.execute(id, { from: executor });
+      await expect(authorizer.execute(id, { from: executor })).to.be.revertedWith('EXECUTION_ALREADY_EXECUTED');
+    });
+
+    it('reverts if action was canceled', async () => {
+      const id = await schedule();
+      await advanceTime(delay);
+      await authorizer.cancel(id, { from: user });
+      await expect(authorizer.execute(id, { from: executor })).to.be.revertedWith('EXECUTION_ALREADY_CANCELED');
+    });
+
+    it('reverts if the delay has not passed', async () => {
+      const id = await schedule();
+      await expect(authorizer.execute(id, { from: executor })).to.be.revertedWith('EXECUTION_NOT_YET_EXECUTABLE');
+    });
+
+    it('reverts if the scheduled id is invalid', async () => {
+      await expect(authorizer.execute(100)).to.be.revertedWith('EXECUTION_DOES_NOT_EXIST');
+    });
+  });
+
+  describe('cancel', () => {
+    const delay = DAY;
+
+    sharedBeforeEach('grant protected function permission with delay', async () => {
+      // We must set a delay for the `setAuthorizer` function as well to be able to give one to `protectedFunction`,
+      // which it must have in order to be able to schedule calls to it.
+      const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
+      await authorizer.scheduleAndExecuteDelayChange(setAuthorizerAction, delay, { from: root });
+
+      const protectedFunctionAction = await actionId(authenticatedContract, 'protectedFunction');
+      await authorizer.scheduleAndExecuteDelayChange(protectedFunctionAction, delay, { from: root });
+      await authorizer.grantPermission(protectedFunctionAction, user, authenticatedContract, { from: root });
+    });
+
+    const schedule = async (): Promise<number> => {
+      const data = authenticatedContract.interface.encodeFunctionData('protectedFunction', ['0x']);
+      const id = await authorizer.schedule(authenticatedContract, data, [], { from: user });
+      await authorizer.addCanceler(id, canceler, { from: root });
+      return id;
+    };
+
+    it('stores canceler information', async () => {
+      const id = await schedule();
+      await advanceTime(delay);
+      await authorizer.cancel(id, { from: canceler });
+
+      const scheduledExecution = await authorizer.getScheduledExecution(id);
+      expect(scheduledExecution.canceledBy).to.equal(canceler.address);
+      expect(scheduledExecution.canceledAt).to.equal(await currentTimestamp());
+    });
+
+    it('stores empty executor information', async () => {
+      const id = await schedule();
+      await advanceTime(delay);
+      await authorizer.cancel(id, { from: canceler });
+
+      const scheduledExecution = await authorizer.getScheduledExecution(id);
+      expect(scheduledExecution.executedBy).to.equal(ZERO_ADDRESS);
+      expect(scheduledExecution.executedAt).to.equal(0);
+    });
+
+    it('specific canceler can cancel the action', async () => {
+      const id = await schedule();
+      await authorizer.cancel(id, { from: canceler });
+
+      const scheduledExecution = await authorizer.getScheduledExecution(id);
+      expect(scheduledExecution.canceled).to.be.true;
+    });
+
+    it('global canceler can cancel the action', async () => {
+      await authorizer.addCanceler(GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID, canceler, { from: root });
+      const id = await authorizer.schedule(
+        authenticatedContract,
+        authenticatedContract.interface.encodeFunctionData('protectedFunction', ['0x']),
+        [],
+        { from: user }
+      );
+      await authorizer.cancel(id, { from: canceler });
+
+      const scheduledExecution = await authorizer.getScheduledExecution(id);
+      expect(scheduledExecution.canceled).to.be.true;
+    });
+
+    it('root canceler can cancel the action', async () => {
+      const id = await schedule();
+      await authorizer.cancel(id, { from: root });
+
+      const scheduledExecution = await authorizer.getScheduledExecution(id);
+      expect(scheduledExecution.canceled).to.be.true;
+    });
+
+    it('emits an event', async () => {
+      const id = await schedule();
+      const receipt = await authorizer.cancel(id, { from: canceler });
+
+      expectEvent.inReceipt(await receipt.wait(), 'ExecutionCanceled', { scheduledExecutionId: id });
+    });
+
+    it('cannot be canceled twice', async () => {
+      const id = await schedule();
+      await authorizer.cancel(id, { from: canceler });
+
+      await expect(authorizer.cancel(id, { from: canceler })).to.be.revertedWith('EXECUTION_ALREADY_CANCELED');
+    });
+
+    it('reverts if the scheduled id is invalid', async () => {
+      await expect(authorizer.cancel(100)).to.be.revertedWith('EXECUTION_DOES_NOT_EXIST');
+    });
+
+    it('reverts if action was executed', async () => {
+      const id = await schedule();
+      await advanceTime(delay);
+      await authorizer.execute(id);
+
+      await expect(authorizer.cancel(id, { from: canceler })).to.be.revertedWith('EXECUTION_ALREADY_EXECUTED');
+    });
+
+    it('reverts if sender is not canceler', async () => {
+      const id = await schedule();
+
+      await expect(authorizer.cancel(id, { from: other })).to.be.revertedWith('SENDER_IS_NOT_CANCELER');
+    });
+  });
+
+  describe('getScheduledExecutions', () => {
+    const delay = DAY * 5;
+
+    sharedBeforeEach('set authorizer permission delay', async () => {
+      // We must set a delay for the `setAuthorizer` function as well to be able to give one to `protectedFunction`,
+      // which it must have in order to be able to schedule calls to it.
+      const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
+      await authorizer.scheduleAndExecuteDelayChange(setAuthorizerAction, 2 * delay, { from: root });
+    });
+
+    sharedBeforeEach('grant permission', async () => {
+      const action = await actionId(authenticatedContract, 'protectedFunction');
+      await authorizer.grantPermission(action, user, authenticatedContract, { from: root });
+
+      await authorizer.scheduleAndExecuteDelayChange(action, delay, { from: root });
+    });
+
+    const schedule = async (functionData: string): Promise<number> => {
+      return authorizer.schedule(
+        authenticatedContract.address,
+        authenticatedContract.interface.encodeFunctionData('protectedFunction', [functionData]),
+        [],
+        { from: user }
+      );
+    };
+
+    // We will schedule 5 calls to `protectedFunction`, with data 0x00, 0x01, 0x02, etc.
+    const SCHEDULED_ENTRIES = 5;
+    // There'll be two extra entries: the one used to set the delay for setAuthorizer, and the one used to set the delay
+    // for `protectedFunction`.
+    const TOTAL_ENTRIES = SCHEDULED_ENTRIES + 2;
+
+    const LARGE_MAX_SIZE = 10; // This is more than there are total entries, so it won't affect the result
+
+    sharedBeforeEach('schedule multiple entries', async () => {
+      for (let i = 0; i < SCHEDULED_ENTRIES; ++i) {
+        await schedule(`0x0${i}`);
+      }
+    });
+
+    it('returns the number of total entries', async () => {
+      expect(await authorizer.instance.getScheduledExecutionsCount()).to.equal(TOTAL_ENTRIES);
+    });
+
+    it('reverts if the skip value is too large', async () => {
+      await expect(authorizer.instance.getScheduledExecutions(TOTAL_ENTRIES, LARGE_MAX_SIZE, false)).to.be.revertedWith(
+        'SKIP_VALUE_TOO_LARGE'
+      );
+    });
+
+    it('reverts if the maxSize value is zero', async () => {
+      await expect(authorizer.instance.getScheduledExecutions(0, 0, false)).to.be.revertedWith('ZERO_MAX_SIZE_VALUE');
+    });
+
+    context('in chronological order', () => {
+      const reverseOrder = false;
+
+      it('returns entries in chronological order', async () => {
+        const entries = await authorizer.instance.getScheduledExecutions(0, LARGE_MAX_SIZE, reverseOrder);
+
+        expect(entries.length).to.equal(TOTAL_ENTRIES);
+
+        // The first entry is the one that sets the setAuthorizer delay
+        expect(entries[0].where).to.equal(authorizer.address);
+        expect(entries[0].data).to.equal(
+          authorizer.interface.encodeFunctionData('setDelay', [await actionId(vault, 'setAuthorizer'), 2 * delay])
+        );
+
+        // The last entry is the one that we scheduled
+        expect(entries[entries.length - 1].where).to.equal(authenticatedContract.address);
+        expect(entries[entries.length - 1].data).to.equal(
+          authenticatedContract.interface.encodeFunctionData('protectedFunction', [`0x04`])
+        );
+      });
+
+      it('skips older entries', async () => {
+        // We skip the initial two entries (setDelay for setAuthorizer and setDelay for protectedFunction)
+        const entries = await authorizer.instance.getScheduledExecutions(2, LARGE_MAX_SIZE, reverseOrder);
+
+        expect(entries.length).to.equal(SCHEDULED_ENTRIES);
+
+        expect(entries[0].where).to.equal(authenticatedContract.address);
+        expect(entries[0].data).to.equal(
+          authenticatedContract.interface.encodeFunctionData('protectedFunction', [`0x00`])
+        );
+
+        // The last entry is the one that we scheduled
+        expect(entries[entries.length - 1].where).to.equal(authenticatedContract.address);
+        expect(entries[entries.length - 1].data).to.equal(
+          authenticatedContract.interface.encodeFunctionData('protectedFunction', [`0x04`])
+        );
+      });
+
+      it('trims newer entries with lower maxSize', async () => {
+        // This skips the initial two entries, but only returns 3 of the `protectedFunction` calls
+        const entries = await authorizer.instance.getScheduledExecutions(2, 3, reverseOrder);
+
+        expect(entries.length).to.equal(3);
+
+        expect(entries[0].where).to.equal(authenticatedContract.address);
+        expect(entries[0].data).to.equal(
+          authenticatedContract.interface.encodeFunctionData('protectedFunction', [`0x00`])
+        );
+
+        expect(entries[2].where).to.equal(authenticatedContract.address);
+        expect(entries[2].data).to.equal(
+          authenticatedContract.interface.encodeFunctionData('protectedFunction', [`0x02`])
+        );
+      });
+    });
+
+    context('in reverse chronological order', () => {
+      const reverseOrder = true;
+
+      it('returns entries in reverse chronological order', async () => {
+        const entries = await authorizer.instance.getScheduledExecutions(0, LARGE_MAX_SIZE, reverseOrder);
+
+        expect(entries.length).to.equal(TOTAL_ENTRIES);
+
+        // The first entry is the last one that we scheduled
+        expect(entries[0].where).to.equal(authenticatedContract.address);
+        expect(entries[0].data).to.equal(
+          authenticatedContract.interface.encodeFunctionData('protectedFunction', [`0x04`])
+        );
+
+        // The last entry is the one that sets the setAuthorizer delay
+        expect(entries[entries.length - 1].where).to.equal(authorizer.address);
+        expect(entries[entries.length - 1].data).to.equal(
+          authorizer.interface.encodeFunctionData('setDelay', [await actionId(vault, 'setAuthorizer'), 2 * delay])
+        );
+      });
+
+      it('skips newer entries', async () => {
+        // We skip the last two entries (the last two calls to `protectedFunction`)
+        const entries = await authorizer.instance.getScheduledExecutions(2, LARGE_MAX_SIZE, reverseOrder);
+
+        expect(entries.length).to.equal(TOTAL_ENTRIES - 2);
+
+        // The first entry is the third to last that we scheduled
+        expect(entries[0].where).to.equal(authenticatedContract.address);
+        expect(entries[0].data).to.equal(
+          authenticatedContract.interface.encodeFunctionData('protectedFunction', [`0x02`])
+        );
+
+        // The last entry is the one that sets the setAuthorizer delay
+        expect(entries[entries.length - 1].where).to.equal(authorizer.address);
+        expect(entries[entries.length - 1].data).to.equal(
+          authorizer.interface.encodeFunctionData('setDelay', [await actionId(vault, 'setAuthorizer'), 2 * delay])
+        );
+      });
+
+      it('trims newer entries with lower maxSize', async () => {
+        // This skips the last two calls to `protectedFunction`, but only returns 3 of the `protectedFunction` calls
+        // (trimming the two initial setup actions).
+        const entries = await authorizer.instance.getScheduledExecutions(2, 3, reverseOrder);
+
+        expect(entries.length).to.equal(3);
+
+        // This is the third to last scheduled call to `protectedFunction`
+        expect(entries[0].where).to.equal(authenticatedContract.address);
+        expect(entries[0].data).to.equal(
+          authenticatedContract.interface.encodeFunctionData('protectedFunction', [`0x02`])
+        );
+
+        // This is the first scheduled call to `protectedFunction`
+        expect(entries[2].where).to.equal(authenticatedContract.address);
+        expect(entries[2].data).to.equal(
+          authenticatedContract.interface.encodeFunctionData('protectedFunction', [`0x00`])
+        );
+      });
+    });
+  });
+});

--- a/pkg/vault/test/authorizer/TimelockAuthorizerPermissions.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerPermissions.test.ts
@@ -1,0 +1,1089 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import TimelockAuthorizer from '@balancer-labs/v2-helpers/src/models/authorizer/TimelockAuthorizer';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import { advanceTime, currentTimestamp, DAY } from '@balancer-labs/v2-helpers/src/time';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+import { randomAddress, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { range } from 'lodash';
+
+describe('TimelockAuthorizer permissions', () => {
+  let authorizer: TimelockAuthorizer, vault: Contract;
+  let root: SignerWithAddress,
+    nextRoot: SignerWithAddress,
+    revoker: SignerWithAddress,
+    granter: SignerWithAddress,
+    user: SignerWithAddress,
+    other: SignerWithAddress;
+
+  before('setup signers', async () => {
+    [, root, nextRoot, granter, revoker, user, other] = await ethers.getSigners();
+  });
+
+  const ACTION_1 = '0x0000000000000000000000000000000000000000000000000000000000000001';
+  const ACTION_2 = '0x0000000000000000000000000000000000000000000000000000000000000002';
+  const ACTION_3 = '0x0000000000000000000000000000000000000000000000000000000000000003';
+
+  const WHERE_1 = ethers.Wallet.createRandom().address;
+  const WHERE_2 = ethers.Wallet.createRandom().address;
+  const WHERE_3 = ethers.Wallet.createRandom().address;
+
+  const EVERYWHERE = TimelockAuthorizer.EVERYWHERE;
+  const NOT_WHERE = ethers.Wallet.createRandom().address;
+  const MINIMUM_EXECUTION_DELAY = 5 * DAY;
+
+  sharedBeforeEach('deploy authorizer', async () => {
+    let authorizerContract: Contract;
+
+    ({ instance: vault, authorizer: authorizerContract } = await Vault.create({
+      admin: root,
+      nextAdmin: nextRoot.address,
+    }));
+
+    authorizer = new TimelockAuthorizer(authorizerContract, root);
+  });
+
+  describe('grantPermission', () => {
+    context('when there is a delay set to grant permissions', () => {
+      const delay = DAY;
+
+      sharedBeforeEach('set delay', async () => {
+        const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
+        await authorizer.scheduleAndExecuteDelayChange(setAuthorizerAction, delay * 2, { from: root });
+        await authorizer.scheduleAndExecuteGrantDelayChange(ACTION_1, delay, { from: root });
+      });
+
+      it('reverts if requires a schedule', async () => {
+        await expect(authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: root })).to.be.revertedWith(
+          'GRANT_MUST_BE_SCHEDULED'
+        );
+      });
+    });
+
+    context('when there is a no delay set to grant permissions', () => {
+      function itGrantsPermissionCorrectly(getSender: () => SignerWithAddress) {
+        it('reverts if the sender is not the granter', async () => {
+          await expect(authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: other })).to.be.revertedWith(
+            'SENDER_IS_NOT_GRANTER'
+          );
+        });
+        context('when the target does not have the permission', () => {
+          context('when granting the permission for a contract', () => {
+            it('grants permission to perform the requested action for the requested contract', async () => {
+              await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() });
+
+              expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
+            });
+
+            it('does not grant permission to perform the requested action everywhere', async () => {
+              await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() });
+
+              expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
+            });
+
+            it('does not grant permission to perform the requested actions for other contracts', async () => {
+              await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() });
+
+              expect(await authorizer.canPerform(ACTION_1, user, NOT_WHERE)).to.be.false;
+            });
+
+            it('emits an event', async () => {
+              const receipt = await (
+                await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() })
+              ).wait();
+
+              expectEvent.inReceipt(receipt, 'PermissionGranted', {
+                actionId: ACTION_1,
+                account: user.address,
+                where: WHERE_1,
+              });
+            });
+          });
+
+          context('when granting the permission for everywhere', () => {
+            it('grants the permission to perform the requested action everywhere', async () => {
+              await authorizer.grantPermissionGlobally(ACTION_1, user, { from: getSender() });
+
+              expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.true;
+              expect(await authorizer.canPerform(ACTION_2, user, EVERYWHERE)).to.be.false;
+            });
+
+            it('grants permission to perform the requested action in any specific contract', async () => {
+              await authorizer.grantPermissionGlobally(ACTION_1, user, { from: getSender() });
+
+              expect(await authorizer.canPerform(ACTION_1, user, NOT_WHERE)).to.be.true;
+              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
+            });
+
+            it('emits an event', async () => {
+              const receipt = await (
+                await authorizer.grantPermissionGlobally(ACTION_1, user, { from: getSender() })
+              ).wait();
+
+              expectEvent.inReceipt(receipt, 'PermissionGranted', {
+                actionId: ACTION_1,
+                account: user.address,
+                where: TimelockAuthorizer.EVERYWHERE,
+              });
+            });
+          });
+        });
+
+        context('when the target has the permission for a contract', () => {
+          sharedBeforeEach('grant a permission', async () => {
+            await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() });
+          });
+
+          it('cannot grant the permission twice', async () => {
+            await expect(authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() })).to.be.revertedWith(
+              'PERMISSION_ALREADY_GRANTED'
+            );
+          });
+
+          context('when granting the permission for everywhere', () => {
+            it('grants permission to perform the requested action everywhere', async () => {
+              await authorizer.grantPermissionGlobally(ACTION_1, user, { from: getSender() });
+
+              expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.true;
+              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
+            });
+
+            it('emits an event', async () => {
+              const receipt = await (
+                await authorizer.grantPermissionGlobally(ACTION_1, user, { from: getSender() })
+              ).wait();
+
+              expectEvent.inReceipt(receipt, 'PermissionGranted', {
+                actionId: ACTION_1,
+                account: user.address,
+                where: TimelockAuthorizer.EVERYWHERE,
+              });
+            });
+          });
+        });
+
+        context('when the target has the permission for everywhere', () => {
+          sharedBeforeEach('grant the permission', async () => {
+            await authorizer.grantPermissionGlobally(ACTION_1, user, { from: getSender() });
+          });
+
+          context('when granting the permission for a contract', () => {
+            it('cannot grant the permission twice', async () => {
+              await expect(
+                authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() })
+              ).to.be.revertedWith('PERMISSION_ALREADY_GRANTED');
+            });
+          });
+
+          it('cannot grant the permision twice', async () => {
+            await expect(authorizer.grantPermissionGlobally(ACTION_1, user, { from: getSender() })).to.revertedWith(
+              'PERMISSION_ALREADY_GRANTED'
+            );
+          });
+        });
+      }
+
+      context('when the sender is root', () => {
+        itGrantsPermissionCorrectly(() => root);
+      });
+
+      context('when the sender is granter everywhere', () => {
+        sharedBeforeEach('makes a granter', async () => {
+          await authorizer.addGranter(ACTION_1, granter, EVERYWHERE, { from: root });
+          await authorizer.addGranter(ACTION_2, granter, EVERYWHERE, { from: root });
+        });
+        itGrantsPermissionCorrectly(() => granter);
+
+        it('cannot grant the permission in other actions', async () => {
+          await expect(authorizer.grantPermission(ACTION_3, user, WHERE_1, { from: granter })).to.be.revertedWith(
+            'SENDER_IS_NOT_GRANTER'
+          );
+        });
+      });
+
+      context('when the sender is granter at a specific contract', () => {
+        sharedBeforeEach('makes a granter', async () => {
+          await authorizer.addGranter(ACTION_1, granter, WHERE_1, { from: root });
+        });
+
+        it('reverts if the sender is not the granter', async () => {
+          await expect(authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: other })).to.be.revertedWith(
+            'SENDER_IS_NOT_GRANTER'
+          );
+        });
+
+        it('cannot grant the permission in other contracts', async () => {
+          await expect(authorizer.grantPermission(ACTION_1, user, WHERE_3, { from: granter })).to.be.revertedWith(
+            'SENDER_IS_NOT_GRANTER'
+          );
+        });
+
+        it('cannot grant the permission for other actions', async () => {
+          await expect(authorizer.grantPermission(ACTION_3, user, WHERE_1, { from: granter })).to.be.revertedWith(
+            'SENDER_IS_NOT_GRANTER'
+          );
+        });
+
+        context('when the target does not have the permission', () => {
+          context('when granting the permission for a contract', () => {
+            it('grants permission to perform the requested action for the requested contract', async () => {
+              await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter });
+
+              expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
+            });
+
+            it('does not grant permission to perform the requested action everywhere', async () => {
+              await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter });
+
+              expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
+            });
+
+            it('does not grant permission to perform the requested actions for other contracts', async () => {
+              await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter });
+
+              expect(await authorizer.canPerform(ACTION_1, user, NOT_WHERE)).to.be.false;
+            });
+
+            it('emits an event', async () => {
+              const receipt = await (
+                await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter })
+              ).wait();
+
+              expectEvent.inReceipt(receipt, 'PermissionGranted', {
+                actionId: ACTION_1,
+                account: user.address,
+                where: WHERE_1,
+              });
+            });
+          });
+        });
+
+        context('when the target has the permission for a contract', () => {
+          it('cannot grant the same permission twice', async () => {
+            await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter });
+            await expect(authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter })).to.revertedWith(
+              'PERMISSION_ALREADY_GRANTED'
+            );
+          });
+        });
+
+        context('when the target has the permission for everywhere', () => {
+          sharedBeforeEach('grant the permission', async () => {
+            await authorizer.grantPermissionGlobally(ACTION_1, user, { from: root });
+          });
+
+          context('when granting the permission for a contract', () => {
+            it('cannot grant the permission twice', async () => {
+              await expect(authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter })).to.be.revertedWith(
+                'PERMISSION_ALREADY_GRANTED'
+              );
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('scheduleGrantPermission', () => {
+    const delay = DAY;
+
+    sharedBeforeEach('set delay', async () => {
+      const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
+      await authorizer.scheduleAndExecuteDelayChange(setAuthorizerAction, delay * 2, { from: root });
+      await authorizer.scheduleAndExecuteGrantDelayChange(ACTION_1, delay, { from: root });
+    });
+
+    it('reverts if action has no grant delay', async () => {
+      await expect(authorizer.scheduleGrantPermission(ACTION_2, user, WHERE_1, [], { from: root })).to.be.revertedWith(
+        'ACTION_HAS_NO_GRANT_DELAY'
+      );
+    });
+
+    it('reverts if sender is not granter', async () => {
+      await expect(authorizer.scheduleGrantPermission(ACTION_1, user, WHERE_1, [], { from: other })).to.be.revertedWith(
+        'SENDER_IS_NOT_GRANTER'
+      );
+    });
+
+    function itScheduleGrantPermissionCorrectly(getSender: () => SignerWithAddress) {
+      it('schedules a grant permission', async () => {
+        const id = await authorizer.scheduleGrantPermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+
+        const { executed, data, where, executableAt } = await authorizer.getScheduledExecution(id);
+        expect(executed).to.be.false;
+        expect(data).to.be.equal(
+          authorizer.instance.interface.encodeFunctionData('grantPermission', [ACTION_1, user.address, WHERE_1])
+        );
+        expect(where).to.be.equal(authorizer.address);
+        expect(executableAt).to.equal((await currentTimestamp()).add(delay));
+      });
+
+      it('increases the scheduled execution count', async () => {
+        const countBefore = await authorizer.instance.getScheduledExecutionsCount();
+        await authorizer.scheduleGrantPermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+
+        const countAfter = await authorizer.instance.getScheduledExecutionsCount();
+
+        expect(countAfter).to.equal(countBefore.add(1));
+      });
+
+      it('stores scheduler information', async () => {
+        const id = await authorizer.scheduleGrantPermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+
+        const scheduledExecution = await authorizer.getScheduledExecution(id);
+        expect(scheduledExecution.scheduledBy).to.equal(getSender().address);
+        expect(scheduledExecution.scheduledAt).to.equal(await currentTimestamp());
+      });
+
+      it('stores empty executor and canceler information', async () => {
+        const id = await authorizer.scheduleGrantPermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+
+        const scheduledExecution = await authorizer.getScheduledExecution(id);
+        expect(scheduledExecution.executedBy).to.equal(ZERO_ADDRESS);
+        expect(scheduledExecution.executedAt).to.equal(0);
+        expect(scheduledExecution.canceledBy).to.equal(ZERO_ADDRESS);
+        expect(scheduledExecution.canceledAt).to.equal(0);
+      });
+
+      it('execution can be unprotected', async () => {
+        const id = await authorizer.scheduleGrantPermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+        const execution = await authorizer.getScheduledExecution(id);
+
+        expect(execution.protected).to.be.false;
+      });
+
+      it('execution can be protected', async () => {
+        const executors = range(4).map(randomAddress);
+        const id = await authorizer.scheduleGrantPermission(ACTION_1, user, WHERE_1, executors, { from: getSender() });
+        const execution = await authorizer.getScheduledExecution(id);
+
+        expect(execution.protected).to.be.true;
+        await Promise.all(
+          executors.map(async (executor) => expect(await authorizer.isExecutor(id, executor)).to.be.true)
+        );
+      });
+
+      it('granter can cancel the execution', async () => {
+        const id = await authorizer.scheduleGrantPermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+        expect(await authorizer.isCanceler(id, getSender())).to.be.true;
+
+        const receipt = await authorizer.cancel(id, { from: getSender() });
+        expectEvent.inReceipt(await receipt.wait(), 'ExecutionCanceled', { scheduledExecutionId: id });
+      });
+
+      it('can be executed after the expected delay', async () => {
+        const id = await authorizer.scheduleGrantPermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+
+        await advanceTime(delay);
+        const receipt = await authorizer.execute(id);
+        expectEvent.inReceipt(await receipt.wait(), 'ExecutionExecuted', { scheduledExecutionId: id });
+      });
+
+      it('grants the permission when executed', async () => {
+        const id = await authorizer.scheduleGrantPermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+
+        await advanceTime(delay);
+        await authorizer.execute(id);
+
+        expect(await authorizer.hasPermission(ACTION_1, user, WHERE_1)).to.be.equal(true);
+      });
+
+      it('does not grant any other permissions when executed', async () => {
+        const id = await authorizer.scheduleGrantPermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+
+        await advanceTime(delay);
+        const receipt = await authorizer.execute(id);
+
+        expectEvent.inReceipt(await receipt.wait(), 'PermissionGranted', {
+          actionId: ACTION_1,
+          account: user.address,
+          where: WHERE_1,
+        });
+
+        expect(await authorizer.hasPermission(ACTION_3, user, WHERE_1)).to.be.equal(false);
+        expect(await authorizer.hasPermission(ACTION_2, user, WHERE_2)).to.be.equal(false);
+      });
+
+      it('emits an event', async () => {
+        const receipt = await authorizer.instance
+          .connect(getSender())
+          .scheduleGrantPermission(ACTION_1, user.address, WHERE_1, []);
+
+        expectEvent.inReceipt(await receipt.wait(), 'GrantPermissionScheduled', {
+          actionId: ACTION_1,
+          account: user.address,
+          where: WHERE_1,
+        });
+      });
+    }
+
+    context('when the sender is root', () => {
+      itScheduleGrantPermissionCorrectly(() => root);
+    });
+
+    context('when the sender is granter everywhere', () => {
+      sharedBeforeEach('makes a granter', async () => {
+        await authorizer.addGranter(ACTION_1, granter, EVERYWHERE, { from: root });
+      });
+
+      it('cannot grant the permission for other actions', async () => {
+        await expect(
+          authorizer.scheduleGrantPermission(ACTION_3, user, WHERE_1, [], { from: granter })
+        ).to.be.revertedWith('SENDER_IS_NOT_GRANTER');
+      });
+
+      itScheduleGrantPermissionCorrectly(() => granter);
+    });
+
+    context('when the sender is granter for a specific contract', () => {
+      sharedBeforeEach('makes a granter', async () => {
+        await authorizer.addGranter(ACTION_1, granter, WHERE_1, { from: root });
+      });
+
+      it('cannot grant the permission in other contracts', async () => {
+        await expect(
+          authorizer.scheduleGrantPermission(ACTION_1, user, WHERE_3, [], { from: granter })
+        ).to.be.revertedWith('SENDER_IS_NOT_GRANTER');
+      });
+
+      it('cannot grant the permission for other actions', async () => {
+        await expect(
+          authorizer.scheduleGrantPermission(ACTION_3, user, WHERE_1, [], { from: granter })
+        ).to.be.revertedWith('SENDER_IS_NOT_GRANTER');
+      });
+
+      itScheduleGrantPermissionCorrectly(() => granter);
+    });
+  });
+
+  describe('revokePermission', () => {
+    const delay = DAY;
+
+    context('when there is a delay set to revoke permissions', () => {
+      sharedBeforeEach('set delay', async () => {
+        const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
+        await authorizer.scheduleAndExecuteDelayChange(setAuthorizerAction, delay * 2, { from: root });
+        await authorizer.scheduleAndExecuteRevokeDelayChange(ACTION_1, delay, { from: root });
+      });
+
+      it('reverts if requires a schedule', async () => {
+        await expect(authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: root })).to.be.revertedWith(
+          'REVOKE_MUST_BE_SCHEDULED'
+        );
+      });
+    });
+
+    context('when there is a no delay set to revoke permissions', () => {
+      it('reverts if the sender is not the revoker', async () => {
+        await expect(authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: revoker })).to.be.revertedWith(
+          'SENDER_IS_NOT_REVOKER'
+        );
+      });
+
+      function itRevokesPermissionCorrectly(getSender: () => SignerWithAddress) {
+        context('when the user does not have the permission', () => {
+          it('cannot revoke the permission', async () => {
+            await expect(
+              authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: getSender() })
+            ).to.be.revertedWith('PERMISSION_NOT_GRANTED');
+          });
+
+          it('cannot perform the requested action everywhere', async () => {
+            expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
+            expect(await authorizer.canPerform(ACTION_2, user, EVERYWHERE)).to.be.false;
+          });
+
+          it('cannot perform the requested action in any specific contract', async () => {
+            expect(await authorizer.canPerform(ACTION_1, user, NOT_WHERE)).to.be.false;
+            expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
+          });
+        });
+
+        context('when the user has the permission for a contract', () => {
+          sharedBeforeEach('grants the permission', async () => {
+            await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: root });
+          });
+
+          context('when revoking the permission for a contract', () => {
+            it('revokes the requested permission for the requested contract', async () => {
+              await authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: getSender() });
+
+              expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.false;
+              expect(await authorizer.canPerform(ACTION_2, user, WHERE_1)).to.be.false;
+              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
+              expect(await authorizer.canPerform(ACTION_2, user, WHERE_2)).to.be.false;
+            });
+
+            it('still cannot perform the requested action everywhere', async () => {
+              await authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: getSender() });
+
+              expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canPerform(ACTION_2, user, EVERYWHERE)).to.be.false;
+            });
+
+            it('emits an event', async () => {
+              const receipt = await (
+                await authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: getSender() })
+              ).wait();
+
+              expectEvent.inReceipt(receipt, 'PermissionRevoked', {
+                actionId: ACTION_1,
+                account: user.address,
+                where: WHERE_1,
+              });
+            });
+          });
+
+          context('when revoking the permission for a everywhere', () => {
+            it('cannot revoke the permission', async () => {
+              await expect(
+                authorizer.revokePermissionGlobally(ACTION_1, user, { from: getSender() })
+              ).to.be.revertedWith('PERMISSION_NOT_GRANTED');
+            });
+          });
+        });
+
+        context('when the user has the permission everywhere', () => {
+          sharedBeforeEach('grants the permissions', async () => {
+            await authorizer.grantPermissionGlobally(ACTION_1, user, { from: root });
+          });
+
+          context('when revoking the permission for a contract', () => {
+            it('cannot revoke the permission', async () => {
+              await expect(
+                authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: getSender() })
+              ).to.be.revertedWith('ACCOUNT_HAS_GLOBAL_PERMISSION');
+            });
+
+            it('can perform the requested action for the requested contract', async () => {
+              expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
+              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
+            });
+
+            it('can perform the requested action everywhere', async () => {
+              expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.true;
+            });
+          });
+
+          context('when revoking the permission for a everywhere', () => {
+            it('revokes the requested global permission and cannot perform the requested action everywhere', async () => {
+              await authorizer.revokePermissionGlobally(ACTION_1, user, { from: getSender() });
+
+              expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.false;
+              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
+            });
+
+            it('cannot perform the requested action in any specific contract', async () => {
+              await authorizer.revokePermissionGlobally(ACTION_1, user, { from: getSender() });
+
+              expect(await authorizer.canPerform(ACTION_1, user, NOT_WHERE)).to.be.false;
+              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
+            });
+
+            it('emits an event', async () => {
+              const receipt = await (
+                await authorizer.revokePermissionGlobally(ACTION_1, user, { from: getSender() })
+              ).wait();
+
+              expectEvent.inReceipt(receipt, 'PermissionRevoked', {
+                actionId: ACTION_1,
+                account: user.address,
+                where: TimelockAuthorizer.EVERYWHERE,
+              });
+            });
+          });
+        });
+
+        context('when the user has the permission in a specific contract and everywhere', () => {
+          sharedBeforeEach('grants the permissions', async () => {
+            await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: root });
+            await authorizer.grantPermissionGlobally(ACTION_1, user, { from: root });
+          });
+
+          context('when revoking the permission for a contract', () => {
+            it('cannot revoke the permission', async () => {
+              await expect(
+                authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: getSender() })
+              ).to.be.revertedWith('ACCOUNT_HAS_GLOBAL_PERMISSION');
+            });
+          });
+
+          context('when revoking the permission for a everywhere', () => {
+            it('revokes the requested global permission', async () => {
+              await authorizer.revokePermissionGlobally(ACTION_1, user, { from: getSender() });
+
+              expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
+            });
+
+            it('can still perform the requested action in the specific contract', async () => {
+              await authorizer.revokePermissionGlobally(ACTION_1, user, { from: getSender() });
+
+              expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
+            });
+
+            it('emits an event', async () => {
+              const receipt = await (
+                await authorizer.revokePermissionGlobally(ACTION_1, user, { from: getSender() })
+              ).wait();
+
+              expectEvent.inReceipt(receipt, 'PermissionRevoked', {
+                actionId: ACTION_1,
+                account: user.address,
+                where: TimelockAuthorizer.EVERYWHERE,
+              });
+            });
+          });
+        });
+      }
+
+      context('when the sender is root', () => {
+        itRevokesPermissionCorrectly(() => root);
+      });
+
+      context('when the sender is revoker everywhere', () => {
+        sharedBeforeEach('makes a revoker', async () => {
+          await authorizer.addRevoker(revoker, EVERYWHERE, { from: root });
+        });
+        itRevokesPermissionCorrectly(() => revoker);
+      });
+
+      context('when the sender is revoker for a specific contract', () => {
+        sharedBeforeEach('makes a revoker', async () => {
+          await authorizer.addRevoker(revoker, WHERE_1, { from: root });
+        });
+
+        it('cannot revoke the permission in other contracts', async () => {
+          await expect(authorizer.revokePermission(ACTION_1, user, WHERE_3, { from: revoker })).to.be.revertedWith(
+            'SENDER_IS_NOT_REVOKER'
+          );
+        });
+
+        it('cannot revoke the permission if it was not granted', async () => {
+          await expect(authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: root })).to.be.revertedWith(
+            'PERMISSION_NOT_GRANTED'
+          );
+        });
+
+        context('when the user has the permission for a contract', () => {
+          sharedBeforeEach('grants the permission', async () => {
+            await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: root });
+          });
+
+          context('when revoking the permission for a contract', () => {
+            it('revokes the requested permission for the requested contract', async () => {
+              await authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: revoker });
+
+              expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.false;
+              expect(await authorizer.canPerform(ACTION_2, user, WHERE_1)).to.be.false;
+              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
+              expect(await authorizer.canPerform(ACTION_2, user, WHERE_2)).to.be.false;
+            });
+
+            it('still cannot perform the requested action everywhere', async () => {
+              await authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: revoker });
+
+              expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
+              expect(await authorizer.canPerform(ACTION_2, user, EVERYWHERE)).to.be.false;
+            });
+
+            it('emits an event', async () => {
+              const receipt = await (
+                await authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: revoker })
+              ).wait();
+
+              expectEvent.inReceipt(receipt, 'PermissionRevoked', {
+                actionId: ACTION_1,
+                account: user.address,
+                where: WHERE_1,
+              });
+            });
+          });
+        });
+
+        context('when the user has the permission everywhere', () => {
+          sharedBeforeEach('grants the permissions', async () => {
+            await authorizer.grantPermissionGlobally(ACTION_1, user, { from: root });
+          });
+
+          context('when revoking the permission for a contract', () => {
+            it('cannot revoke the permission', async () => {
+              await expect(authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: revoker })).to.be.revertedWith(
+                'ACCOUNT_HAS_GLOBAL_PERMISSION'
+              );
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('scheduleRevokePermission', () => {
+    const delay = DAY;
+
+    sharedBeforeEach('set delay', async () => {
+      const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
+      await authorizer.scheduleAndExecuteDelayChange(setAuthorizerAction, delay * 2, { from: root });
+      await authorizer.scheduleAndExecuteRevokeDelayChange(ACTION_1, delay, { from: root });
+    });
+
+    it('reverts if action has no revoke delay', async () => {
+      await expect(authorizer.scheduleRevokePermission(ACTION_2, user, WHERE_1, [], { from: root })).to.be.revertedWith(
+        'ACTION_HAS_NO_REVOKE_DELAY'
+      );
+    });
+
+    it('reverts if sender is not revoker', async () => {
+      await expect(
+        authorizer.scheduleRevokePermission(ACTION_1, user, WHERE_1, [], { from: other })
+      ).to.be.revertedWith('SENDER_IS_NOT_REVOKER');
+    });
+
+    function itScheduleRevokePermissionCorrectly(getSender: () => SignerWithAddress) {
+      it('schedules a revoke permission', async () => {
+        const id = await authorizer.scheduleRevokePermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+
+        const { executed, data, where, executableAt } = await authorizer.getScheduledExecution(id);
+        expect(executed).to.be.false;
+        expect(data).to.be.equal(
+          authorizer.instance.interface.encodeFunctionData('revokePermission', [ACTION_1, user.address, WHERE_1])
+        );
+        expect(where).to.be.equal(authorizer.address);
+        expect(executableAt).to.equal((await currentTimestamp()).add(delay));
+      });
+
+      it('increases the scheduled execution count', async () => {
+        const countBefore = await authorizer.instance.getScheduledExecutionsCount();
+        await authorizer.scheduleRevokePermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+
+        const countAfter = await authorizer.instance.getScheduledExecutionsCount();
+
+        expect(countAfter).to.equal(countBefore.add(1));
+      });
+
+      it('stores scheduler information', async () => {
+        const id = await authorizer.scheduleRevokePermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+
+        const scheduledExecution = await authorizer.getScheduledExecution(id);
+        expect(scheduledExecution.scheduledBy).to.equal(getSender().address);
+        expect(scheduledExecution.scheduledAt).to.equal(await currentTimestamp());
+      });
+
+      it('stores empty executor and canceler information', async () => {
+        const id = await authorizer.scheduleRevokePermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+
+        const scheduledExecution = await authorizer.getScheduledExecution(id);
+        expect(scheduledExecution.executedBy).to.equal(ZERO_ADDRESS);
+        expect(scheduledExecution.executedAt).to.equal(0);
+        expect(scheduledExecution.canceledBy).to.equal(ZERO_ADDRESS);
+        expect(scheduledExecution.canceledAt).to.equal(0);
+      });
+
+      it('execution can be unprotected', async () => {
+        const id = await authorizer.scheduleRevokePermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+        const execution = await authorizer.getScheduledExecution(id);
+
+        expect(execution.protected).to.be.false;
+      });
+
+      it('execution can be protected', async () => {
+        const executors = range(4).map(randomAddress);
+        const id = await authorizer.scheduleRevokePermission(ACTION_1, user, WHERE_1, executors, { from: getSender() });
+        const execution = await authorizer.getScheduledExecution(id);
+
+        expect(execution.protected).to.be.true;
+        await Promise.all(
+          executors.map(async (executor) => expect(await authorizer.isExecutor(id, executor)).to.be.true)
+        );
+      });
+
+      it('revoker can cancel the execution', async () => {
+        const id = await authorizer.scheduleRevokePermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+        expect(await authorizer.isCanceler(id, getSender())).to.be.true;
+
+        const receipt = await authorizer.cancel(id, { from: getSender() });
+        expectEvent.inReceipt(await receipt.wait(), 'ExecutionCanceled', { scheduledExecutionId: id });
+      });
+
+      it('can be executed after the expected delay', async () => {
+        // Grant the permission so we can later revoke it
+        await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: root });
+        const id = await authorizer.scheduleRevokePermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+
+        await advanceTime(delay);
+        const receipt = await authorizer.execute(id);
+        expectEvent.inReceipt(await receipt.wait(), 'ExecutionExecuted', { scheduledExecutionId: id });
+      });
+
+      it('revokes the permission when executed', async () => {
+        // grant the premission first
+        await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: root });
+
+        expect(await authorizer.hasPermission(ACTION_1, user, WHERE_1)).to.be.equal(true);
+
+        const id = await authorizer.scheduleRevokePermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+
+        await advanceTime(delay);
+        await authorizer.execute(id);
+
+        expect(await authorizer.hasPermission(ACTION_1, user, WHERE_1)).to.be.equal(false);
+      });
+
+      it('does not revoke any other permissions when executed', async () => {
+        // Grant the permission so we can later revoke it
+        await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: root });
+        const id = await authorizer.scheduleRevokePermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
+
+        await advanceTime(delay);
+        await authorizer.execute(id);
+
+        expect(await authorizer.hasPermission(ACTION_3, user, WHERE_1)).to.be.equal(false);
+        expect(await authorizer.hasPermission(ACTION_2, user, WHERE_2)).to.be.equal(false);
+      });
+
+      it('emits an event', async () => {
+        const receipt = await authorizer.instance
+          .connect(getSender())
+          .scheduleRevokePermission(ACTION_1, user.address, WHERE_1, []);
+
+        expectEvent.inReceipt(await receipt.wait(), 'RevokePermissionScheduled', {
+          actionId: ACTION_1,
+          account: user.address,
+          where: WHERE_1,
+        });
+      });
+    }
+
+    context('when the sender is root', () => {
+      itScheduleRevokePermissionCorrectly(() => root);
+    });
+
+    context('when the sender is revoker everywhere', () => {
+      sharedBeforeEach('makes a revoker', async () => {
+        await authorizer.addRevoker(revoker, EVERYWHERE, { from: root });
+      });
+      itScheduleRevokePermissionCorrectly(() => revoker);
+    });
+
+    context('when the sender is revoker for a specific contract', () => {
+      sharedBeforeEach('makes a revoker', async () => {
+        await authorizer.addRevoker(revoker, WHERE_1, { from: root });
+      });
+      itScheduleRevokePermissionCorrectly(() => revoker);
+
+      it('cannot schedule revoke the permission in other contracts', async () => {
+        await expect(
+          authorizer.scheduleRevokePermission(ACTION_1, user, WHERE_3, [], { from: revoker })
+        ).to.be.revertedWith('SENDER_IS_NOT_REVOKER');
+      });
+    });
+  });
+
+  describe('renouncePermission', () => {
+    const delay = DAY;
+    context('when the sender does not have the permission', () => {
+      context('when renouncing the permission for a specific contract', () => {
+        it('cannot renounce the permission if it was not granted', async () => {
+          await expect(authorizer.renouncePermission(ACTION_1, WHERE_1, { from: user })).to.be.revertedWith(
+            'PERMISSION_NOT_GRANTED'
+          );
+        });
+
+        it('cannot perform the requested action everywhere', async () => {
+          expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
+        });
+
+        it('cannot perform the requested action in any specific contract', async () => {
+          expect(await authorizer.canPerform(ACTION_1, user, NOT_WHERE)).to.be.false;
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
+        });
+      });
+
+      context('when renouncing the permission for everywhere', () => {
+        it('cannot renounce the permission if it was not granted', async () => {
+          await expect(authorizer.renouncePermissionGlobally(ACTION_1, { from: user })).to.be.revertedWith(
+            'PERMISSION_NOT_GRANTED'
+          );
+        });
+
+        it('cannot perform the requested action everywhere', async () => {
+          expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
+        });
+
+        it('cannot perform the requested action in any specific contract', async () => {
+          expect(await authorizer.canPerform(ACTION_1, user, NOT_WHERE)).to.be.false;
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
+        });
+      });
+    });
+
+    context('when the user has the permission for a specific contract', () => {
+      sharedBeforeEach('grants the permission', async () => {
+        await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: root });
+      });
+
+      context('when renouncing the permission for a specific contract', () => {
+        it('revokes the requested permission for the requested contract', async () => {
+          await authorizer.renouncePermission(ACTION_1, WHERE_1, { from: user });
+
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.false;
+          expect(await authorizer.canPerform(ACTION_2, user, WHERE_1)).to.be.false;
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
+          expect(await authorizer.canPerform(ACTION_2, user, WHERE_2)).to.be.false;
+        });
+
+        it('cannot perform the requested action everywhere', async () => {
+          await authorizer.renouncePermission(ACTION_1, WHERE_1, { from: user });
+
+          expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
+        });
+
+        it('can revoke even if the permission has a delay', async () => {
+          await authorizer.scheduleAndExecuteDelayChange(await actionId(vault, 'setAuthorizer'), delay, { from: root });
+          const id = await authorizer.scheduleRevokeDelayChange(ACTION_1, delay, [], { from: root });
+          await advanceTime(MINIMUM_EXECUTION_DELAY);
+          await authorizer.execute(id);
+          expect(authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: user })).to.be.revertedWith(
+            'REVOKE_MUST_BE_SCHEDULED'
+          );
+          await authorizer.renouncePermission(ACTION_1, WHERE_1, { from: user });
+
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.false;
+          expect(await authorizer.canPerform(ACTION_2, user, WHERE_1)).to.be.false;
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
+          expect(await authorizer.canPerform(ACTION_2, user, WHERE_2)).to.be.false;
+        });
+      });
+
+      context('when renouncing the permission for everywhere', () => {
+        it('cannot renounce the permission if it was not granted', async () => {
+          await expect(authorizer.renouncePermissionGlobally(ACTION_1, { from: user })).to.be.revertedWith(
+            'PERMISSION_NOT_GRANTED'
+          );
+        });
+
+        it('can perform the requested action for the requested contract', async () => {
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
+        });
+
+        it('cannot perform the requested action everywhere', async () => {
+          expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
+          expect(await authorizer.canPerform(ACTION_2, user, EVERYWHERE)).to.be.false;
+        });
+      });
+    });
+
+    context('when the user has the permission for everywhere', () => {
+      sharedBeforeEach('grants the permission', async () => {
+        await authorizer.grantPermissionGlobally(ACTION_1, user, { from: root });
+      });
+
+      context('when renouncing the permission for a specific contract', () => {
+        it('cannot renounce the permission if it was not granted', async () => {
+          await expect(authorizer.renouncePermission(ACTION_1, WHERE_1, { from: user })).to.be.revertedWith(
+            'ACCOUNT_HAS_GLOBAL_PERMISSION'
+          );
+        });
+
+        it('can perform the requested actions for the requested contract', async () => {
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
+        });
+
+        it('can perform the requested action everywhere', async () => {
+          expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.true;
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
+        });
+      });
+
+      context('when renouncing the permission for everywhere', () => {
+        it('revokes the requested permissions everywhere', async () => {
+          await authorizer.renouncePermissionGlobally(ACTION_1, { from: user });
+
+          expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
+        });
+
+        it('can revoke even if the permission has a delay', async () => {
+          await authorizer.scheduleAndExecuteDelayChange(await actionId(vault, 'setAuthorizer'), delay, { from: root });
+          const id = await authorizer.scheduleRevokeDelayChange(ACTION_1, delay, [], { from: root });
+          await advanceTime(MINIMUM_EXECUTION_DELAY);
+          await authorizer.execute(id);
+          expect(authorizer.revokePermissionGlobally(ACTION_1, user, { from: user })).to.be.revertedWith(
+            'REVOKE_MUST_BE_SCHEDULED'
+          );
+          await authorizer.renouncePermissionGlobally(ACTION_1, { from: user });
+
+          expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
+        });
+
+        it('still cannot perform the requested action in any specific contract', async () => {
+          await authorizer.renouncePermissionGlobally(ACTION_1, { from: user });
+
+          expect(await authorizer.canPerform(ACTION_1, user, NOT_WHERE)).to.be.false;
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
+        });
+      });
+    });
+
+    context('when the user has the permission for a specific contract and everywhere', () => {
+      sharedBeforeEach('grants the permission', async () => {
+        await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: root });
+        await authorizer.grantPermissionGlobally(ACTION_1, user, { from: root });
+      });
+
+      context('when renouncing the permission for a specific contract', () => {
+        it('cannot renounce the permission', async () => {
+          await expect(authorizer.renouncePermission(ACTION_1, WHERE_1, { from: user })).to.be.revertedWith(
+            'ACCOUNT_HAS_GLOBAL_PERMISSION'
+          );
+        });
+
+        it('can perform the requested actions for the requested contract', async () => {
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
+        });
+
+        it('can perform the requested action everywhere', async () => {
+          expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.true;
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
+        });
+      });
+
+      context('when renouncing the permission for everywhere', () => {
+        it('revokes the requested permissions everywhere', async () => {
+          await authorizer.renouncePermissionGlobally(ACTION_1, { from: user });
+
+          expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
+        });
+
+        it('can still perform the requested action in the specific contract', async () => {
+          await authorizer.renouncePermissionGlobally(ACTION_1, { from: user });
+
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
+        });
+
+        it('can revoke even if the permission has a delay', async () => {
+          await authorizer.scheduleAndExecuteDelayChange(await actionId(vault, 'setAuthorizer'), delay, { from: root });
+          const id = await authorizer.scheduleRevokeDelayChange(ACTION_1, delay, [], { from: root });
+          await advanceTime(MINIMUM_EXECUTION_DELAY);
+          await authorizer.execute(id);
+          expect(authorizer.revokePermissionGlobally(ACTION_1, user, { from: user })).to.be.revertedWith(
+            'REVOKE_MUST_BE_SCHEDULED'
+          );
+          await authorizer.renouncePermissionGlobally(ACTION_1, { from: user });
+
+          expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
+          expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
+        });
+      });
+    });
+  });
+});

--- a/pkg/vault/test/authorizer/TimelockAuthorizerRoot.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerRoot.test.ts
@@ -1,0 +1,152 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import TimelockAuthorizer from '@balancer-labs/v2-helpers/src/models/authorizer/TimelockAuthorizer';
+import { BigNumberish } from '@balancer-labs/v2-helpers/src/numbers';
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { advanceTime, currentTimestamp } from '@balancer-labs/v2-helpers/src/time';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+
+describe('TimelockAuthorizer root', () => {
+  let authorizer: TimelockAuthorizer;
+  let root: SignerWithAddress, nextRoot: SignerWithAddress, user: SignerWithAddress, other: SignerWithAddress;
+
+  before('setup signers', async () => {
+    [, root, nextRoot, user, other] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy authorizer', async () => {
+    const vault = await Vault.create({
+      admin: root,
+      nextAdmin: nextRoot.address,
+    });
+
+    authorizer = new TimelockAuthorizer(vault.authorizer, root);
+  });
+
+  describe('root', () => {
+    describe('setPendingRoot', () => {
+      let ROOT_CHANGE_DELAY: BigNumberish;
+
+      beforeEach('fetch root change delay', async () => {
+        ROOT_CHANGE_DELAY = await authorizer.instance.getRootTransferDelay();
+      });
+
+      it('sets the nextRoot as the pending root during construction', async () => {
+        expect(await authorizer.instance.getPendingRoot()).to.equal(nextRoot.address);
+      });
+
+      context('when scheduling root change', async () => {
+        function itSetsThePendingRootCorrectly(getNewPendingRoot: () => SignerWithAddress) {
+          it('schedules a root change', async () => {
+            const newPendingRoot: SignerWithAddress = getNewPendingRoot();
+            const expectedData = authorizer.instance.interface.encodeFunctionData('setPendingRoot', [
+              newPendingRoot.address,
+            ]);
+
+            const id = await authorizer.scheduleRootChange(newPendingRoot, [], { from: root });
+
+            const scheduledExecution = await authorizer.getScheduledExecution(id);
+            expect(scheduledExecution.executed).to.be.false;
+            expect(scheduledExecution.data).to.be.equal(expectedData);
+            expect(scheduledExecution.where).to.be.equal(authorizer.address);
+            expect(scheduledExecution.protected).to.be.false;
+            expect(scheduledExecution.executableAt).to.be.at.almostEqual(
+              (await currentTimestamp()).add(ROOT_CHANGE_DELAY)
+            );
+          });
+
+          it('can be executed after the delay', async () => {
+            const newPendingRoot: SignerWithAddress = getNewPendingRoot();
+            const id = await authorizer.scheduleRootChange(newPendingRoot, [], { from: root });
+
+            await expect(authorizer.execute(id)).to.be.revertedWith('EXECUTION_NOT_YET_EXECUTABLE');
+
+            await advanceTime(ROOT_CHANGE_DELAY);
+            await authorizer.execute(id);
+
+            expect(await authorizer.isRoot(root)).to.be.true;
+            expect(await authorizer.isPendingRoot(newPendingRoot)).to.be.true;
+          });
+
+          it('emits an event', async () => {
+            const newPendingRoot: SignerWithAddress = getNewPendingRoot();
+            let receipt = await authorizer.instance.connect(root).scheduleRootChange(newPendingRoot.address, []);
+            const event = expectEvent.inReceipt(await receipt.wait(), 'RootChangeScheduled', {
+              newRoot: newPendingRoot.address,
+            });
+
+            await advanceTime(ROOT_CHANGE_DELAY);
+            receipt = await authorizer.execute(event.args.scheduledExecutionId);
+            expectEvent.inReceipt(await receipt.wait(), 'PendingRootSet', { pendingRoot: newPendingRoot.address });
+          });
+        }
+
+        itSetsThePendingRootCorrectly(() => user);
+
+        context('starting a new root transfer while pending root is set', () => {
+          // We test this to ensure that executing an action which sets the pending root to an address which cannot
+          // call `claimRoot` won't result in the Authorizer being unable to transfer root power to a different address.
+
+          sharedBeforeEach('initiate a root transfer', async () => {
+            const id = await authorizer.scheduleRootChange(user, [], { from: root });
+            await advanceTime(ROOT_CHANGE_DELAY);
+            await authorizer.execute(id);
+          });
+
+          itSetsThePendingRootCorrectly(() => other);
+        });
+      });
+
+      it('reverts if trying to execute it directly', async () => {
+        await expect(authorizer.instance.setPendingRoot(user.address)).to.be.revertedWith('CAN_ONLY_BE_SCHEDULED');
+      });
+
+      it('reverts if the sender is not the root', async () => {
+        await expect(authorizer.scheduleRootChange(user, [], { from: user })).to.be.revertedWith('SENDER_IS_NOT_ROOT');
+      });
+    });
+
+    describe('claimRoot', () => {
+      let ROOT_CHANGE_DELAY: BigNumberish;
+
+      beforeEach('fetch root change delay', async () => {
+        ROOT_CHANGE_DELAY = await authorizer.instance.getRootTransferDelay();
+      });
+
+      sharedBeforeEach('initiate a root transfer', async () => {
+        const id = await authorizer.scheduleRootChange(user, [], { from: root });
+        await advanceTime(ROOT_CHANGE_DELAY);
+        await authorizer.execute(id);
+      });
+
+      it('transfers root powers from the current to the pending root', async () => {
+        await authorizer.claimRoot({ from: user });
+        expect(await authorizer.isRoot(root)).to.be.false;
+        expect(await authorizer.isRoot(user)).to.be.true;
+        expect(await authorizer.instance.getRoot()).to.be.eq(user.address);
+      });
+
+      it('resets the pending root address to the zero address', async () => {
+        await authorizer.claimRoot({ from: user });
+        expect(await authorizer.isPendingRoot(root)).to.be.false;
+        expect(await authorizer.isPendingRoot(user)).to.be.false;
+        expect(await authorizer.isPendingRoot(ZERO_ADDRESS)).to.be.true;
+        expect(await authorizer.instance.getPendingRoot()).to.be.eq(ZERO_ADDRESS);
+      });
+
+      it('emits an event', async () => {
+        const receipt = await authorizer.claimRoot({ from: user });
+        expectEvent.inReceipt(await receipt.wait(), 'RootSet', { root: user.address });
+        expectEvent.inReceipt(await receipt.wait(), 'PendingRootSet', { pendingRoot: ZERO_ADDRESS });
+      });
+
+      it('reverts if the sender is not the pending root', async () => {
+        await expect(authorizer.claimRoot({ from: other })).to.be.revertedWith('SENDER_IS_NOT_PENDING_ROOT');
+      });
+    });
+  });
+});

--- a/pkg/vault/test/authorizer/TimelockExecutionHelper.test.ts
+++ b/pkg/vault/test/authorizer/TimelockExecutionHelper.test.ts
@@ -1,0 +1,57 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import { fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+
+describe('TimelockExecutionHelper', () => {
+  let executionHelper: Contract, token: Contract;
+  let authorizer: SignerWithAddress, other: SignerWithAddress;
+
+  before('setup signers', async () => {
+    [, authorizer, other] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy contracts', async () => {
+    token = await deploy('v2-solidity-utils/ERC20Mock', { args: ['Token', 'TKN'] });
+    executionHelper = await deploy('TimelockExecutionHelper', { from: authorizer });
+  });
+
+  describe('execute', () => {
+    context('when the sender is the authorizer', () => {
+      it('forwards the given call', async () => {
+        const previousAmount = await token.balanceOf(other.address);
+
+        const mintAmount = fp(1);
+        await executionHelper
+          .connect(authorizer)
+          .execute(token.address, token.interface.encodeFunctionData('mint', [other.address, mintAmount]));
+
+        expect(await token.balanceOf(other.address)).to.be.equal(previousAmount.add(mintAmount));
+      });
+
+      it('reverts if the call is reentrant', async () => {
+        await expect(
+          executionHelper
+            .connect(authorizer)
+            .execute(
+              executionHelper.address,
+              executionHelper.interface.encodeFunctionData('execute', [ZERO_ADDRESS, '0x'])
+            )
+        ).to.be.revertedWith('REENTRANCY');
+      });
+    });
+
+    context('when the sender is not the authorizer', () => {
+      it('reverts', async () => {
+        await expect(executionHelper.connect(other).execute(token.address, '0x')).to.be.revertedWith(
+          'SENDER_IS_NOT_AUTHORIZER'
+        );
+      });
+    });
+  });
+});

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -1,0 +1,314 @@
+import { Interface } from 'ethers/lib/utils';
+import { BigNumber, Contract, ContractTransaction } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import * as expectEvent from '../../test/expectEvent';
+import { BigNumberish } from '../../numbers';
+import { ANY_ADDRESS } from '../../constants';
+
+import TimelockAuthorizerDeployer from './TimelockAuthorizerDeployer';
+import { TimelockAuthorizerDeployment } from './types';
+import { Account, NAry, TxParams } from '../types/types';
+import { advanceToTimestamp } from '../../time';
+
+export default class TimelockAuthorizer {
+  static EVERYWHERE = ANY_ADDRESS;
+
+  instance: Contract;
+  root: SignerWithAddress;
+
+  static async create(deployment: TimelockAuthorizerDeployment = {}): Promise<TimelockAuthorizer> {
+    return TimelockAuthorizerDeployer.deploy(deployment);
+  }
+
+  constructor(instance: Contract, root: SignerWithAddress) {
+    this.instance = instance;
+    this.root = root;
+  }
+
+  get address(): string {
+    return this.instance.address;
+  }
+
+  get interface(): Interface {
+    return this.instance.interface;
+  }
+
+  async hasPermission(action: string, account: Account, where: Account): Promise<boolean> {
+    return this.instance.hasPermission(action, this.toAddress(account), this.toAddress(where));
+  }
+
+  async isRoot(account: Account): Promise<boolean> {
+    return this.instance.isRoot(this.toAddress(account));
+  }
+
+  async isPendingRoot(account: Account): Promise<boolean> {
+    return this.instance.isPendingRoot(this.toAddress(account));
+  }
+
+  async isExecutor(scheduledExecutionId: BigNumberish, account: Account): Promise<boolean> {
+    return this.instance.isExecutor(scheduledExecutionId, this.toAddress(account));
+  }
+
+  async isCanceler(scheduledExecutionId: BigNumberish, account: Account): Promise<boolean> {
+    return this.instance.isCanceler(scheduledExecutionId, this.toAddress(account));
+  }
+
+  async delay(action: string): Promise<BigNumber> {
+    return this.instance.getActionIdDelay(action);
+  }
+
+  async getActionIdRevokeDelay(actionId: string): Promise<BigNumber> {
+    return this.instance.getActionIdRevokeDelay(actionId);
+  }
+
+  async getActionIdGrantDelay(actionId: string): Promise<BigNumber> {
+    return this.instance.getActionIdGrantDelay(actionId);
+  }
+
+  async getScheduledExecution(id: BigNumberish): Promise<{
+    executed: boolean;
+    canceled: boolean;
+    protected: boolean;
+    executableAt: BigNumber;
+    data: string;
+    where: string;
+    scheduledBy: string;
+    scheduledAt: BigNumber;
+    executedBy: string;
+    executedAt: BigNumber;
+    canceledBy: string;
+    canceledAt: BigNumber;
+  }> {
+    return this.instance.getScheduledExecution(id);
+  }
+
+  async canPerform(action: string, account: Account, where: Account): Promise<boolean> {
+    return this.instance.canPerform(action, this.toAddress(account), this.toAddress(where));
+  }
+
+  async isGranter(actionId: string, account: Account, where: Account): Promise<boolean> {
+    return this.instance.isGranter(actionId, this.toAddress(account), this.toAddress(where));
+  }
+
+  async isRevoker(account: Account, where: Account): Promise<boolean> {
+    return this.instance.isRevoker(this.toAddress(account), this.toAddress(where));
+  }
+
+  async scheduleRootChange(root: Account, executors: Account[], params?: TxParams): Promise<number> {
+    const receipt = await this.with(params).scheduleRootChange(this.toAddress(root), this.toAddresses(executors));
+    const event = expectEvent.inReceipt(await receipt.wait(), 'RootChangeScheduled', {
+      newRoot: this.toAddress(root),
+    });
+    return event.args.scheduledExecutionId;
+  }
+
+  async claimRoot(params?: TxParams): Promise<ContractTransaction> {
+    return this.with(params).claimRoot();
+  }
+
+  async scheduleDelayChange(
+    action: string,
+    delay: BigNumberish,
+    executors: Account[],
+    params?: TxParams
+  ): Promise<number> {
+    const receipt = await this.with(params).scheduleDelayChange(action, delay, this.toAddresses(executors));
+    const event = expectEvent.inReceipt(await receipt.wait(), 'DelayChangeScheduled', {
+      actionId: action,
+      newDelay: delay,
+    });
+    return event.args.scheduledExecutionId;
+  }
+
+  async scheduleGrantDelayChange(
+    action: string,
+    delay: BigNumberish,
+    executors: Account[],
+    params?: TxParams
+  ): Promise<number> {
+    const receipt = await this.with(params).scheduleGrantDelayChange(action, delay, this.toAddresses(executors));
+    const event = expectEvent.inReceipt(await receipt.wait(), 'GrantDelayChangeScheduled', {
+      actionId: action,
+      newDelay: delay,
+    });
+    return event.args.scheduledExecutionId;
+  }
+
+  async scheduleRevokeDelayChange(
+    action: string,
+    delay: BigNumberish,
+    executors: Account[],
+    params?: TxParams
+  ): Promise<number> {
+    const receipt = await this.with(params).scheduleRevokeDelayChange(action, delay, this.toAddresses(executors));
+    const event = expectEvent.inReceipt(await receipt.wait(), 'RevokeDelayChangeScheduled', {
+      actionId: action,
+      newDelay: delay,
+    });
+    return event.args.scheduledExecutionId;
+  }
+
+  async schedule(where: Account, data: string, executors: Account[], params?: TxParams): Promise<number> {
+    const receipt = await this.with(params).schedule(this.toAddress(where), data, this.toAddresses(executors));
+    const event = expectEvent.inReceipt(await receipt.wait(), 'ExecutionScheduled');
+    return event.args.scheduledExecutionId;
+  }
+
+  async scheduleGrantPermission(
+    action: string,
+    account: Account,
+    where: Account,
+    executors: Account[],
+    params?: TxParams
+  ): Promise<number> {
+    const receipt = await this.with(params).scheduleGrantPermission(
+      action,
+      this.toAddress(account),
+      this.toAddress(where),
+      this.toAddresses(executors)
+    );
+
+    const event = expectEvent.inReceipt(await receipt.wait(), 'GrantPermissionScheduled', {
+      actionId: action,
+      account: this.toAddress(account),
+      where: this.toAddress(where),
+    });
+    return event.args.scheduledExecutionId;
+  }
+
+  async scheduleRevokePermission(
+    action: string,
+    account: Account,
+    where: Account,
+    executors: Account[],
+    params?: TxParams
+  ): Promise<number> {
+    const receipt = await this.with(params).scheduleRevokePermission(
+      action,
+      this.toAddress(account),
+      this.toAddress(where),
+      this.toAddresses(executors)
+    );
+
+    const event = expectEvent.inReceipt(await receipt.wait(), 'RevokePermissionScheduled', {
+      actionId: action,
+      account: this.toAddress(account),
+      where: this.toAddress(where),
+    });
+    return event.args.scheduledExecutionId;
+  }
+
+  async execute(id: BigNumberish, params?: TxParams): Promise<ContractTransaction> {
+    return this.with(params).execute(id);
+  }
+
+  async cancel(id: BigNumberish, params?: TxParams): Promise<ContractTransaction> {
+    return this.with(params).cancel(id);
+  }
+
+  async addCanceler(
+    scheduledExecutionId: BigNumberish,
+    account: Account,
+    params?: TxParams
+  ): Promise<ContractTransaction> {
+    return this.with(params).addCanceler(scheduledExecutionId, this.toAddress(account));
+  }
+
+  async removeCanceler(
+    scheduledExecutionId: BigNumberish,
+    account: Account,
+    params?: TxParams
+  ): Promise<ContractTransaction> {
+    return this.with(params).removeCanceler(scheduledExecutionId, this.toAddress(account));
+  }
+
+  async addGranter(action: string, account: Account, where: Account, params?: TxParams): Promise<ContractTransaction> {
+    return this.with(params).addGranter(action, this.toAddress(account), this.toAddress(where));
+  }
+
+  async removeGranter(
+    action: string,
+    account: Account,
+    wheres: Account,
+    params?: TxParams
+  ): Promise<ContractTransaction> {
+    return this.with(params).removeGranter(action, this.toAddress(account), this.toAddress(wheres));
+  }
+
+  async addRevoker(account: Account, where: Account, params?: TxParams): Promise<ContractTransaction> {
+    return this.with(params).addRevoker(this.toAddress(account), this.toAddress(where));
+  }
+
+  async removeRevoker(account: Account, wheres: Account, params?: TxParams): Promise<ContractTransaction> {
+    return this.with(params).removeRevoker(this.toAddress(account), this.toAddress(wheres));
+  }
+
+  async grantPermission(
+    action: string,
+    account: Account,
+    where: Account,
+    params?: TxParams
+  ): Promise<ContractTransaction> {
+    return this.with(params).grantPermission(action, this.toAddress(account), this.toAddress(where));
+  }
+
+  async revokePermission(
+    action: string,
+    account: Account,
+    where: Account,
+    params?: TxParams
+  ): Promise<ContractTransaction> {
+    return this.with(params).revokePermission(action, this.toAddress(account), this.toAddress(where));
+  }
+
+  async renouncePermission(action: string, where: Account, params?: TxParams): Promise<ContractTransaction> {
+    return this.with(params).renouncePermission(action, this.toAddress(where));
+  }
+
+  async grantPermissionGlobally(action: string, account: Account, params?: TxParams): Promise<ContractTransaction> {
+    return this.with(params).grantPermission(action, this.toAddress(account), TimelockAuthorizer.EVERYWHERE);
+  }
+
+  async revokePermissionGlobally(action: string, account: Account, params?: TxParams): Promise<ContractTransaction> {
+    return this.with(params).revokePermission(action, this.toAddress(account), TimelockAuthorizer.EVERYWHERE);
+  }
+
+  async renouncePermissionGlobally(action: string, params: TxParams): Promise<ContractTransaction> {
+    return this.with(params).renouncePermission(action, TimelockAuthorizer.EVERYWHERE);
+  }
+
+  async scheduleAndExecuteDelayChange(action: string, delay: number, params?: TxParams): Promise<void> {
+    const id = await this.scheduleDelayChange(action, delay, [], params);
+    await advanceToTimestamp((await this.getScheduledExecution(id)).executableAt);
+    await this.execute(id);
+  }
+
+  async scheduleAndExecuteGrantDelayChange(action: string, delay: number, params?: TxParams): Promise<void> {
+    const id = await this.scheduleGrantDelayChange(action, delay, [], params);
+    await advanceToTimestamp((await this.getScheduledExecution(id)).executableAt);
+    await this.execute(id);
+  }
+
+  async scheduleAndExecuteRevokeDelayChange(action: string, delay: number, params?: TxParams): Promise<void> {
+    const id = await this.scheduleRevokeDelayChange(action, delay, [], params);
+    await advanceToTimestamp((await this.getScheduledExecution(id)).executableAt);
+    await this.execute(id);
+  }
+
+  toAddress(account: Account): string {
+    return typeof account === 'string' ? account : account.address;
+  }
+
+  toAddresses(accounts: NAry<Account>): string[] {
+    return this.toList(accounts).map(this.toAddress);
+  }
+
+  toList<T>(items: NAry<T>): T[] {
+    return Array.isArray(items) ? items : [items];
+  }
+
+  with(params: TxParams = {}): Contract {
+    return params.from ? this.instance.connect(params.from) : this.instance;
+  }
+}

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizerDeployer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizerDeployer.ts
@@ -1,0 +1,26 @@
+import { ethers } from 'hardhat';
+
+import { MONTH } from '../../time';
+import { deploy } from '../../contract';
+import { TimelockAuthorizerDeployment } from './types';
+
+import TimelockAuthorizer from './TimelockAuthorizer';
+import TypesConverter from '../types/TypesConverter';
+import { ZERO_ADDRESS } from '../../constants';
+
+export default {
+  async deploy(deployment: TimelockAuthorizerDeployment): Promise<TimelockAuthorizer> {
+    const root = deployment.root || deployment.from || (await ethers.getSigners())[0];
+    const nextRoot = deployment.nextRoot || ZERO_ADDRESS;
+    const rootTransferDelay = deployment.rootTransferDelay || MONTH;
+    const entrypoint = await deploy('MockAuthorizerAdaptorEntrypoint');
+    const args = [
+      TypesConverter.toAddress(root),
+      TypesConverter.toAddress(nextRoot),
+      entrypoint.address,
+      rootTransferDelay,
+    ];
+    const instance = await deploy('TimelockAuthorizer', { args });
+    return new TimelockAuthorizer(instance, root);
+  },
+};

--- a/pvt/helpers/src/models/authorizer/types.ts
+++ b/pvt/helpers/src/models/authorizer/types.ts
@@ -1,0 +1,12 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import { Account } from '../types/types';
+import { BigNumberish } from '../../numbers';
+
+export type TimelockAuthorizerDeployment = {
+  vault?: Account;
+  root?: SignerWithAddress;
+  nextRoot?: Account;
+  rootTransferDelay?: BigNumberish;
+  from?: SignerWithAddress;
+};


### PR DESCRIPTION
# Description

There are a few incompatibilities baked in the timelock authorizer code that won't allow us to use it as is for both V2 and V3, mostly related to the authorizer adaptor (and vault references).

I believe the best way to deal with this is to just port it over to this repository, removing the bits that we won't use for V3. The changes will be fairly simple.

To make this reviewable by humans, I'll be targeting the branch `timelock-authorizer-v3-dev` which is based off the current `main` branch. This PR just brings the code from V2 as is and is not expected to build or do anything.
We don't care about that for now; the point here is to double check that we're not introducing unwanted mistakes along the way. The code will build in a follow-up PR with smaller diff. In other words, to review just check that the files are exactly the same as in V2.

All these PRs shall be merged to the dev branch in order to keep CI healthy on main, and then we'll merge the branch to main once we're done.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A