### PR TITLE
Tighten bounds to prevent intermittent test failure

### DIFF
--- a/pkg/oracles/test/foundry/StableLPOracle.t.sol
+++ b/pkg/oracles/test/foundry/StableLPOracle.t.sol
@@ -188,8 +188,8 @@ contract StableLPOracleTest is BaseLPOracleTest, StablePoolContractsDeployer {
 
             // Since the ratio between the min price and max price cannot be higher than PRICE_RATIO_LIMIT, we need a
             // way to test different price ranges. `priceBase` will define what will be the minimum possible price, so
-            // the prices in the price array will be in the interval [priceBase, priceBase * PRICE_RATIO_LIMIT / 2].
-            uint256 priceBase = bound(pricesRaw[0], MIN_PRICE, MAX_PRICE / (PRICE_RATIO_LIMIT / 2));
+            // the prices in the price array will be in the interval [priceBase, priceBase * PRICE_RATIO_LIMIT].
+            uint256 priceBase = bound(pricesRaw[0], MIN_PRICE, MAX_PRICE / PRICE_RATIO_LIMIT);
 
             for (uint256 i = 0; i < totalTokens; i++) {
                 _tokens[i] = address(sortedTokens[i]);
@@ -197,11 +197,11 @@ contract StableLPOracleTest is BaseLPOracleTest, StablePoolContractsDeployer {
                 poolInitAmounts[i] =
                     bound(poolInitAmountsRaw[i], FixedPoint.ONE, 1e9 * FixedPoint.ONE) /
                     (10 ** (18 - tokenDecimals));
-                // The prices will be in the interval [priceBase, priceBase * PRICE_RATIO_LIMIT / 2]. It means, we are
+                // The prices will be in the interval [priceBase, priceBase * PRICE_RATIO_LIMIT]. It means, we are
                 // sure that the ratio between the maximum and minimum prices is less than PRICE_RATIO_LIMIT, and the
-                // oracle will not revert.
+                // oracle will not revert. We restrict the max price more to guarantee K convergence.
                 prices[i] =
-                    bound(pricesRaw[i], priceBase, ((priceBase * PRICE_RATIO_LIMIT) / 2).mulDown(0.99e18)) /
+                    bound(pricesRaw[i], priceBase, ((priceBase * PRICE_RATIO_LIMIT) / 2).mulDown(99e16)) /
                     (10 ** (18 - tokenDecimals));
 
                 uint256 price = prices[i] * (10 ** (18 - tokenDecimals));


### PR DESCRIPTION
# Description

`testComputeMarketPriceBalances__Fuzz` had been failing intermittently. Didn't see any actual issue; mostly convergence and sensitivity to extreme parameter ranges. Tightened up the price bounds (vs. changing tolerances) to address the issue.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [X] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Resolves #1558 
