### PR TITLE
Reorder UnbalancedAdd router args for consistency

### DIFF
--- a/pkg/vault/contracts/UnbalancedAddViaSwapRouter.sol
+++ b/pkg/vault/contracts/UnbalancedAddViaSwapRouter.sol
@@ -23,8 +23,8 @@ import { RouterHooks } from "./RouterHooks.sol";
 contract UnbalancedAddViaSwapRouter is RouterHooks, IUnbalancedAddViaSwapRouter {
     constructor(
         IVault vault,
-        IPermit2 permit2,
         IWETH weth,
+        IPermit2 permit2,
         string memory routerVersion
     ) RouterHooks(vault, weth, permit2, routerVersion) {
         // solhint-disable-previous-line no-empty-blocks

--- a/pkg/vault/test/foundry/UnbalancedAddViaSwapRouter.t.sol
+++ b/pkg/vault/test/foundry/UnbalancedAddViaSwapRouter.t.sol
@@ -42,7 +42,7 @@ contract UnbalancedAddViaSwapRouterTest is BaseVaultTest {
 
     function setUp() public virtual override {
         BaseVaultTest.setUp();
-        unbalancedAddViaSwapRouter = new UnbalancedAddViaSwapRouter(IVault(address(vault)), permit2, weth, version);
+        unbalancedAddViaSwapRouter = new UnbalancedAddViaSwapRouter(IVault(address(vault)), weth, permit2, version);
 
         vm.startPrank(alice);
         for (uint256 i = 0; i < tokens.length; ++i) {


### PR DESCRIPTION
# Description

The order of arguments in the UnbalancedAddViaSwap router is reversed from all other Routers, making the deployment and tests have to change as well. This reorders them to match the rest of the system.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
