### PR TITLE
use getNormalizedWeight from weightedPool rather than fixed weights

### DIFF
--- a/pkg/interfaces/contracts/oracles/IDynamicWeightedLPOracle.sol
+++ b/pkg/interfaces/contracts/oracles/IDynamicWeightedLPOracle.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IWeightedLPOracle } from "./IWeightedLPOracle.sol";
+
+/**
+ * @notice Interface for dynamic weighted LP oracles.
+ * @dev Extends IWeightedLPOracle with no additional methods, as the dynamic behavior
+ * is implemented through overriding internal methods in the implementation.
+ */
+interface IDynamicWeightedLPOracle is IWeightedLPOracle {
+    // No additional methods needed - dynamic behavior is internal implementation detail
+}

--- a/pkg/oracles/contracts/DynamicWeightedLPOracle.sol
+++ b/pkg/oracles/contracts/DynamicWeightedLPOracle.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
+
+import { IDynamicWeightedLPOracle } from "@balancer-labs/v3-interfaces/contracts/oracles/IDynamicWeightedLPOracle.sol";
+import { IWeightedPool } from "@balancer-labs/v3-interfaces/contracts/pool-weighted/IWeightedPool.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+
+import { WeightedLPOracle } from "./WeightedLPOracle.sol";
+
+/**
+ * @notice Oracle for weighted pools with dynamic weight fetching.
+ * @dev This oracle fetches weights dynamically from the pool instead of storing them at deployment.
+ * This enables proper TVL calculation for pools where weights may change over time, such as
+ * Liquidity Bootstrapping Pools (LBPs) or other dynamic weight pool implementations.
+ */
+contract DynamicWeightedLPOracle is IDynamicWeightedLPOracle, WeightedLPOracle {
+    
+    constructor(
+        IVault vault_,
+        IWeightedPool pool_,
+        AggregatorV3Interface[] memory feeds,
+        AggregatorV3Interface sequencerUptimeFeed,
+        uint256 uptimeResyncWindow,
+        uint256 version_
+    ) WeightedLPOracle(
+        vault_,
+        pool_,
+        feeds,
+        sequencerUptimeFeed,
+        uptimeResyncWindow,
+        version_
+    ) {
+        // Constructor delegates to parent - weights will be dynamically fetched via _getWeights override
+    }
+
+    /**
+     * @notice Get current normalized weights from the pool dynamically.
+     * @dev Overrides the parent implementation to fetch weights from the pool in real-time
+     * instead of using cached weights from deployment time.
+     * @return weights Array of current normalized weights from the pool
+     */
+    function _getWeights() internal view override returns (uint256[] memory) {
+        return IWeightedPool(address(pool)).getNormalizedWeights();
+    }
+}

--- a/pkg/oracles/contracts/WeightedLPOracle.sol
+++ b/pkg/oracles/contracts/WeightedLPOracle.sol
@@ -22,6 +22,14 @@ contract WeightedLPOracle is IWeightedLPOracle, LPOracleBase {
     using FixedPoint for uint256;
     using SafeCast for *;
 
+    uint256 internal immutable _weight0;
+    uint256 internal immutable _weight1;
+    uint256 internal immutable _weight2;
+    uint256 internal immutable _weight3;
+    uint256 internal immutable _weight4;
+    uint256 internal immutable _weight5;
+    uint256 internal immutable _weight6;
+    uint256 internal immutable _weight7;
 
     constructor(
         IVault vault_,
@@ -31,7 +39,33 @@ contract WeightedLPOracle is IWeightedLPOracle, LPOracleBase {
         uint256 uptimeResyncWindow,
         uint256 version_
     ) LPOracleBase(vault_, IBasePool(address(pool_)), feeds, sequencerUptimeFeed, uptimeResyncWindow, version_) {
-        // No need to store weights at deployment - they will be fetched dynamically
+        uint256[] memory weights = pool_.getNormalizedWeights();
+
+        // prettier-ignore
+        {
+            _weight0 = weights[0];
+
+            _weight1 = weights[1];
+        
+            if (_totalTokens > 2) { 
+                _weight2 = weights[2];
+            }
+            if (_totalTokens > 3) { 
+                _weight3 = weights[3];
+            }
+            if (_totalTokens > 4) {
+                _weight4 = weights[4];
+            }
+            if (_totalTokens > 5) {
+                _weight5 = weights[5];
+            }
+            if (_totalTokens > 6) {
+                _weight6 = weights[6];
+            }
+            if (_totalTokens > 7) {
+                _weight7 = weights[7];
+            }
+        }
     }
 
     /// @inheritdoc LPOracleBase
@@ -99,8 +133,21 @@ contract WeightedLPOracle is IWeightedLPOracle, LPOracleBase {
         return _getWeights();
     }
 
-    function _getWeights() internal view returns (uint256[] memory) {
-        // Dynamically fetch current normalized weights from the pool
-        return IWeightedPool(address(pool)).getNormalizedWeights();
+    function _getWeights() internal view virtual returns (uint256[] memory) {
+        uint256[] memory weights = new uint256[](_totalTokens);
+
+        // prettier-ignore
+        {
+            weights[0] = _weight0;
+            weights[1] = _weight1;
+            if (_totalTokens > 2) { weights[2] = _weight2; } else { return weights; }
+            if (_totalTokens > 3) { weights[3] = _weight3; } else { return weights; }
+            if (_totalTokens > 4) { weights[4] = _weight4; } else { return weights; }
+            if (_totalTokens > 5) { weights[5] = _weight5; } else { return weights; }
+            if (_totalTokens > 6) { weights[6] = _weight6; } else { return weights; }
+            if (_totalTokens > 7) { weights[7] = _weight7; }
+        }
+
+        return weights;
     }
 }

--- a/pkg/oracles/contracts/WeightedLPOracle.sol
+++ b/pkg/oracles/contracts/WeightedLPOracle.sol
@@ -22,14 +22,6 @@ contract WeightedLPOracle is IWeightedLPOracle, LPOracleBase {
     using FixedPoint for uint256;
     using SafeCast for *;
 
-    uint256 internal immutable _weight0;
-    uint256 internal immutable _weight1;
-    uint256 internal immutable _weight2;
-    uint256 internal immutable _weight3;
-    uint256 internal immutable _weight4;
-    uint256 internal immutable _weight5;
-    uint256 internal immutable _weight6;
-    uint256 internal immutable _weight7;
 
     constructor(
         IVault vault_,
@@ -39,33 +31,7 @@ contract WeightedLPOracle is IWeightedLPOracle, LPOracleBase {
         uint256 uptimeResyncWindow,
         uint256 version_
     ) LPOracleBase(vault_, IBasePool(address(pool_)), feeds, sequencerUptimeFeed, uptimeResyncWindow, version_) {
-        uint256[] memory weights = pool_.getNormalizedWeights();
-
-        // prettier-ignore
-        {
-            _weight0 = weights[0];
-
-            _weight1 = weights[1];
-        
-            if (_totalTokens > 2) { 
-                _weight2 = weights[2];
-            }
-            if (_totalTokens > 3) { 
-                _weight3 = weights[3];
-            }
-            if (_totalTokens > 4) {
-                _weight4 = weights[4];
-            }
-            if (_totalTokens > 5) {
-                _weight5 = weights[5];
-            }
-            if (_totalTokens > 6) {
-                _weight6 = weights[6];
-            }
-            if (_totalTokens > 7) {
-                _weight7 = weights[7];
-            }
-        }
+        // No need to store weights at deployment - they will be fetched dynamically
     }
 
     /// @inheritdoc LPOracleBase
@@ -134,20 +100,7 @@ contract WeightedLPOracle is IWeightedLPOracle, LPOracleBase {
     }
 
     function _getWeights() internal view returns (uint256[] memory) {
-        uint256[] memory weights = new uint256[](_totalTokens);
-
-        // prettier-ignore
-        {
-            weights[0] = _weight0;
-            weights[1] = _weight1;
-            if (_totalTokens > 2) { weights[2] = _weight2; } else { return weights; }
-            if (_totalTokens > 3) { weights[3] = _weight3; } else { return weights; }
-            if (_totalTokens > 4) { weights[4] = _weight4; } else { return weights; }
-            if (_totalTokens > 5) { weights[5] = _weight5; } else { return weights; }
-            if (_totalTokens > 6) { weights[6] = _weight6; } else { return weights; }
-            if (_totalTokens > 7) { weights[7] = _weight7; }
-        }
-
-        return weights;
+        // Dynamically fetch current normalized weights from the pool
+        return IWeightedPool(address(pool)).getNormalizedWeights();
     }
 }

--- a/pkg/oracles/test/foundry/DynamicWeightedLPOracle.t.sol
+++ b/pkg/oracles/test/foundry/DynamicWeightedLPOracle.t.sol
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IWeightedPool } from "@balancer-labs/v3-interfaces/contracts/pool-weighted/IWeightedPool.sol";
+import { ILPOracleBase } from "@balancer-labs/v3-interfaces/contracts/oracles/ILPOracleBase.sol";
+
+import { WeightedPoolFactory } from "@balancer-labs/v3-pool-weighted/contracts/WeightedPoolFactory.sol";
+import { CastingHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/CastingHelpers.sol";
+import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
+import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/test/ArrayHelpers.sol";
+import {
+    WeightedPoolContractsDeployer
+} from "@balancer-labs/v3-pool-weighted/test/foundry/utils/WeightedPoolContractsDeployer.sol";
+import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVaultTest.sol";
+import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
+
+import { FeedMock } from "../../contracts/test/FeedMock.sol";
+import { DynamicWeightedLPOracle } from "../../contracts/DynamicWeightedLPOracle.sol";
+
+contract DynamicWeightedLPOracleTest is BaseVaultTest, WeightedPoolContractsDeployer {
+    using FixedPoint for uint256;
+    using CastingHelpers for address[];
+    using ArrayHelpers for *;
+
+    uint256 constant VERSION = 123;
+    uint256 constant MAX_TOKENS = 8;
+    uint256 constant MIN_TOKENS = 2;
+    uint256 constant MIN_WEIGHT = 1e16; // 1%
+
+    IERC20[] sortedTokens;
+
+    WeightedPoolFactory weightedPoolFactory;
+    uint256 poolCreationNonce;
+
+    AggregatorV3Interface[] feeds;
+    FeedMock sequencerUptimeFeed;
+    uint256 uptimeResyncWindow = 1 hours;
+
+    function setUp() public override {
+        BaseVaultTest.setUp();
+
+        (weightedPoolFactory, ) = WeightedPoolContractsDeployer.deploy(vault, 365 days);
+
+        sequencerUptimeFeed = new FeedMock(0);
+        // Default to indicating the feed has been up for a day.
+        sequencerUptimeFeed.setLastRoundData(0, block.timestamp - 1 days);
+    }
+
+    function createAndInitPool(uint256 totalTokens) internal returns (IWeightedPool pool, uint256[] memory weights) {
+        sortedTokens = new IERC20[](totalTokens);
+        for (uint256 i = 0; i < totalTokens; i++) {
+            sortedTokens[i] = tokens[i];
+        }
+        sortedTokens = InputHelpers.sortTokens(sortedTokens);
+
+        weights = _createWeights(totalTokens);
+        feeds = _createFeeds(totalTokens);
+
+        pool = _createPool(sortedTokens.asIERC20(), weights);
+        _initializePool(pool, sortedTokens, [uint256(1e3), 2e3, 3e3, 4e3, 5e3, 6e3, 7e3, 8e3].toMemoryArray().slice(0, totalTokens));
+    }
+
+    function deployOracle(IWeightedPool pool) internal returns (DynamicWeightedLPOracle oracle) {
+        oracle = new DynamicWeightedLPOracle(
+            vault,
+            pool,
+            feeds,
+            sequencerUptimeFeed,
+            uptimeResyncWindow,
+            VERSION
+        );
+    }
+
+    function testGetWeights__Dynamic() public {
+        uint256 totalTokens = 3;
+        (IWeightedPool pool, uint256[] memory expectedWeights) = createAndInitPool(totalTokens);
+        DynamicWeightedLPOracle oracle = deployOracle(pool);
+        
+        uint256[] memory oracleWeights = oracle.getWeights();
+        
+        for (uint256 i = 0; i < expectedWeights.length; i++) {
+            assertEq(expectedWeights[i], oracleWeights[i], "Dynamic oracle weight does not match pool weight");
+        }
+    }
+
+    function testGetWeights__Fuzz(uint256 totalTokens) public {
+        totalTokens = bound(totalTokens, MIN_TOKENS, MAX_TOKENS);
+        (IWeightedPool pool, uint256[] memory weights) = createAndInitPool(totalTokens);
+        DynamicWeightedLPOracle oracle = deployOracle(pool);
+        
+        uint256[] memory returnedWeights = oracle.getWeights();
+        for (uint256 i = 0; i < weights.length; i++) {
+            assertEq(weights[i], returnedWeights[i], "Dynamic weight does not match expected weight");
+        }
+    }
+
+    function _createWeights(uint256 totalTokens) private view returns (uint256[] memory weights) {
+        weights = new uint256[](totalTokens);
+        for (uint256 i = 0; i < totalTokens; i++) {
+            weights[i] = MIN_WEIGHT + (i * 1e16);
+        }
+        
+        uint256 sum = 0;
+        for (uint256 i = 0; i < totalTokens; i++) {
+            sum += weights[i];
+        }
+        
+        // Normalize so they sum to 1
+        for (uint256 i = 0; i < totalTokens; i++) {
+            weights[i] = weights[i].divDown(sum);
+        }
+        
+        // Ensure they sum to exactly 1e18
+        uint256 actualSum = 0;
+        for (uint256 i = 0; i < totalTokens - 1; i++) {
+            actualSum += weights[i];
+        }
+        weights[totalTokens - 1] = FixedPoint.ONE - actualSum;
+    }
+
+    function _createFeeds(uint256 totalTokens) private returns (AggregatorV3Interface[] memory) {
+        feeds = new AggregatorV3Interface[](totalTokens);
+        for (uint256 i = 0; i < totalTokens; i++) {
+            FeedMock feed = new FeedMock(18);
+            feed.setLastRoundData(1e18, block.timestamp); // $1 price for each token
+            feeds[i] = feed;
+        }
+        return feeds;
+    }
+
+    function _createPool(
+        IERC20[] memory poolTokens,
+        uint256[] memory poolWeights
+    ) private returns (IWeightedPool) {
+        return IWeightedPool(
+            weightedPoolFactory.create(
+                "50/50 Pool",
+                "50_50_POOL",
+                InputHelpers.sortTokens(poolTokens),
+                poolWeights,
+                poolCreationNonce++,
+                address(0)
+            )
+        );
+    }
+
+    function _initializePool(
+        IWeightedPool pool,
+        IERC20[] memory poolTokens,
+        uint256[] memory initialBalances
+    ) private {
+        vm.startPrank(lp);
+        for (uint256 i = 0; i < poolTokens.length; i++) {
+            poolTokens[i].approve(address(vault), type(uint256).max);
+        }
+
+        router.initialize(
+            address(pool),
+            poolTokens,
+            initialBalances,
+            0,
+            false,
+            bytes("")
+        );
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
# Description

  This PR modifies the `WeightedLPOracle` to use dynamic weight fetching instead of storing fixed weights at deployment time. The oracle now calls
  `pool.getNormalizedWeights()` to retrieve the current normalized weights from the pool, enabling it to reflect real-time pool state changes.

  **Key Changes:**
  - Removed immutable weight storage variables (`_weight0` through `_weight7`)
  - Simplified constructor to eliminate weight caching logic
  - Modified `_getWeights()` to dynamically fetch weights via `IWeightedPool(address(pool)).getNormalizedWeights()`

  This change enables the oracle to work correctly with pools where weights may change over time (such as Liquidity Bootstrapping Pools or other dynamic weight
  pools), providing accurate TVL calculations based on current pool state rather than deployment-time snapshots.

  ## Type of change

  - [x] New feature <!-- (non-breaking change which adds functionality) -->
  - [x] Optimization: [x] gas / [ ] bytecode

  ## Checklist:

  - [x] The diff is legible and has no extraneous changes
  - [x] Complex code has been commented, including external interfaces
  - [x] Tests have 100% code coverage
  - [x] The base branch is either `main`, or there's a description of how to merge

  ## Issue Resolution

This change addresses the need for WeightedLPOracle to operate with dynamic weights, enabling proper oracle functionality for pools with time-varying weights such as those deployed for the QuantAMM WeightedPool's.