### PR TITLE
#3 - Adding ETH tests for batch routers (Liquidity Tests)

### DIFF
--- a/pkg/vault/test/foundry/AggregatorBatchRouterE2E.t.sol
+++ b/pkg/vault/test/foundry/AggregatorBatchRouterE2E.t.sol
@@ -188,10 +188,7 @@ contract AggregatorBatchRouterE2ETest is BatchRouterE2ETest {
         vm.skip(true);
     }
 
-    function _testExitSwapSinglePathAndIntermediateRemoveLiquidityStep(
-        SwapKind,
-        bool
-    ) internal override {
+    function _testExitSwapSinglePathAndIntermediateRemoveLiquidityStep(SwapKind, bool) internal override {
         // Add/Remove liquidity operations are unsupported by the aggregate router.
         vm.skip(true);
     }

--- a/pkg/vault/test/foundry/BatchRouterE2E.t.sol
+++ b/pkg/vault/test/foundry/BatchRouterE2E.t.sol
@@ -13,6 +13,9 @@ import "@balancer-labs/v3-interfaces/contracts/vault/BatchRouterTypes.sol";
 import { BaseBatchRouterE2ETest } from "./utils/BaseBatchRouterE2ETest.sol";
 
 contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
+    bool private constant USE_ETH_TRUE = true;
+    bool private constant USE_ETH_FALSE = false;
+
     /***************************************************************************
                                 Test restrictions
     ***************************************************************************/
@@ -93,19 +96,19 @@ contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
 
     // ------ testSinglePath ------
     function testSinglePathExactIn() public {
-        _testSinglePath(SwapKind.EXACT_IN, false);
+        _testSinglePath(SwapKind.EXACT_IN, USE_ETH_FALSE);
     }
 
     function testSinglePathExactOut() public {
-        _testSinglePath(SwapKind.EXACT_OUT, false);
+        _testSinglePath(SwapKind.EXACT_OUT, USE_ETH_FALSE);
     }
 
     function testSinglePathExactInETH() public {
-        _testSinglePath(SwapKind.EXACT_IN, true);
+        _testSinglePath(SwapKind.EXACT_IN, USE_ETH_TRUE);
     }
 
     function testSinglePathExactOutETH() public {
-        _testSinglePath(SwapKind.EXACT_OUT, true);
+        _testSinglePath(SwapKind.EXACT_OUT, USE_ETH_TRUE);
     }
 
     function _testSinglePath(SwapKind kind, bool wethIsEth) internal {
@@ -125,19 +128,19 @@ contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
 
     // ------ testSinglePathIntermediateFinalSteps ------
     function testSinglePathExactInIntermediateFinalSteps() public {
-        _testSinglePathIntermediateFinalSteps(SwapKind.EXACT_IN, false);
+        _testSinglePathIntermediateFinalSteps(SwapKind.EXACT_IN, USE_ETH_FALSE);
     }
 
     function testSinglePathExactInIntermediateFinalStepsETH() public {
-        _testSinglePathIntermediateFinalSteps(SwapKind.EXACT_IN, true);
+        _testSinglePathIntermediateFinalSteps(SwapKind.EXACT_IN, USE_ETH_TRUE);
     }
 
     function testSinglePathExactOutIntermediateFinalSteps() public {
-        _testSinglePathIntermediateFinalSteps(SwapKind.EXACT_OUT, false);
+        _testSinglePathIntermediateFinalSteps(SwapKind.EXACT_OUT, USE_ETH_FALSE);
     }
 
     function testSinglePathExactOutIntermediateFinalStepsETH() public {
-        _testSinglePathIntermediateFinalSteps(SwapKind.EXACT_OUT, true);
+        _testSinglePathIntermediateFinalSteps(SwapKind.EXACT_OUT, USE_ETH_TRUE);
     }
 
     function _testSinglePathIntermediateFinalSteps(SwapKind kind, bool wethIsEth) internal {
@@ -161,19 +164,19 @@ contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
 
     // ------ testSwapMultiPathSISO ------
     function testSwapExactInMultiPathSISO() public {
-        _testSwapMultiPathSISO(SwapKind.EXACT_IN, false);
+        _testSwapMultiPathSISO(SwapKind.EXACT_IN, USE_ETH_FALSE);
     }
 
     function testSwapExactInMultiPathSISOWithETH() public {
-        _testSwapMultiPathSISO(SwapKind.EXACT_IN, true);
+        _testSwapMultiPathSISO(SwapKind.EXACT_IN, USE_ETH_TRUE);
     }
 
     function testSwapExactOutMultiPathSISO() public {
-        _testSwapMultiPathSISO(SwapKind.EXACT_OUT, false);
+        _testSwapMultiPathSISO(SwapKind.EXACT_OUT, USE_ETH_FALSE);
     }
 
     function testSwapExactOutMultiPathSISOWithETH() public {
-        _testSwapMultiPathSISO(SwapKind.EXACT_OUT, true);
+        _testSwapMultiPathSISO(SwapKind.EXACT_OUT, USE_ETH_TRUE);
     }
 
     function _testSwapMultiPathSISO(SwapKind kind, bool wethIsEth) internal {
@@ -201,19 +204,19 @@ contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
 
     // ------ testSwapMultiPathMISO ------
     function testSwapExactInMultiPathMISO() public {
-        _testSwapMultiPathMISO(SwapKind.EXACT_IN, false);
+        _testSwapMultiPathMISO(SwapKind.EXACT_IN, USE_ETH_FALSE);
     }
 
     function testSwapExactInMultiPathMISOWithETH() public {
-        _testSwapMultiPathMISO(SwapKind.EXACT_IN, true);
+        _testSwapMultiPathMISO(SwapKind.EXACT_IN, USE_ETH_TRUE);
     }
 
     function testSwapExactOutMultiPathMISO() public {
-        _testSwapMultiPathMISO(SwapKind.EXACT_OUT, false);
+        _testSwapMultiPathMISO(SwapKind.EXACT_OUT, USE_ETH_FALSE);
     }
 
     function testSwapExactOutMultiPathMISOWithETH() public {
-        _testSwapMultiPathMISO(SwapKind.EXACT_OUT, true);
+        _testSwapMultiPathMISO(SwapKind.EXACT_OUT, USE_ETH_TRUE);
     }
 
     function _testSwapMultiPathMISO(SwapKind kind, bool wethIsEth) internal {
@@ -241,19 +244,19 @@ contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
 
     // ------ testSwapMultiPathSIMO ------
     function testSwapExactInMultiPathSIMO() public {
-        _testSwapMultiPathSIMO(SwapKind.EXACT_IN, false);
+        _testSwapMultiPathSIMO(SwapKind.EXACT_IN, USE_ETH_FALSE);
     }
 
     function testSwapExactInMultiPathSIMOWithETH() public {
-        _testSwapMultiPathSIMO(SwapKind.EXACT_IN, true);
+        _testSwapMultiPathSIMO(SwapKind.EXACT_IN, USE_ETH_TRUE);
     }
 
     function testSwapExactOutMultiPathSIMO() public {
-        _testSwapMultiPathSIMO(SwapKind.EXACT_OUT, false);
+        _testSwapMultiPathSIMO(SwapKind.EXACT_OUT, USE_ETH_FALSE);
     }
 
     function testSwapExactOutMultiPathSIMOWithETH() public {
-        _testSwapMultiPathSIMO(SwapKind.EXACT_OUT, true);
+        _testSwapMultiPathSIMO(SwapKind.EXACT_OUT, USE_ETH_TRUE);
     }
 
     function _testSwapMultiPathSIMO(SwapKind kind, bool wethIsEth) internal {
@@ -281,19 +284,19 @@ contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
 
     // ------ testSwapMultiPathSIMO ------
     function testSwapExactInMultiPathMIMO() public {
-        _testSwapMultiPathMIMO(SwapKind.EXACT_IN, false);
+        _testSwapMultiPathMIMO(SwapKind.EXACT_IN, USE_ETH_FALSE);
     }
 
     function testSwapExactInMultiPathMIMOWithETH() public {
-        _testSwapMultiPathMIMO(SwapKind.EXACT_IN, true);
+        _testSwapMultiPathMIMO(SwapKind.EXACT_IN, USE_ETH_TRUE);
     }
 
     function testSwapExactOutMultiPathMIMO() public {
-        _testSwapMultiPathMIMO(SwapKind.EXACT_OUT, false);
+        _testSwapMultiPathMIMO(SwapKind.EXACT_OUT, USE_ETH_FALSE);
     }
 
     function testSwapExactOutMultiPathMIMOWithETH() public {
-        _testSwapMultiPathMIMO(SwapKind.EXACT_OUT, true);
+        _testSwapMultiPathMIMO(SwapKind.EXACT_OUT, USE_ETH_TRUE);
     }
 
     function _testSwapMultiPathMIMO(SwapKind kind, bool wethIsEth) internal {
@@ -331,19 +334,19 @@ contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
 
     // ------ testSwapMultiPathCircular ------
     function testSwapExactInMultiPathCircular() public {
-        _testSwapMultiPathCircular(SwapKind.EXACT_IN, false);
+        _testSwapMultiPathCircular(SwapKind.EXACT_IN, USE_ETH_FALSE);
     }
 
     function testSwapExactInMultiPathCircularWithETH() public {
-        _testSwapMultiPathCircular(SwapKind.EXACT_IN, true);
+        _testSwapMultiPathCircular(SwapKind.EXACT_IN, USE_ETH_TRUE);
     }
 
     function testSwapExactOutMultiPathCircular() public {
-        _testSwapMultiPathCircular(SwapKind.EXACT_OUT, false);
+        _testSwapMultiPathCircular(SwapKind.EXACT_OUT, USE_ETH_FALSE);
     }
 
     function testSwapExactOutMultiPathCircularWithETH() public {
-        _testSwapMultiPathCircular(SwapKind.EXACT_OUT, true);
+        _testSwapMultiPathCircular(SwapKind.EXACT_OUT, USE_ETH_TRUE);
     }
 
     function _testSwapMultiPathCircular(SwapKind kind, bool wethIsEth) internal {
@@ -411,11 +414,11 @@ contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
 
     // ------ testWrapFirst ------
     function testWrapExactInFirst() public {
-        _testWrapFirst(SwapKind.EXACT_IN, false);
+        _testWrapFirst(SwapKind.EXACT_IN, USE_ETH_FALSE);
     }
 
     function testWrapExactInFirstWithETH() public {
-        _testWrapFirst(SwapKind.EXACT_IN, true);
+        _testWrapFirst(SwapKind.EXACT_IN, USE_ETH_TRUE);
     }
 
     function _testWrapFirst(SwapKind kind, bool wethIsEth) internal {
@@ -451,11 +454,11 @@ contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
 
     // ------ testUnwrapFirst ------
     function testUnwrapExactInFirst() public {
-        _testUnwrapFirst(SwapKind.EXACT_IN, false);
+        _testUnwrapFirst(SwapKind.EXACT_IN, USE_ETH_FALSE);
     }
 
     function testUnwrapExactInFirstWithETH() public {
-        _testUnwrapFirst(SwapKind.EXACT_IN, true);
+        _testUnwrapFirst(SwapKind.EXACT_IN, USE_ETH_TRUE);
     }
 
     function _testUnwrapFirst(SwapKind kind, bool wethIsEth) internal {
@@ -493,19 +496,19 @@ contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
 
     // ------ _testJoinSwapSinglePathAndInitialAddLiquidityStep ------
     function testJoinSwapExactInSinglePathAndInitialAddLiquidityStep() public {
-        _testJoinSwapSinglePathAndInitialAddLiquidityStep(SwapKind.EXACT_IN, false);
+        _testJoinSwapSinglePathAndInitialAddLiquidityStep(SwapKind.EXACT_IN, USE_ETH_FALSE);
     }
 
     function testJoinSwapExactInSinglePathAndInitialAddLiquidityStepETH() public {
-        _testJoinSwapSinglePathAndInitialAddLiquidityStep(SwapKind.EXACT_IN, true);
+        _testJoinSwapSinglePathAndInitialAddLiquidityStep(SwapKind.EXACT_IN, USE_ETH_TRUE);
     }
 
     function testJoinSwapExactOutSinglePathAndInitialAddLiquidityStep() public {
-        _testJoinSwapSinglePathAndInitialAddLiquidityStep(SwapKind.EXACT_OUT, false);
+        _testJoinSwapSinglePathAndInitialAddLiquidityStep(SwapKind.EXACT_OUT, USE_ETH_FALSE);
     }
 
     function testJoinSwapExactOutSinglePathAndInitialAddLiquidityStepETH() public {
-        _testJoinSwapSinglePathAndInitialAddLiquidityStep(SwapKind.EXACT_OUT, true);
+        _testJoinSwapSinglePathAndInitialAddLiquidityStep(SwapKind.EXACT_OUT, USE_ETH_TRUE);
     }
 
     function _testJoinSwapSinglePathAndInitialAddLiquidityStep(SwapKind kind, bool wethIsEth) internal virtual {
@@ -543,19 +546,19 @@ contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
 
     // ------ _testJoinSwapSinglePathAndIntermediateAddLiquidityStep ------
     function testJoinSwapExactInSinglePathAndIntermediateAddLiquidityStep() public {
-        _testJoinSwapSinglePathAndIntermediateAddLiquidityStep(SwapKind.EXACT_IN, false);
+        _testJoinSwapSinglePathAndIntermediateAddLiquidityStep(SwapKind.EXACT_IN, USE_ETH_FALSE);
     }
 
     function testJoinSwapExactInSinglePathAndIntermediateAddLiquidityStepETH() public {
-        _testJoinSwapSinglePathAndIntermediateAddLiquidityStep(SwapKind.EXACT_IN, true);
+        _testJoinSwapSinglePathAndIntermediateAddLiquidityStep(SwapKind.EXACT_IN, USE_ETH_TRUE);
     }
 
     function testJoinSwapExactOutSinglePathAndIntermediateAddLiquidityStep() public {
-        _testJoinSwapSinglePathAndIntermediateAddLiquidityStep(SwapKind.EXACT_OUT, false);
+        _testJoinSwapSinglePathAndIntermediateAddLiquidityStep(SwapKind.EXACT_OUT, USE_ETH_FALSE);
     }
 
     function testJoinSwapExactOutSinglePathAndIntermediateAddLiquidityStepETH() public {
-        _testJoinSwapSinglePathAndIntermediateAddLiquidityStep(SwapKind.EXACT_OUT, true);
+        _testJoinSwapSinglePathAndIntermediateAddLiquidityStep(SwapKind.EXACT_OUT, USE_ETH_TRUE);
     }
 
     function _testJoinSwapSinglePathAndIntermediateAddLiquidityStep(SwapKind kind, bool wethIsEth) internal virtual {
@@ -593,19 +596,19 @@ contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
 
     // ------ _testJoinSwapMultiPathAndInitialFinalAddLiquidityStep ------
     function testJoinSwapExactInMultiPathAndInitialFinalAddLiquidityStep() public {
-        _testJoinSwapMultiPathAndInitialFinalAddLiquidityStep(SwapKind.EXACT_IN, false);
+        _testJoinSwapMultiPathAndInitialFinalAddLiquidityStep(SwapKind.EXACT_IN, USE_ETH_FALSE);
     }
 
     function testJoinSwapExactInMultiPathAndInitialFinalAddLiquidityStepETH() public {
-        _testJoinSwapMultiPathAndInitialFinalAddLiquidityStep(SwapKind.EXACT_IN, true);
+        _testJoinSwapMultiPathAndInitialFinalAddLiquidityStep(SwapKind.EXACT_IN, USE_ETH_TRUE);
     }
 
     function testJoinSwapExactOutMultiPathAndInitialFinalAddLiquidityStep() public {
-        _testJoinSwapMultiPathAndInitialFinalAddLiquidityStep(SwapKind.EXACT_OUT, false);
+        _testJoinSwapMultiPathAndInitialFinalAddLiquidityStep(SwapKind.EXACT_OUT, USE_ETH_FALSE);
     }
 
     function testJoinSwapExactOutMultiPathAndInitialFinalAddLiquidityStepETH() public {
-        _testJoinSwapMultiPathAndInitialFinalAddLiquidityStep(SwapKind.EXACT_OUT, true);
+        _testJoinSwapMultiPathAndInitialFinalAddLiquidityStep(SwapKind.EXACT_OUT, USE_ETH_TRUE);
     }
 
     function _testJoinSwapMultiPathAndInitialFinalAddLiquidityStep(SwapKind kind, bool wethIsEth) internal virtual {
@@ -662,19 +665,19 @@ contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
 
     // ------ testExitSwapSinglePathAndInitialRemoveLiquidityStep ------
     function testExitSwapExactInSinglePathAndInitialRemoveLiquidityStep() public {
-        _testExitSwapSinglePathAndInitialRemoveLiquidityStep(SwapKind.EXACT_IN, false);
+        _testExitSwapSinglePathAndInitialRemoveLiquidityStep(SwapKind.EXACT_IN, USE_ETH_FALSE);
     }
 
     function testExitSwapExactInSinglePathAndInitialRemoveLiquidityStepETH() public {
-        _testExitSwapSinglePathAndInitialRemoveLiquidityStep(SwapKind.EXACT_IN, true);
+        _testExitSwapSinglePathAndInitialRemoveLiquidityStep(SwapKind.EXACT_IN, USE_ETH_TRUE);
     }
 
     function testExitSwapExactOutSinglePathAndInitialRemoveLiquidityStep() public {
-        _testExitSwapSinglePathAndInitialRemoveLiquidityStep(SwapKind.EXACT_OUT, false);
+        _testExitSwapSinglePathAndInitialRemoveLiquidityStep(SwapKind.EXACT_OUT, USE_ETH_FALSE);
     }
 
     function testExitSwapExactOutSinglePathAndInitialRemoveLiquidityStepETH() public {
-        _testExitSwapSinglePathAndInitialRemoveLiquidityStep(SwapKind.EXACT_OUT, true);
+        _testExitSwapSinglePathAndInitialRemoveLiquidityStep(SwapKind.EXACT_OUT, USE_ETH_TRUE);
     }
 
     function _testExitSwapSinglePathAndInitialRemoveLiquidityStep(SwapKind kind, bool wethIsEth) internal virtual {
@@ -706,19 +709,19 @@ contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
 
     // ------ testExitSwapSinglePathAndIntermediateRemoveLiquidityStep ------
     function testExitSwapExactInSinglePathAndIntermediateRemoveLiquidityStep() public {
-        _testExitSwapSinglePathAndIntermediateRemoveLiquidityStep(SwapKind.EXACT_IN, false);
+        _testExitSwapSinglePathAndIntermediateRemoveLiquidityStep(SwapKind.EXACT_IN, USE_ETH_FALSE);
     }
 
     function testExitSwapExactInSinglePathAndIntermediateRemoveLiquidityStepETH() public {
-        _testExitSwapSinglePathAndIntermediateRemoveLiquidityStep(SwapKind.EXACT_IN, true);
+        _testExitSwapSinglePathAndIntermediateRemoveLiquidityStep(SwapKind.EXACT_IN, USE_ETH_TRUE);
     }
 
     function testExitSwapExactOutSinglePathAndIntermediateRemoveLiquidityStep() public {
-        _testExitSwapSinglePathAndIntermediateRemoveLiquidityStep(SwapKind.EXACT_OUT, false);
+        _testExitSwapSinglePathAndIntermediateRemoveLiquidityStep(SwapKind.EXACT_OUT, USE_ETH_FALSE);
     }
 
     function testExitSwapExactOutSinglePathAndIntermediateRemoveLiquidityStepETH() public {
-        _testExitSwapSinglePathAndIntermediateRemoveLiquidityStep(SwapKind.EXACT_OUT, true);
+        _testExitSwapSinglePathAndIntermediateRemoveLiquidityStep(SwapKind.EXACT_OUT, USE_ETH_TRUE);
     }
 
     function _testExitSwapSinglePathAndIntermediateRemoveLiquidityStep(SwapKind kind, bool wethIsEth) internal virtual {
@@ -750,19 +753,19 @@ contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
 
     // ------ testExitSwapSinglePathAndFinalRemoveLiquidityStep ------
     function testExitSwapExactInSinglePathAndFinalRemoveLiquidityStep() public {
-        _testExitSwapSinglePathAndFinalRemoveLiquidityStep(SwapKind.EXACT_IN, false);
+        _testExitSwapSinglePathAndFinalRemoveLiquidityStep(SwapKind.EXACT_IN, USE_ETH_FALSE);
     }
 
     function testExitSwapExactInSinglePathAndFinalRemoveLiquidityStepETH() public {
-        _testExitSwapSinglePathAndFinalRemoveLiquidityStep(SwapKind.EXACT_IN, true);
+        _testExitSwapSinglePathAndFinalRemoveLiquidityStep(SwapKind.EXACT_IN, USE_ETH_TRUE);
     }
 
     function testExitSwapExactOutSinglePathAndFinalRemoveLiquidityStep() public {
-        _testExitSwapSinglePathAndFinalRemoveLiquidityStep(SwapKind.EXACT_OUT, false);
+        _testExitSwapSinglePathAndFinalRemoveLiquidityStep(SwapKind.EXACT_OUT, USE_ETH_FALSE);
     }
 
     function testExitSwapExactOutSinglePathAndFinalRemoveLiquidityStepETH() public {
-        _testExitSwapSinglePathAndFinalRemoveLiquidityStep(SwapKind.EXACT_OUT, true);
+        _testExitSwapSinglePathAndFinalRemoveLiquidityStep(SwapKind.EXACT_OUT, USE_ETH_TRUE);
     }
 
     function _testExitSwapSinglePathAndFinalRemoveLiquidityStep(SwapKind kind, bool wethIsEth) internal virtual {
@@ -791,19 +794,19 @@ contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
 
     // ------ testExitSwapMultiPathAndFinalRemoveLiquidityStep ------
     function testExitSwapExactInMultiPathAndFinalRemoveLiquidityStep() public {
-        _testExitSwapMultiPathAndFinalRemoveLiquidityStep(SwapKind.EXACT_IN, false);
+        _testExitSwapMultiPathAndFinalRemoveLiquidityStep(SwapKind.EXACT_IN, USE_ETH_FALSE);
     }
 
     function testExitSwapExactInMultiPathAndFinalRemoveLiquidityStepETH() public {
-        _testExitSwapMultiPathAndFinalRemoveLiquidityStep(SwapKind.EXACT_IN, true);
+        _testExitSwapMultiPathAndFinalRemoveLiquidityStep(SwapKind.EXACT_IN, USE_ETH_TRUE);
     }
 
     function testExitSwapExactOutMultiPathAndFinalRemoveLiquidityStep() public {
-        _testExitSwapMultiPathAndFinalRemoveLiquidityStep(SwapKind.EXACT_OUT, false);
+        _testExitSwapMultiPathAndFinalRemoveLiquidityStep(SwapKind.EXACT_OUT, USE_ETH_FALSE);
     }
 
     function testExitSwapExactOutMultiPathAndFinalRemoveLiquidityStepETH() public {
-        _testExitSwapMultiPathAndFinalRemoveLiquidityStep(SwapKind.EXACT_OUT, true);
+        _testExitSwapMultiPathAndFinalRemoveLiquidityStep(SwapKind.EXACT_OUT, USE_ETH_TRUE);
     }
 
     function _testExitSwapMultiPathAndFinalRemoveLiquidityStep(SwapKind kind, bool wethIsEth) internal virtual {
@@ -855,19 +858,19 @@ contract BatchRouterE2ETest is BaseBatchRouterE2ETest {
 
     // ------ testExitSwapMultiPathAndIntermediateRemoveLiquidityStep ------
     function testExitSwapExactInMultiPathAndIntermediateRemoveLiquidityStep() public {
-        _testExitSwapMultiPathAndIntermediateRemoveLiquidityStep(SwapKind.EXACT_IN, false);
+        _testExitSwapMultiPathAndIntermediateRemoveLiquidityStep(SwapKind.EXACT_IN, USE_ETH_FALSE);
     }
 
     function testExitSwapExactInMultiPathAndIntermediateRemoveLiquidityStepETH() public {
-        _testExitSwapMultiPathAndIntermediateRemoveLiquidityStep(SwapKind.EXACT_IN, true);
+        _testExitSwapMultiPathAndIntermediateRemoveLiquidityStep(SwapKind.EXACT_IN, USE_ETH_TRUE);
     }
 
     function testExitSwapExactOutMultiPathAndIntermediateRemoveLiquidityStep() public {
-        _testExitSwapMultiPathAndIntermediateRemoveLiquidityStep(SwapKind.EXACT_OUT, false);
+        _testExitSwapMultiPathAndIntermediateRemoveLiquidityStep(SwapKind.EXACT_OUT, USE_ETH_FALSE);
     }
 
     function testExitSwapExactOutMultiPathAndIntermediateRemoveLiquidityStepETH() public {
-        _testExitSwapMultiPathAndIntermediateRemoveLiquidityStep(SwapKind.EXACT_OUT, true);
+        _testExitSwapMultiPathAndIntermediateRemoveLiquidityStep(SwapKind.EXACT_OUT, USE_ETH_TRUE);
     }
 
     function _testExitSwapMultiPathAndIntermediateRemoveLiquidityStep(SwapKind kind, bool wethIsEth) internal virtual {


### PR DESCRIPTION
# Description

This PR adds liquidity ETH and ERC4626 tests for the batch routers. These tests mirror the ones from BatchSwap.test.ts, AggregatorBatchSwap.test.ts, and BatchSwapBaseTest.ts.

They are not intended to replace those tests. We should keep the existing ones, but all new tests should be written in these Solidity tests (or by inheriting from BaseBatchRouterE2ETest), as this approach adds universality and flexibility by testing both routers simultaneously.


<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
