### PR TITLE
Rename minBptAmountOut to exactBptAmountOut in UnbalancedAddViaSwapRouter

### DIFF
--- a/pkg/interfaces/contracts/vault/IUnbalancedAddViaSwapRouter.sol
+++ b/pkg/interfaces/contracts/vault/IUnbalancedAddViaSwapRouter.sol
@@ -9,7 +9,7 @@ import "./RouterTypes.sol";
 /// @notice Router interface for adding unbalanced liquidity via a combination of a proportional add and a swap.
 interface IUnbalancedAddViaSwapRouter {
     struct AddLiquidityAndSwapParams {
-        uint256 minBptAmountOut;
+        uint256 exactBptAmountOut;
         IERC20 exactToken;
         uint256 exactAmount;
         uint256 maxAdjustableAmount;

--- a/pkg/vault/contracts/UnbalancedAddViaSwapRouter.sol
+++ b/pkg/vault/contracts/UnbalancedAddViaSwapRouter.sol
@@ -158,7 +158,7 @@ contract UnbalancedAddViaSwapRouter is RouterHooks, IUnbalancedAddViaSwapRouter 
                 pool: hookParams.pool,
                 to: hookParams.sender,
                 maxAmountsIn: maxAmountsIn,
-                minBptAmountOut: hookParams.operationParams.minBptAmountOut,
+                minBptAmountOut: hookParams.operationParams.exactBptAmountOut,
                 kind: AddLiquidityKind.PROPORTIONAL,
                 userData: hookParams.operationParams.addLiquidityUserData
             })

--- a/pkg/vault/test/foundry/UnbalancedAddViaSwapRouter.t.sol
+++ b/pkg/vault/test/foundry/UnbalancedAddViaSwapRouter.t.sol
@@ -96,7 +96,7 @@ contract UnbalancedAddViaSwapRouterTest is BaseVaultTest {
         // Create add liquidity and swap params
         IUnbalancedAddViaSwapRouter.AddLiquidityAndSwapParams memory params = IUnbalancedAddViaSwapRouter
             .AddLiquidityAndSwapParams({
-                minBptAmountOut: expectedBptAmountOut,
+                exactBptAmountOut: expectedBptAmountOut,
                 exactToken: weth,
                 exactAmount: exactAmount,
                 maxAdjustableAmount: maxAdjustableAmount,
@@ -170,7 +170,7 @@ contract UnbalancedAddViaSwapRouterTest is BaseVaultTest {
         // Create add liquidity and swap params
         IUnbalancedAddViaSwapRouter.AddLiquidityAndSwapParams memory params = IUnbalancedAddViaSwapRouter
             .AddLiquidityAndSwapParams({
-                minBptAmountOut: expectedBptAmountOut,
+                exactBptAmountOut: expectedBptAmountOut,
                 exactToken: weth,
                 exactAmount: exactAmount,
                 maxAdjustableAmount: maxAdjustableAmount,
@@ -200,7 +200,7 @@ contract UnbalancedAddViaSwapRouterTest is BaseVaultTest {
 
         IUnbalancedAddViaSwapRouter.AddLiquidityAndSwapParams memory params = IUnbalancedAddViaSwapRouter
             .AddLiquidityAndSwapParams({
-                minBptAmountOut: 0,
+                exactBptAmountOut: 0,
                 exactToken: weth,
                 exactAmount: 1e18,
                 maxAdjustableAmount: MAX_UINT256,
@@ -215,7 +215,7 @@ contract UnbalancedAddViaSwapRouterTest is BaseVaultTest {
     function testSwapAfterDeadline() public {
         IUnbalancedAddViaSwapRouter.AddLiquidityAndSwapParams memory params = IUnbalancedAddViaSwapRouter
             .AddLiquidityAndSwapParams({
-                minBptAmountOut: 0,
+                exactBptAmountOut: 0,
                 exactToken: weth,
                 exactAmount: 1e18,
                 maxAdjustableAmount: MAX_UINT256,


### PR DESCRIPTION
# Description

The name `minBptAmountOut` is incorrect for this parameter because it actually represents the exact amount of BPT out. Therefore, this PR renames `minBptAmountOut` to `exactBptAmountOut`.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
