### PR TITLE
Use standard `authenticate` for pool helpers

### DIFF
--- a/pkg/standalone-utils/contracts/PoolHelperCommon.sol
+++ b/pkg/standalone-utils/contracts/PoolHelperCommon.sol
@@ -57,7 +57,7 @@ abstract contract PoolHelperCommon is IPoolHelperCommon, OwnableAuthentication {
     /// @inheritdoc IPoolHelperCommon
     function createPoolSet(
         address initialManager
-    ) external onlyOwner withValidManager(initialManager) returns (uint256) {
+    ) external authenticate withValidManager(initialManager) returns (uint256) {
         return _createPoolSet(initialManager);
     }
 
@@ -65,7 +65,7 @@ abstract contract PoolHelperCommon is IPoolHelperCommon, OwnableAuthentication {
     function createPoolSet(
         address initialManager,
         address[] memory newPools
-    ) external onlyOwner withValidManager(initialManager) returns (uint256 poolSetId) {
+    ) external authenticate withValidManager(initialManager) returns (uint256 poolSetId) {
         poolSetId = _createPoolSet(initialManager);
 
         if (newPools.length > 0) {
@@ -84,7 +84,7 @@ abstract contract PoolHelperCommon is IPoolHelperCommon, OwnableAuthentication {
     }
 
     /// @inheritdoc IPoolHelperCommon
-    function destroyPoolSet(uint256 poolSetId) external onlyOwner withValidPoolSet(poolSetId) {
+    function destroyPoolSet(uint256 poolSetId) external authenticate withValidPoolSet(poolSetId) {
         EnumerableSet.AddressSet storage poolSet = _poolSets[poolSetId];
 
         // Remove all pools from the set.
@@ -131,7 +131,10 @@ abstract contract PoolHelperCommon is IPoolHelperCommon, OwnableAuthentication {
     ***************************************************************************/
 
     /// @inheritdoc IPoolHelperCommon
-    function addPoolsToSet(uint256 poolSetId, address[] memory newPools) public onlyOwner withValidPoolSet(poolSetId) {
+    function addPoolsToSet(
+        uint256 poolSetId,
+        address[] memory newPools
+    ) public authenticate withValidPoolSet(poolSetId) {
         uint256 numPools = newPools.length;
 
         for (uint256 i = 0; i < numPools; i++) {
@@ -157,7 +160,7 @@ abstract contract PoolHelperCommon is IPoolHelperCommon, OwnableAuthentication {
     function removePoolsFromSet(
         uint256 poolSetId,
         address[] memory pools
-    ) public onlyOwner withValidPoolSet(poolSetId) {
+    ) public authenticate withValidPoolSet(poolSetId) {
         uint256 numPools = pools.length;
 
         for (uint256 i = 0; i < numPools; i++) {

--- a/pkg/standalone-utils/test/foundry/PoolHelperCommon.t.sol
+++ b/pkg/standalone-utils/test/foundry/PoolHelperCommon.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
+import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
 import { IPoolHelperCommon } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IPoolHelperCommon.sol";
 
 import { PoolHelperMock } from "../../contracts/test/PoolHelperMock.sol";
@@ -30,7 +31,7 @@ contract PoolHelperCommonTest is BasePoolHelperTest {
     }
 
     function testCreatePoolSetPermissioned() public {
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, lp));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         vm.prank(lp);
         poolHelper.createPoolSet(lp);
     }
@@ -151,7 +152,7 @@ contract PoolHelperCommonTest is BasePoolHelperTest {
     }
 
     function testDestroyPoolSetPermissions() public {
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, lp));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         vm.prank(lp);
         poolHelper.destroyPoolSet(alicePoolSetId);
     }

--- a/pkg/standalone-utils/test/foundry/utils/BasePoolHelperTest.sol
+++ b/pkg/standalone-utils/test/foundry/utils/BasePoolHelperTest.sol
@@ -6,6 +6,7 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVaultTest.sol";
 
+import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
 import { IPoolHelperCommon } from "@balancer-labs/v3-interfaces/contracts/standalone-utils/IPoolHelperCommon.sol";
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 
@@ -84,7 +85,7 @@ abstract contract BasePoolHelperTest is BaseVaultTest {
     }
 
     function testAddPoolWithoutPermission() public {
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, lp));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         vm.prank(lp);
         poolHelper.addPoolsToSet(alicePoolSetId, new address[](0));
     }
@@ -121,7 +122,7 @@ abstract contract BasePoolHelperTest is BaseVaultTest {
     function testRemovePoolWithoutPermission() public {
         address[] memory pools = _addPools(10);
 
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, lp));
+        vm.expectRevert(IAuthentication.SenderNotAllowed.selector);
         vm.prank(lp);
         poolHelper.removePoolsFromSet(alicePoolSetId, pools);
     }


### PR DESCRIPTION
# Description

This detail slipped through the review.
In practice it doesn't make much difference since:
- the owner will be the primary caller for the permissioned functions; the whole point of this pattern is to skip the step of granting the initial permissions via governance
- governance can still force-transfer the owner and take control

Using `authenticate` is slightly more flexible and more similar to the usual `SingletonAuthentication` pattern, so this approach is preferable. No need to redeploy existing helpers though.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A