### PR TITLE
Address LP oracle findings

### DIFF
--- a/pkg/oracles/contracts/LPOracleBase.sol
+++ b/pkg/oracles/contracts/LPOracleBase.sol
@@ -147,37 +147,29 @@ abstract contract LPOracleBase is ILPOracleBase, ISequencerUptimeFeed, Aggregato
 
     /**
      * @notice Get data about a specific round, using the roundId.
-     * @dev Declared in AggregatorV3Interface. This is unused, and always returns all zeros.
+     * @dev Declared in AggregatorV3Interface. This function is deprecated, and always returns all zeros.
      * @return roundId The round ID
      * @return answer The answer for this round
      * @return startedAt Timestamp when the round started
      * @return updatedAt Timestamp when the round was updated
      * @return answeredInRound [Deprecated] - Previously used when answers could take multiple rounds to be computed
      */
-    function getRoundData(
-        uint80 /* _roundId */
-    )
-        external
-        pure
-        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
-    {
+    function getRoundData(uint80) external pure returns (uint80, int256, uint256, uint256, uint80) {
         return (0, 0, 0, 0, 0);
     }
 
     /**
      * @notice Get the data from the latest round.
-     * @dev Declared in AggregatorV3Interface.
-     * @return roundId The round ID
+     * @dev Declared in AggregatorV3Interface. Note that `getFeedData` reviews all `updatedAt` timestamps and selects
+     * the earliest one to return as `minUpdatedAt`. That is the value returned by this function as `updatedAt`.
+     *
+     * @return roundId [Deprecated] The round ID (always 0)
      * @return answer The answer for this round
-     * @return startedAt Timestamp when the round started
-     * @return updatedAt Timestamp when the round was updated
+     * @return startedAt [Deprecated] Timestamp when the round started (always 0)
+     * @return updatedAt The oldest / least recent timestamp when a constituent feed was updated
      * @return answeredInRound [Deprecated] - Previously used when answers could take multiple rounds to be computed
      */
-    function latestRoundData()
-        external
-        view
-        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
-    {
+    function latestRoundData() external view returns (uint80, int256 answer, uint256, uint256 updatedAt, uint80) {
         (int256[] memory prices, , uint256 _updatedAt) = getFeedData();
 
         uint256 tvl = _computeTVL(prices);


### PR DESCRIPTION
# Description

Clarify unconventional definition of `updatedAt` returned by `latestRoundData`.

I'm getting intermittent failures on `testComputeMarketPriceBalances__Fuzz` - and have seen them in CI occasionally.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [X] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
