### PR TITLE
Test failure in TokenPairRegistry

### DIFF
--- a/pkg/standalone-utils/test/foundry/TokenPairRegistry.t.sol
+++ b/pkg/standalone-utils/test/foundry/TokenPairRegistry.t.sol
@@ -177,7 +177,13 @@ contract TokenPairRegistryTest is BaseERC4626BufferTest {
     }
 
     function testBufferAddSimplePath() external {
-        _expectEmitPathAddedEvents(address(weth), address(waWETH));
+        // Order is always underlying first; does not depend on token addresses.
+        vm.expectEmit();
+        emit ITokenPairRegistry.PathAdded(address(weth), address(waWETH), 1);
+
+        vm.expectEmit();
+        emit ITokenPairRegistry.PathAdded(address(waWETH), address(weth), 1);
+
         vm.prank(admin);
         registry.addSimplePath(address(waWETH));
 
@@ -406,14 +412,19 @@ contract TokenPairRegistryTest is BaseERC4626BufferTest {
     function testBufferRemoveSimplePath() external {
         registry.getPaths(address(weth), address(waWETH));
 
-        vm.startPrank(admin);
+        vm.prank(admin);
         registry.addSimplePath(address(waWETH));
-        vm.stopPrank();
 
         assertEq(registry.getPathCount(address(weth), address(waWETH)), 1, "Wrong path count weth / waWETH");
         assertEq(registry.getPathCount(address(waWETH), address(weth)), 1, "Wrong path count waWETH / weth");
 
-        _expectEmitPathRemovedEvents(address(weth), address(waWETH));
+        // Order is always underlying first; does not depend on token addresses.
+        vm.expectEmit();
+        emit ITokenPairRegistry.PathRemoved(address(weth), address(waWETH), 0);
+
+        vm.expectEmit();
+        emit ITokenPairRegistry.PathRemoved(address(waWETH), address(weth), 0);
+
         vm.prank(admin);
         registry.removeSimplePath(address(waWETH));
         assertEq(


### PR DESCRIPTION
# Description

Discovered a latent bug triggered by #1564. I suspect adding a new token to BaseTest rejiggered the token order so that this accidentally working test now failed.

## Type of change

- [X] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
