### PR TITLE
add swap fee minimizer and factory with tests

### DIFF
--- a/pkg/standalone-utils/contracts/SwapFeeMinimizer/SwapFeeMinimizer.sol
+++ b/pkg/standalone-utils/contracts/SwapFeeMinimizer/SwapFeeMinimizer.sol
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import { ReentrancyGuardTransient } from "@balancer-labs/v3-solidity-utils/contracts/openzeppelin/ReentrancyGuardTransient.sol";
+
+import { IRouter } from "@balancer-labs/v3-interfaces/contracts/vault/IRouter.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import { IPermit2 } from "permit2/src/interfaces/IPermit2.sol";
+
+interface ISwapFeeMinimizerFactory {
+    function getCurrentPool() external view returns (address);
+}
+
+/**
+ * @notice Helper contract that minimizes swap fees for the contract `owner` when swapping a specific
+ *         `outputToken` from a specific pool.
+ * @dev Temporarily reduces swap fees to a minimal level during swap execution for owner-only swaps
+ */
+contract SwapFeeMinimizer is Ownable2Step, ReentrancyGuardTransient {
+    using SafeERC20 for IERC20;
+    
+    IRouter private immutable _router;
+    IVault private immutable _vault;
+    IPermit2 private immutable _permit2;
+    address private immutable _pool;
+    IERC20 private immutable _outputToken;
+    uint256 private immutable _minimalSwapFee;
+
+    error InvalidOutputToken(IERC20 expected, IERC20 actual);
+    error FeeValidationFailed();
+    error InvalidPool();
+
+    modifier withSwapMinimized() {
+        uint256 originalFee = _vault.getStaticSwapFeePercentage(_pool);
+        _vault.setStaticSwapFeePercentage(_pool, _minimalSwapFee);
+        _;
+        _vault.setStaticSwapFeePercentage(_pool, originalFee);
+    }
+
+    modifier onlyAllowableOutputToken(IERC20 tokenOut) {
+        if (tokenOut != _outputToken) {
+            revert InvalidOutputToken(_outputToken, tokenOut);
+        }
+        _;
+    }
+
+    modifier onlyPool(address poolAddress) {
+        if (poolAddress != _pool) {
+            revert InvalidPool();
+        }
+        _;
+    }
+
+    constructor(
+        IRouter router,
+        IVault vault,
+        IPermit2 permit2,
+        IERC20[] memory inputTokens,
+        IERC20 outputToken,
+        uint256 minimalSwapFeeAmount,
+        address initialOwner
+    ) Ownable(initialOwner) {
+        
+        _router = router;
+        _vault = vault;
+        _permit2 = permit2;
+        _outputToken = outputToken;
+        _minimalSwapFee = minimalSwapFeeAmount;
+
+        // Get the just-deployed pool address from the factory since it cannot be passed as a constructor arg
+        address poolAddress = ISwapFeeMinimizerFactory(msg.sender).getCurrentPool();
+        _pool = poolAddress;
+
+        // Max approve all possible input tokens for the pool
+
+        // Note: we don't unlock the output token since any attempt to swap with 
+        // that token as an input token will revert. This contract itself sets permit2 ERC20
+        // allowances to max and then each swap approves either the exact amount being swapped
+        // of the max allowable input amount for that swap.
+        for (uint256 i = 0; i < inputTokens.length; i++) {
+            inputTokens[i].forceApprove(address(_permit2), type(uint256).max);
+        }
+
+        // Validate that fee-setting permissions and `minimalSwapFeeAmount` are valid
+
+        // Note: using two _setAndValidateFee calls here since the weighted
+        // pool factory itself is an argument to the minimizer factory and,
+        // though unlikely, it is possible that the max/min fees in the pool
+        // could change
+        uint256 originalFee = _vault.getStaticSwapFeePercentage(poolAddress);
+        _setAndValidateFee(poolAddress, minimalSwapFeeAmount);
+        _setAndValidateFee(poolAddress, originalFee);
+    }
+
+    function _setAndValidateFee(address poolAddress, uint256 feeAmount) internal {
+        _vault.setStaticSwapFeePercentage(poolAddress, feeAmount);
+        if (_vault.getStaticSwapFeePercentage(poolAddress) != feeAmount) {
+            revert FeeValidationFailed();
+        }
+    }
+
+    function swapSingleTokenExactIn(
+        address poolAddress,
+        IERC20 tokenIn,
+        IERC20 tokenOut,
+        uint256 exactAmountIn,
+        uint256 minAmountOut,
+        uint256 deadline,
+        bool wethIsEth,
+        bytes calldata userData
+    ) external payable onlyOwner onlyAllowableOutputToken(tokenOut) onlyPool(poolAddress) withSwapMinimized nonReentrant returns (uint256) {
+        {
+        tokenIn.safeTransferFrom(msg.sender, address(this), exactAmountIn);
+
+        // using the swap deadline for the permit2 deadline is safe since
+        // the swap deadline gets checked before transferFrom is called
+        _permit2.approve(address(tokenIn), address(_router), uint160(exactAmountIn), uint48(deadline));
+            
+        }
+        
+        uint256 amountOut = _router.swapSingleTokenExactIn{value: msg.value}(
+            poolAddress,
+            tokenIn,
+            tokenOut,
+            exactAmountIn,
+            minAmountOut,
+            deadline,
+            wethIsEth,
+            userData
+        );
+        
+        tokenOut.safeTransfer(msg.sender, amountOut);
+        return amountOut;
+    }
+
+    function swapSingleTokenExactOut(
+        address poolAddress,
+        IERC20 tokenIn,
+        IERC20 tokenOut,
+        uint256 exactAmountOut,
+        uint256 maxAmountIn,
+        uint256 deadline,
+        bool wethIsEth,
+        bytes calldata userData
+    ) external payable onlyOwner onlyAllowableOutputToken(tokenOut) onlyPool(poolAddress) withSwapMinimized nonReentrant returns (uint256) {
+        tokenIn.safeTransferFrom(msg.sender, address(this), maxAmountIn);
+        
+        // using the swap deadline for the permit2 deadline is safe since
+        // the swap deadline gets checked before transferFrom is called
+        _permit2.approve(address(tokenIn), address(_router), uint160(maxAmountIn), uint48(deadline));
+        
+        uint256 amountIn = _router.swapSingleTokenExactOut{value: msg.value}(
+            poolAddress,
+            tokenIn,
+            tokenOut,
+            exactAmountOut,
+            maxAmountIn,
+            deadline,
+            wethIsEth,
+            userData
+        );
+        
+        tokenOut.safeTransfer(msg.sender, exactAmountOut);
+        
+        // Return leftover input tokens if any (`amountIn` determined at execution time)
+        if (amountIn < maxAmountIn) {
+            tokenIn.safeTransfer(msg.sender, maxAmountIn - amountIn);
+        }
+        
+        return amountIn;
+    }
+
+    function setSwapFeePercentage(uint256 swapFeePercentage) external onlyOwner {
+        _vault.setStaticSwapFeePercentage(_pool, swapFeePercentage);
+    }
+
+    function getRouter() external view returns (IRouter) {
+        return _router;
+    }
+
+    function getVault() external view returns (IVault) {
+        return _vault;
+    }
+
+    function getPool() external view returns (address) {
+        return _pool;
+    }
+
+    function getOutputToken() external view returns (IERC20) {
+        return _outputToken;
+    }
+
+    function getMinimalSwapFee() external view returns (uint256) {
+        return _minimalSwapFee;
+    }
+}

--- a/pkg/standalone-utils/contracts/SwapFeeMinimizer/SwapFeeMinimizerFactory.sol
+++ b/pkg/standalone-utils/contracts/SwapFeeMinimizer/SwapFeeMinimizerFactory.sol
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
+
+import { IRouter } from "@balancer-labs/v3-interfaces/contracts/vault/IRouter.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import { IPermit2 } from "permit2/src/interfaces/IPermit2.sol";
+import { WeightedPoolFactory } from "@balancer-labs/v3-pool-weighted/contracts/WeightedPoolFactory.sol";
+import {
+    TokenConfig,
+    PoolRoleAccounts,
+    LiquidityManagement
+} from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+
+import { SwapFeeMinimizer } from "./SwapFeeMinimizer.sol";
+
+struct PoolCreationParams {
+    string name;
+    string symbol;
+    TokenConfig[] tokens;
+    uint256[] normalizedWeights;
+    uint256 swapFeePercentage;
+    address poolHooksContract;
+    bool enableDonation;
+    bool disableUnbalancedLiquidity;
+}
+
+struct MinimizerParams {
+    IERC20[] inputTokens;
+    IERC20 outputToken;
+    address initialOwner;
+    uint256 minimalFee;
+}
+
+contract SwapFeeMinimizerFactory {
+    IRouter public immutable router;
+    IVault public immutable vault;
+    IPermit2 public immutable permit2;
+
+    mapping(address => SwapFeeMinimizer) public feeMinimizers;
+    address private _pendingPool;
+
+    event SwapFeeMinimizerDeployed(
+        address indexed pool,
+        IERC20 indexed outputToken,
+        address indexed initialOwner,
+        SwapFeeMinimizer minimizer,
+        uint256 minimalFee
+    );
+
+    error NoPendingPool();
+
+    constructor(IRouter _router, IVault _vault, IPermit2 _permit2) {
+        router = _router;
+        vault = _vault;
+        permit2 = _permit2;
+    }
+
+    function deployWeightedPoolWithMinimizer(
+        PoolCreationParams memory poolParams,
+        MinimizerParams memory minimizerParams,
+        WeightedPoolFactory poolFactory,
+        bytes32 salt
+    ) external returns (address pool, SwapFeeMinimizer minimizer) {
+        address predictedMinimizer = _predictMinimizerAddress(
+            minimizerParams.inputTokens,
+            minimizerParams.outputToken,
+            minimizerParams.minimalFee,
+            minimizerParams.initialOwner,
+            salt
+        );
+
+        pool = _deployPool(poolFactory, poolParams, predictedMinimizer, salt);
+
+        _pendingPool = pool;
+        
+        minimizer = _deployMinimizer(
+            minimizerParams.inputTokens,
+            minimizerParams.outputToken,
+            minimizerParams.minimalFee,
+            minimizerParams.initialOwner,
+            salt
+        );
+
+        feeMinimizers[pool] = minimizer;
+        _pendingPool = address(0);
+
+        emit SwapFeeMinimizerDeployed(pool, minimizerParams.outputToken, minimizerParams.initialOwner, minimizer, minimizerParams.minimalFee);
+    }
+
+    function _deployPool(
+        WeightedPoolFactory poolFactory,
+        PoolCreationParams memory poolParams,
+        address swapFeeManager,
+        bytes32 salt
+    ) internal returns (address) {
+        PoolRoleAccounts memory roleAccounts = PoolRoleAccounts({
+            pauseManager: address(0),
+            swapFeeManager: swapFeeManager,
+            poolCreator: address(0)
+        });
+
+        return poolFactory.create(
+            poolParams.name,
+            poolParams.symbol,
+            poolParams.tokens,
+            poolParams.normalizedWeights,
+            roleAccounts,
+            poolParams.swapFeePercentage,
+            poolParams.poolHooksContract,
+            poolParams.enableDonation,
+            poolParams.disableUnbalancedLiquidity,
+            salt
+        );
+    }
+
+    function getCurrentPool() external view returns (address) {
+        if (_pendingPool == address(0)) {
+            revert NoPendingPool();
+        }
+        return _pendingPool;
+    }
+
+    function _predictMinimizerAddress(
+        IERC20[] memory inputTokens,
+        IERC20 outputToken,
+        uint256 minimalFee,
+        address initialOwner,
+        bytes32 salt
+    ) internal view returns (address) {
+        bytes memory constructorArgs = abi.encode(
+            router,
+            vault,
+            permit2,
+            inputTokens,
+            outputToken,
+            minimalFee,
+            initialOwner
+        );
+        
+        bytes memory creationCode = abi.encodePacked(
+            type(SwapFeeMinimizer).creationCode,
+            constructorArgs
+        );
+
+        return Create2.computeAddress(salt, keccak256(creationCode), address(this));
+    }
+
+    function _deployMinimizer(
+        IERC20[] memory inputTokens,
+        IERC20 outputToken,
+        uint256 minimalFee,
+        address initialOwner,
+        bytes32 salt
+    ) internal returns (SwapFeeMinimizer) {
+        bytes memory constructorArgs = abi.encode(
+            router,
+            vault,
+            permit2,
+            inputTokens,
+            outputToken,
+            minimalFee,
+            initialOwner
+        );
+
+        bytes memory creationCode = abi.encodePacked(
+            type(SwapFeeMinimizer).creationCode,
+            constructorArgs
+        );
+
+        address minimizerAddress = Create2.deploy(0, salt, creationCode);
+        return SwapFeeMinimizer(minimizerAddress);
+    }
+
+    function getMinimizerForPool(address pool) external view returns (SwapFeeMinimizer) {
+        return feeMinimizers[pool];
+    }
+}

--- a/pkg/standalone-utils/contracts/SwapFeeMinimizer/SwapFeeMinimizerFactory.sol
+++ b/pkg/standalone-utils/contracts/SwapFeeMinimizer/SwapFeeMinimizerFactory.sol
@@ -76,7 +76,7 @@ contract SwapFeeMinimizerFactory {
         pool = _deployPool(poolFactory, poolParams, predictedMinimizer, salt);
 
         _pendingPool = pool;
-        
+
         minimizer = _deployMinimizer(
             minimizerParams.inputTokens,
             minimizerParams.outputToken,
@@ -88,7 +88,13 @@ contract SwapFeeMinimizerFactory {
         feeMinimizers[pool] = minimizer;
         _pendingPool = address(0);
 
-        emit SwapFeeMinimizerDeployed(pool, minimizerParams.outputToken, minimizerParams.initialOwner, minimizer, minimizerParams.minimalFee);
+        emit SwapFeeMinimizerDeployed(
+            pool,
+            minimizerParams.outputToken,
+            minimizerParams.initialOwner,
+            minimizer,
+            minimizerParams.minimalFee
+        );
     }
 
     function _deployPool(
@@ -103,18 +109,19 @@ contract SwapFeeMinimizerFactory {
             poolCreator: address(0)
         });
 
-        return poolFactory.create(
-            poolParams.name,
-            poolParams.symbol,
-            poolParams.tokens,
-            poolParams.normalizedWeights,
-            roleAccounts,
-            poolParams.swapFeePercentage,
-            poolParams.poolHooksContract,
-            poolParams.enableDonation,
-            poolParams.disableUnbalancedLiquidity,
-            salt
-        );
+        return
+            poolFactory.create(
+                poolParams.name,
+                poolParams.symbol,
+                poolParams.tokens,
+                poolParams.normalizedWeights,
+                roleAccounts,
+                poolParams.swapFeePercentage,
+                poolParams.poolHooksContract,
+                poolParams.enableDonation,
+                poolParams.disableUnbalancedLiquidity,
+                salt
+            );
     }
 
     function getCurrentPool() external view returns (address) {
@@ -140,11 +147,8 @@ contract SwapFeeMinimizerFactory {
             minimalFee,
             initialOwner
         );
-        
-        bytes memory creationCode = abi.encodePacked(
-            type(SwapFeeMinimizer).creationCode,
-            constructorArgs
-        );
+
+        bytes memory creationCode = abi.encodePacked(type(SwapFeeMinimizer).creationCode, constructorArgs);
 
         return Create2.computeAddress(salt, keccak256(creationCode), address(this));
     }
@@ -166,10 +170,7 @@ contract SwapFeeMinimizerFactory {
             initialOwner
         );
 
-        bytes memory creationCode = abi.encodePacked(
-            type(SwapFeeMinimizer).creationCode,
-            constructorArgs
-        );
+        bytes memory creationCode = abi.encodePacked(type(SwapFeeMinimizer).creationCode, constructorArgs);
 
         address minimizerAddress = Create2.deploy(0, salt, creationCode);
         return SwapFeeMinimizer(minimizerAddress);

--- a/pkg/standalone-utils/test/foundry/SwapFeeMinimizer.t.sol
+++ b/pkg/standalone-utils/test/foundry/SwapFeeMinimizer.t.sol
@@ -111,7 +111,7 @@ contract SwapFeeMinimizerTest is BaseVaultTest {
         // Initialize pool
         uint256[] memory amountsIn = new uint256[](2);
         amountsIn[0] = LIQUIDITY_AMOUNT_DAI / 2;
-        amountsIn[1] = (LIQUIDITY_AMOUNT_USDC / 2);
+        amountsIn[1] = LIQUIDITY_AMOUNT_USDC / 2;
         
         IERC20[] memory tokens = new IERC20[](2);
         tokens[0] = dai;

--- a/pkg/standalone-utils/test/foundry/SwapFeeMinimizer.t.sol
+++ b/pkg/standalone-utils/test/foundry/SwapFeeMinimizer.t.sol
@@ -18,23 +18,27 @@ import { WeightedPoolFactory } from "@balancer-labs/v3-pool-weighted/contracts/W
 import { WeightedPool } from "@balancer-labs/v3-pool-weighted/contracts/WeightedPool.sol";
 
 import { SwapFeeMinimizer } from "../../contracts/SwapFeeMinimizer/SwapFeeMinimizer.sol";
-import { SwapFeeMinimizerFactory, PoolCreationParams, MinimizerParams } from "../../contracts/SwapFeeMinimizer/SwapFeeMinimizerFactory.sol";
+import {
+    SwapFeeMinimizerFactory,
+    PoolCreationParams,
+    MinimizerParams
+} from "../../contracts/SwapFeeMinimizer/SwapFeeMinimizerFactory.sol";
 
 contract SwapFeeMinimizerTest is BaseVaultTest {
     SwapFeeMinimizerFactory factory;
     WeightedPoolFactory weightedPoolFactory;
     SwapFeeMinimizer minimizer;
     address testPool;
-    
+
     address poolOwner = makeAddr("poolOwner");
     address normalUser = makeAddr("normalUser");
-    
+
     uint256 constant MIN_SWAP_FEE = 0.001e16; // 0.001%
     uint256 constant MAX_SWAP_FEE = 10e16; // 10%
     uint256 constant NORMAL_SWAP_FEE = 1e16; // 1%
     uint256 constant LIQUIDITY_AMOUNT_DAI = 1000e18;
     uint256 constant LIQUIDITY_AMOUNT_USDC = 1000e6;
-    
+
     // Pool configuration
     string poolName = "Fee Minimizer Test Pool";
     string poolSymbol = "FMTP";
@@ -42,27 +46,32 @@ contract SwapFeeMinimizerTest is BaseVaultTest {
 
     function setUp() public override {
         super.setUp();
-        
+
         // Deploy factory and pool factory
         factory = new SwapFeeMinimizerFactory(router, vault, permit2);
-        weightedPoolFactory = new WeightedPoolFactory(
-            vault,
-            365 days,
-            "Factory v1",
-            "Pool v1"
-        );
-        
+        weightedPoolFactory = new WeightedPoolFactory(vault, 365 days, "Factory v1", "Pool v1");
+
         outputToken = dai;
-        
+
         TokenConfig[] memory tokens = new TokenConfig[](2);
-        tokens[0] = TokenConfig({token: dai, tokenType: TokenType.STANDARD, rateProvider: IRateProvider(address(0)), paysYieldFees: false});
-        tokens[1] = TokenConfig({token: usdc, tokenType: TokenType.STANDARD, rateProvider: IRateProvider(address(0)), paysYieldFees: false});
-        
+        tokens[0] = TokenConfig({
+            token: dai,
+            tokenType: TokenType.STANDARD,
+            rateProvider: IRateProvider(address(0)),
+            paysYieldFees: false
+        });
+        tokens[1] = TokenConfig({
+            token: usdc,
+            tokenType: TokenType.STANDARD,
+            rateProvider: IRateProvider(address(0)),
+            paysYieldFees: false
+        });
+
         uint256[] memory weights = new uint256[](2);
         // 50/50 pool
         weights[0] = 50e16;
         weights[1] = 50e16;
-        
+
         PoolCreationParams memory poolParams = PoolCreationParams({
             name: poolName,
             symbol: poolSymbol,
@@ -73,24 +82,24 @@ contract SwapFeeMinimizerTest is BaseVaultTest {
             enableDonation: false,
             disableUnbalancedLiquidity: false
         });
-        
+
         IERC20[] memory inputTokens = new IERC20[](1);
         inputTokens[0] = usdc;
-        
+
         MinimizerParams memory minimizerParams = MinimizerParams({
             inputTokens: inputTokens,
             outputToken: outputToken,
             initialOwner: poolOwner,
             minimalFee: MIN_SWAP_FEE
         });
-        
+
         (testPool, minimizer) = factory.deployWeightedPoolWithMinimizer(
             poolParams,
             minimizerParams,
             weightedPoolFactory,
             keccak256("test")
         );
-        
+
         _setupPoolLiquidity();
     }
 
@@ -99,7 +108,7 @@ contract SwapFeeMinimizerTest is BaseVaultTest {
         dai.mint(address(this), LIQUIDITY_AMOUNT_DAI);
         usdc.mint(address(this), LIQUIDITY_AMOUNT_USDC);
         vm.stopPrank();
-        
+
         // Approve tokens from test contract to router to seed pool
         dai.approve(address(router), type(uint256).max);
         usdc.approve(address(router), type(uint256).max);
@@ -107,39 +116,32 @@ contract SwapFeeMinimizerTest is BaseVaultTest {
         usdc.approve(address(permit2), type(uint256).max);
         permit2.approve(address(dai), address(router), type(uint160).max, type(uint48).max);
         permit2.approve(address(usdc), address(router), type(uint160).max, type(uint48).max);
-        
+
         // Initialize pool
         uint256[] memory amountsIn = new uint256[](2);
         amountsIn[0] = LIQUIDITY_AMOUNT_DAI / 2;
         amountsIn[1] = LIQUIDITY_AMOUNT_USDC / 2;
-        
+
         IERC20[] memory tokens = new IERC20[](2);
         tokens[0] = dai;
         tokens[1] = usdc;
-        
-        router.initialize(
-            testPool,
-            tokens,
-            amountsIn,
-            0,
-            false,
-            ""
-        );
-        
+
+        router.initialize(testPool, tokens, amountsIn, 0, false, "");
+
         vm.startPrank(admin);
         dai.mint(poolOwner, 100e18);
         dai.mint(normalUser, 100e18);
         usdc.mint(poolOwner, 100e6);
         usdc.mint(normalUser, 100e6);
         vm.stopPrank();
-        
+
         vm.startPrank(poolOwner);
         dai.approve(address(router), type(uint256).max);
         usdc.approve(address(router), type(uint256).max);
         dai.approve(address(minimizer), type(uint256).max);
         usdc.approve(address(minimizer), type(uint256).max);
         vm.stopPrank();
-        
+
         vm.startPrank(normalUser);
         dai.approve(address(router), type(uint256).max);
         usdc.approve(address(router), type(uint256).max);
@@ -156,19 +158,10 @@ contract SwapFeeMinimizerTest is BaseVaultTest {
         // Record initial fee
         uint256 initialFee = vault.getStaticSwapFeePercentage(testPool);
         assertEq(initialFee, NORMAL_SWAP_FEE);
-        
+
         vm.prank(poolOwner);
-        uint256 amountOut = minimizer.swapSingleTokenExactIn(
-            testPool,
-            usdc,
-            dai,
-            10e6,
-            0,
-            block.timestamp,
-            false,
-            ""
-        );
-        
+        uint256 amountOut = minimizer.swapSingleTokenExactIn(testPool, usdc, dai, 10e6, 0, block.timestamp, false, "");
+
         uint256 finalFee = vault.getStaticSwapFeePercentage(testPool);
         assertEq(finalFee, NORMAL_SWAP_FEE);
         assertTrue(amountOut > 0);
@@ -177,7 +170,7 @@ contract SwapFeeMinimizerTest is BaseVaultTest {
     function testSwapExactOutWithMinimizedFees() public {
         uint256 initialFee = vault.getStaticSwapFeePercentage(testPool);
         assertEq(initialFee, NORMAL_SWAP_FEE);
-        
+
         vm.prank(poolOwner);
         uint256 amountIn = minimizer.swapSingleTokenExactOut(
             testPool,
@@ -189,16 +182,16 @@ contract SwapFeeMinimizerTest is BaseVaultTest {
             false,
             ""
         );
-        
+
         uint256 finalFee = vault.getStaticSwapFeePercentage(testPool);
-        assertEq(finalFee, NORMAL_SWAP_FEE);        
+        assertEq(finalFee, NORMAL_SWAP_FEE);
         assertTrue(amountIn > 0);
     }
 
     function testFeeMinimizationDuringSwap() public {
         uint256 swapAmount = 10e6;
         uint256 snapshot = vm.snapshot();
-        
+
         // compare output from normal user via router to poolOwner via minimizer
         vm.prank(normalUser);
         uint256 normalFeeResult = router.swapSingleTokenExactIn(
@@ -211,7 +204,7 @@ contract SwapFeeMinimizerTest is BaseVaultTest {
             false,
             ""
         );
-        
+
         vm.revertTo(snapshot);
         vm.prank(poolOwner);
         uint256 minimizedFeeResult = minimizer.swapSingleTokenExactIn(
@@ -224,43 +217,47 @@ contract SwapFeeMinimizerTest is BaseVaultTest {
             false,
             ""
         );
-        
+
         assertGt(minimizedFeeResult, normalFeeResult);
 
         // Check that the swap amounts without fees charged are roughly equivalent
-        uint256 untaxedSwapAmountMinimized = minimizedFeeResult * 1e18 / (1e18 - MIN_SWAP_FEE);
-        uint256 untaxedSwapAmountNormal = normalFeeResult * 1e18 / (1e18 - NORMAL_SWAP_FEE);
-        uint256 positiveNumerator = SignedMath.abs(int256(untaxedSwapAmountMinimized) - int256(untaxedSwapAmountNormal));
-        uint256 pctError = positiveNumerator * 1e18 / untaxedSwapAmountNormal;
+        uint256 untaxedSwapAmountMinimized = (minimizedFeeResult * 1e18) / (1e18 - MIN_SWAP_FEE);
+        uint256 untaxedSwapAmountNormal = (normalFeeResult * 1e18) / (1e18 - NORMAL_SWAP_FEE);
+        uint256 positiveNumerator = SignedMath.abs(
+            int256(untaxedSwapAmountMinimized) - int256(untaxedSwapAmountNormal)
+        );
+        uint256 pctError = (positiveNumerator * 1e18) / untaxedSwapAmountNormal;
         uint256 smallError = 0.1e16; // 0.1%
         assertLt(pctError, smallError);
-
     }
 
     function testFeeRestoresOnSwapRevert() public {
         uint256 initialFee = vault.getStaticSwapFeePercentage(testPool);
-        
+
         // Induce a swap revert with expired deadline deadline
         vm.prank(poolOwner);
-        try minimizer.swapSingleTokenExactIn(
-            testPool,
-            usdc,
-            dai,
-            10e6,
-            0,
-            block.timestamp - 1, // Deadline in past
-            false,
-            ""
-        ) {
+        try
+            minimizer.swapSingleTokenExactIn(
+                testPool,
+                usdc,
+                dai,
+                10e6,
+                0,
+                block.timestamp - 1, // Deadline in past
+                false,
+                ""
+            )
+        {
             fail();
         } catch {
             // Do nothing
         }
-        
+
         // Fee is restored to normal
         uint256 finalFee = vault.getStaticSwapFeePercentage(testPool);
         assertEq(finalFee, initialFee);
     }
+
     function testOwnerCanSetSwapFee() public {
         uint256 newFee = 0.005e16; // 0.005%
         vm.prank(poolOwner);
@@ -272,13 +269,13 @@ contract SwapFeeMinimizerTest is BaseVaultTest {
     function testNonOwnerCannotSetSwapFee() public {
         uint256 newFee = 0.005e16; // 0.005%
         vm.prank(normalUser);
-        
+
         // expect revert message from ownable
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, normalUser));
         minimizer.setSwapFeePercentage(newFee);
     }
 
-    function testConcurrentUsage() public {        
+    function testConcurrentUsage() public {
         // Normal users can swap via router
         vm.prank(normalUser);
         uint256 normalResult = router.swapSingleTokenExactIn(
@@ -291,20 +288,20 @@ contract SwapFeeMinimizerTest is BaseVaultTest {
             false,
             ""
         );
-        
+
         // Owner swap with minimizer
         vm.prank(poolOwner);
         uint256 minimizerResult = minimizer.swapSingleTokenExactIn(
             testPool,
             usdc,
             dai,
-            5e6, // 5 USDC  
+            5e6, // 5 USDC
             0,
             block.timestamp,
             false,
             ""
         );
-        
+
         // Both swaps work, fee is nominal
         assertTrue(normalResult > 0);
         assertTrue(minimizerResult > 0);
@@ -331,7 +328,7 @@ contract SwapFeeMinimizerTest is BaseVaultTest {
             false,
             ""
         );
-        
+
         // Verify on ExactOut
         vm.prank(poolOwner);
         vm.expectRevert(expectedRevert);
@@ -349,34 +346,16 @@ contract SwapFeeMinimizerTest is BaseVaultTest {
 
     function testOnlyPoolModifierReverts() public {
         address wrongPool = makeAddr("wrongPool");
-        
+
         // Verify on ExactIn
         vm.prank(poolOwner);
         vm.expectRevert(SwapFeeMinimizer.InvalidPool.selector);
-        minimizer.swapSingleTokenExactIn(
-            wrongPool,
-            usdc,
-            dai,
-            10e6,
-            0,
-            block.timestamp,
-            false,
-            ""
-        );
-        
+        minimizer.swapSingleTokenExactIn(wrongPool, usdc, dai, 10e6, 0, block.timestamp, false, "");
+
         // Verify on ExactOut
         vm.prank(poolOwner);
         vm.expectRevert(SwapFeeMinimizer.InvalidPool.selector);
-        minimizer.swapSingleTokenExactOut(
-            wrongPool,
-            usdc,
-            dai,
-            5e18,
-            100e6,
-            block.timestamp,
-            false,
-            ""
-        );
+        minimizer.swapSingleTokenExactOut(wrongPool, usdc, dai, 5e18, 100e6, block.timestamp, false, "");
     }
 
     function testPreExistingTokenBalance() public {
@@ -384,59 +363,49 @@ contract SwapFeeMinimizerTest is BaseVaultTest {
         uint256 preExistingBalance = 50e18;
         vm.prank(admin);
         dai.mint(address(minimizer), preExistingBalance);
-        
+
         uint256 contractBalanceBefore = dai.balanceOf(address(minimizer));
         assertEq(contractBalanceBefore, preExistingBalance);
-        
+
         uint256 userBalanceBefore = dai.balanceOf(poolOwner);
-        
+
         vm.prank(poolOwner);
-        uint256 amountOut = minimizer.swapSingleTokenExactIn(
-            testPool,
-            usdc,
-            dai,
-            10e6,
-            0,
-            block.timestamp,
-            false,
-            ""
-        );
-        
+        uint256 amountOut = minimizer.swapSingleTokenExactIn(testPool, usdc, dai, 10e6, 0, block.timestamp, false, "");
+
         uint256 userBalanceAfter = dai.balanceOf(poolOwner);
         uint256 contractBalanceAfter = dai.balanceOf(address(minimizer));
-        
+
         // User gets amountOut
         assertEq(userBalanceAfter - userBalanceBefore, amountOut);
-        
+
         // Contract pre-existing balance unchanged
         assertEq(contractBalanceAfter, preExistingBalance);
-        
+
         // Verify swap worked
         assertGt(amountOut, 0);
     }
 
     function testFeeSettingBounds() public {
-        
         // Success on MIN
         vm.prank(poolOwner);
         minimizer.setSwapFeePercentage(MIN_SWAP_FEE);
         assertEq(vault.getStaticSwapFeePercentage(testPool), MIN_SWAP_FEE);
-        
+
         // Success on MAX
         vm.prank(poolOwner);
         minimizer.setSwapFeePercentage(MAX_SWAP_FEE);
         assertEq(vault.getStaticSwapFeePercentage(testPool), MAX_SWAP_FEE);
-        
+
         // Fail on MIN - 1
         vm.prank(poolOwner);
         vm.expectRevert();
         minimizer.setSwapFeePercentage(MIN_SWAP_FEE - 1);
-        
+
         // Fail on MAX + 1
         vm.prank(poolOwner);
         vm.expectRevert();
         minimizer.setSwapFeePercentage(MAX_SWAP_FEE + 1);
-        
+
         // Success on NORMAL
         vm.prank(poolOwner);
         minimizer.setSwapFeePercentage(NORMAL_SWAP_FEE);

--- a/pkg/standalone-utils/test/foundry/SwapFeeMinimizer.t.sol
+++ b/pkg/standalone-utils/test/foundry/SwapFeeMinimizer.t.sol
@@ -1,0 +1,444 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { SignedMath } from "@openzeppelin/contracts/utils/math/SignedMath.sol";
+
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import { IRouter } from "@balancer-labs/v3-interfaces/contracts/vault/IRouter.sol";
+import { TokenConfig, PoolRoleAccounts, TokenType } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+import { IRateProvider } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IRateProvider.sol";
+
+import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVaultTest.sol";
+import { WeightedPoolFactory } from "@balancer-labs/v3-pool-weighted/contracts/WeightedPoolFactory.sol";
+import { WeightedPool } from "@balancer-labs/v3-pool-weighted/contracts/WeightedPool.sol";
+
+import { SwapFeeMinimizer } from "../../contracts/SwapFeeMinimizer/SwapFeeMinimizer.sol";
+import { SwapFeeMinimizerFactory, PoolCreationParams, MinimizerParams } from "../../contracts/SwapFeeMinimizer/SwapFeeMinimizerFactory.sol";
+
+contract SwapFeeMinimizerTest is BaseVaultTest {
+    SwapFeeMinimizerFactory factory;
+    WeightedPoolFactory weightedPoolFactory;
+    SwapFeeMinimizer minimizer;
+    address testPool;
+    
+    address poolOwner = makeAddr("poolOwner");
+    address normalUser = makeAddr("normalUser");
+    
+    uint256 constant MIN_SWAP_FEE = 0.001e16; // 0.001%
+    uint256 constant MAX_SWAP_FEE = 10e16; // 10%
+    uint256 constant NORMAL_SWAP_FEE = 1e16; // 1%
+    uint256 constant LIQUIDITY_AMOUNT_DAI = 1000e18;
+    uint256 constant LIQUIDITY_AMOUNT_USDC = 1000e6;
+    
+    // Pool configuration
+    string poolName = "Fee Minimizer Test Pool";
+    string poolSymbol = "FMTP";
+    IERC20 outputToken;
+
+    function setUp() public override {
+        super.setUp();
+        
+        // Deploy factory and pool factory
+        factory = new SwapFeeMinimizerFactory(router, vault, permit2);
+        weightedPoolFactory = new WeightedPoolFactory(
+            vault,
+            365 days,
+            "Factory v1",
+            "Pool v1"
+        );
+        
+        outputToken = dai;
+        
+        TokenConfig[] memory tokens = new TokenConfig[](2);
+        tokens[0] = TokenConfig({token: dai, tokenType: TokenType.STANDARD, rateProvider: IRateProvider(address(0)), paysYieldFees: false});
+        tokens[1] = TokenConfig({token: usdc, tokenType: TokenType.STANDARD, rateProvider: IRateProvider(address(0)), paysYieldFees: false});
+        
+        uint256[] memory weights = new uint256[](2);
+        // 50/50 pool
+        weights[0] = 50e16;
+        weights[1] = 50e16;
+        
+        PoolCreationParams memory poolParams = PoolCreationParams({
+            name: poolName,
+            symbol: poolSymbol,
+            tokens: tokens,
+            normalizedWeights: weights,
+            swapFeePercentage: NORMAL_SWAP_FEE,
+            poolHooksContract: address(0),
+            enableDonation: false,
+            disableUnbalancedLiquidity: false
+        });
+        
+        IERC20[] memory inputTokens = new IERC20[](1);
+        inputTokens[0] = usdc;
+        
+        MinimizerParams memory minimizerParams = MinimizerParams({
+            inputTokens: inputTokens,
+            outputToken: outputToken,
+            initialOwner: poolOwner,
+            minimalFee: MIN_SWAP_FEE
+        });
+        
+        (testPool, minimizer) = factory.deployWeightedPoolWithMinimizer(
+            poolParams,
+            minimizerParams,
+            weightedPoolFactory,
+            keccak256("test")
+        );
+        
+        _setupPoolLiquidity();
+    }
+
+    function _setupPoolLiquidity() internal {
+        vm.startPrank(admin);
+        dai.mint(address(this), LIQUIDITY_AMOUNT_DAI);
+        usdc.mint(address(this), LIQUIDITY_AMOUNT_USDC);
+        vm.stopPrank();
+        
+        // Approve tokens from test contract to router to seed pool
+        dai.approve(address(router), type(uint256).max);
+        usdc.approve(address(router), type(uint256).max);
+        dai.approve(address(permit2), type(uint256).max);
+        usdc.approve(address(permit2), type(uint256).max);
+        permit2.approve(address(dai), address(router), type(uint160).max, type(uint48).max);
+        permit2.approve(address(usdc), address(router), type(uint160).max, type(uint48).max);
+        
+        // Initialize pool
+        uint256[] memory amountsIn = new uint256[](2);
+        amountsIn[0] = LIQUIDITY_AMOUNT_DAI / 2;
+        amountsIn[1] = (LIQUIDITY_AMOUNT_USDC / 2);
+        
+        IERC20[] memory tokens = new IERC20[](2);
+        tokens[0] = dai;
+        tokens[1] = usdc;
+        
+        router.initialize(
+            testPool,
+            tokens,
+            amountsIn,
+            0,
+            false,
+            ""
+        );
+        
+        vm.startPrank(admin);
+        dai.mint(poolOwner, 100e18);
+        dai.mint(normalUser, 100e18);
+        usdc.mint(poolOwner, 100e6);
+        usdc.mint(normalUser, 100e6);
+        vm.stopPrank();
+        
+        vm.startPrank(poolOwner);
+        dai.approve(address(router), type(uint256).max);
+        usdc.approve(address(router), type(uint256).max);
+        dai.approve(address(minimizer), type(uint256).max);
+        usdc.approve(address(minimizer), type(uint256).max);
+        vm.stopPrank();
+        
+        vm.startPrank(normalUser);
+        dai.approve(address(router), type(uint256).max);
+        usdc.approve(address(router), type(uint256).max);
+        dai.approve(address(permit2), type(uint256).max);
+        usdc.approve(address(permit2), type(uint256).max);
+
+        // permit2 approvals needed for **router** actions rather than the minimizer for normalUser
+        permit2.approve(address(dai), address(router), type(uint160).max, type(uint48).max);
+        permit2.approve(address(usdc), address(router), type(uint160).max, type(uint48).max);
+        vm.stopPrank();
+    }
+
+    function testSwapExactInWithMinimizedFees() public {
+        // Record initial fee
+        uint256 initialFee = vault.getStaticSwapFeePercentage(testPool);
+        assertEq(initialFee, NORMAL_SWAP_FEE);
+        
+        vm.prank(poolOwner);
+        uint256 amountOut = minimizer.swapSingleTokenExactIn(
+            testPool,
+            usdc,
+            dai,
+            10e6,
+            0,
+            block.timestamp,
+            false,
+            ""
+        );
+        
+        uint256 finalFee = vault.getStaticSwapFeePercentage(testPool);
+        assertEq(finalFee, NORMAL_SWAP_FEE);
+        assertTrue(amountOut > 0);
+    }
+
+    function testSwapExactOutWithMinimizedFees() public {
+        uint256 initialFee = vault.getStaticSwapFeePercentage(testPool);
+        assertEq(initialFee, NORMAL_SWAP_FEE);
+        
+        vm.prank(poolOwner);
+        uint256 amountIn = minimizer.swapSingleTokenExactOut(
+            testPool,
+            usdc,
+            dai,
+            5e18,
+            10e6,
+            block.timestamp,
+            false,
+            ""
+        );
+        
+        uint256 finalFee = vault.getStaticSwapFeePercentage(testPool);
+        assertEq(finalFee, NORMAL_SWAP_FEE);        
+        assertTrue(amountIn > 0);
+    }
+
+    function testFeeMinimizationDuringSwap() public {
+        uint256 swapAmount = 10e6;
+        uint256 snapshot = vm.snapshot();
+        
+        // compare output from normal user via router to poolOwner via minimizer
+        vm.prank(normalUser);
+        uint256 normalFeeResult = router.swapSingleTokenExactIn(
+            testPool,
+            usdc,
+            dai,
+            swapAmount,
+            0,
+            block.timestamp,
+            false,
+            ""
+        );
+        
+        vm.revertTo(snapshot);
+        vm.prank(poolOwner);
+        uint256 minimizedFeeResult = minimizer.swapSingleTokenExactIn(
+            testPool,
+            usdc,
+            dai,
+            swapAmount,
+            0,
+            block.timestamp,
+            false,
+            ""
+        );
+        
+        assertGt(minimizedFeeResult, normalFeeResult);
+
+        // Check that the swap amounts without fees charged are roughly equivalent
+        uint256 untaxedSwapAmountMinimized = minimizedFeeResult * 1e18 / (1e18 - MIN_SWAP_FEE);
+        uint256 untaxedSwapAmountNormal = normalFeeResult * 1e18 / (1e18 - NORMAL_SWAP_FEE);
+        uint256 positiveNumerator = SignedMath.abs(int256(untaxedSwapAmountMinimized) - int256(untaxedSwapAmountNormal));
+        uint256 pctError = positiveNumerator * 1e18 / untaxedSwapAmountNormal;
+        uint256 smallError = 0.1e16; // 0.1%
+        assertLt(pctError, smallError);
+
+    }
+
+    function testFeeRestoresOnSwapRevert() public {
+        uint256 initialFee = vault.getStaticSwapFeePercentage(testPool);
+        
+        // Induce a swap revert with expired deadline deadline
+        vm.prank(poolOwner);
+        try minimizer.swapSingleTokenExactIn(
+            testPool,
+            usdc,
+            dai,
+            10e6,
+            0,
+            block.timestamp - 1, // Deadline in past
+            false,
+            ""
+        ) {
+            fail();
+        } catch {
+            // Do nothing
+        }
+        
+        // Fee is restored to normal
+        uint256 finalFee = vault.getStaticSwapFeePercentage(testPool);
+        assertEq(finalFee, initialFee);
+    }
+    function testOwnerCanSetSwapFee() public {
+        uint256 newFee = 0.005e16; // 0.005%
+        vm.prank(poolOwner);
+
+        minimizer.setSwapFeePercentage(newFee);
+        assertEq(vault.getStaticSwapFeePercentage(testPool), newFee);
+    }
+
+    function testNonOwnerCannotSetSwapFee() public {
+        uint256 newFee = 0.005e16; // 0.005%
+        vm.prank(normalUser);
+        
+        // expect revert message from ownable
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, normalUser));
+        minimizer.setSwapFeePercentage(newFee);
+    }
+
+    function testConcurrentUsage() public {        
+        // Normal users can swap via router
+        vm.prank(normalUser);
+        uint256 normalResult = router.swapSingleTokenExactIn(
+            testPool,
+            usdc,
+            dai,
+            5e6, // 5 USDC
+            0,
+            block.timestamp,
+            false,
+            ""
+        );
+        
+        // Owner swap with minimizer
+        vm.prank(poolOwner);
+        uint256 minimizerResult = minimizer.swapSingleTokenExactIn(
+            testPool,
+            usdc,
+            dai,
+            5e6, // 5 USDC  
+            0,
+            block.timestamp,
+            false,
+            ""
+        );
+        
+        // Both swaps work, fee is nominal
+        assertTrue(normalResult > 0);
+        assertTrue(minimizerResult > 0);
+        assertEq(vault.getStaticSwapFeePercentage(testPool), NORMAL_SWAP_FEE);
+    }
+
+    function testInvalidOutputToken() public {
+        bytes memory expectedRevert = abi.encodeWithSelector(
+            SwapFeeMinimizer.InvalidOutputToken.selector,
+            dai, // expected
+            usdc // actual
+        );
+
+        // Verify on ExactIn
+        vm.prank(poolOwner);
+        vm.expectRevert(expectedRevert);
+        minimizer.swapSingleTokenExactIn(
+            testPool,
+            dai,
+            usdc, // Invalid output token
+            10e18,
+            0,
+            block.timestamp,
+            false,
+            ""
+        );
+        
+        // Verify on ExactOut
+        vm.prank(poolOwner);
+        vm.expectRevert(expectedRevert);
+        minimizer.swapSingleTokenExactOut(
+            testPool,
+            dai,
+            usdc, // Invalid output token
+            5e6,
+            type(uint256).max,
+            block.timestamp,
+            false,
+            ""
+        );
+    }
+
+    function testOnlyPoolModifierReverts() public {
+        address wrongPool = makeAddr("wrongPool");
+        
+        // Verify on ExactIn
+        vm.prank(poolOwner);
+        vm.expectRevert(SwapFeeMinimizer.InvalidPool.selector);
+        minimizer.swapSingleTokenExactIn(
+            wrongPool,
+            usdc,
+            dai,
+            10e6,
+            0,
+            block.timestamp,
+            false,
+            ""
+        );
+        
+        // Verify on ExactOut
+        vm.prank(poolOwner);
+        vm.expectRevert(SwapFeeMinimizer.InvalidPool.selector);
+        minimizer.swapSingleTokenExactOut(
+            wrongPool,
+            usdc,
+            dai,
+            5e18,
+            100e6,
+            block.timestamp,
+            false,
+            ""
+        );
+    }
+
+    function testPreExistingTokenBalance() public {
+        // Give the contract some pre-existing DAI tokens
+        uint256 preExistingBalance = 50e18;
+        vm.prank(admin);
+        dai.mint(address(minimizer), preExistingBalance);
+        
+        uint256 contractBalanceBefore = dai.balanceOf(address(minimizer));
+        assertEq(contractBalanceBefore, preExistingBalance);
+        
+        uint256 userBalanceBefore = dai.balanceOf(poolOwner);
+        
+        vm.prank(poolOwner);
+        uint256 amountOut = minimizer.swapSingleTokenExactIn(
+            testPool,
+            usdc,
+            dai,
+            10e6,
+            0,
+            block.timestamp,
+            false,
+            ""
+        );
+        
+        uint256 userBalanceAfter = dai.balanceOf(poolOwner);
+        uint256 contractBalanceAfter = dai.balanceOf(address(minimizer));
+        
+        // User gets amountOut
+        assertEq(userBalanceAfter - userBalanceBefore, amountOut);
+        
+        // Contract pre-existing balance unchanged
+        assertEq(contractBalanceAfter, preExistingBalance);
+        
+        // Verify swap worked
+        assertGt(amountOut, 0);
+    }
+
+    function testFeeSettingBounds() public {
+        
+        // Success on MIN
+        vm.prank(poolOwner);
+        minimizer.setSwapFeePercentage(MIN_SWAP_FEE);
+        assertEq(vault.getStaticSwapFeePercentage(testPool), MIN_SWAP_FEE);
+        
+        // Success on MAX
+        vm.prank(poolOwner);
+        minimizer.setSwapFeePercentage(MAX_SWAP_FEE);
+        assertEq(vault.getStaticSwapFeePercentage(testPool), MAX_SWAP_FEE);
+        
+        // Fail on MIN - 1
+        vm.prank(poolOwner);
+        vm.expectRevert();
+        minimizer.setSwapFeePercentage(MIN_SWAP_FEE - 1);
+        
+        // Fail on MAX + 1
+        vm.prank(poolOwner);
+        vm.expectRevert();
+        minimizer.setSwapFeePercentage(MAX_SWAP_FEE + 1);
+        
+        // Success on NORMAL
+        vm.prank(poolOwner);
+        minimizer.setSwapFeePercentage(NORMAL_SWAP_FEE);
+    }
+}

--- a/pkg/standalone-utils/test/foundry/SwapFeeMinimizerFactory.t.sol
+++ b/pkg/standalone-utils/test/foundry/SwapFeeMinimizerFactory.t.sol
@@ -20,70 +20,86 @@ import { WeightedPoolFactory } from "@balancer-labs/v3-pool-weighted/contracts/W
 import { WeightedPool } from "@balancer-labs/v3-pool-weighted/contracts/WeightedPool.sol";
 
 import { SwapFeeMinimizer } from "../../contracts/SwapFeeMinimizer/SwapFeeMinimizer.sol";
-import { SwapFeeMinimizerFactory, PoolCreationParams, MinimizerParams } from "../../contracts/SwapFeeMinimizer/SwapFeeMinimizerFactory.sol";
+import {
+    SwapFeeMinimizerFactory,
+    PoolCreationParams,
+    MinimizerParams
+} from "../../contracts/SwapFeeMinimizer/SwapFeeMinimizerFactory.sol";
 
 contract SwapFeeMinimizerFactoryTest is BaseVaultTest {
     SwapFeeMinimizerFactory factory;
     WeightedPoolFactory weightedPoolFactory;
-    
+
     address poolOwner = makeAddr("poolOwner");
     address swapUser = makeAddr("swapUser");
-    
+
     uint256 constant MIN_SWAP_FEE = 0.001e16; // 0.001%
     uint256 constant NORMAL_SWAP_FEE = 0.01e16; // 0.01%
-    
+
     string poolName = "Test Pool";
     string poolSymbol = "TEST";
     IERC20 outputToken;
 
     function setUp() public override {
         super.setUp();
-        
+
         factory = new SwapFeeMinimizerFactory(router, vault, permit2);
-        
+
         // Deploy weighted pool factory
         weightedPoolFactory = new WeightedPoolFactory(
             vault,
             365 days, // pauseWindowDuration
-            "Factory v1", // factoryVersion  
+            "Factory v1", // factoryVersion
             "Pool v1" // poolVersion
         );
-        
+
         outputToken = dai; // Tests will minimize fees w/ DAI as outputToken
     }
 
     function _createPoolParams() internal view returns (PoolCreationParams memory) {
         TokenConfig[] memory tokens = new TokenConfig[](2);
-        tokens[0] = TokenConfig({token: dai, tokenType: TokenType.STANDARD, rateProvider: IRateProvider(address(0)), paysYieldFees: false});
-        tokens[1] = TokenConfig({token: usdc, tokenType: TokenType.STANDARD, rateProvider: IRateProvider(address(0)), paysYieldFees: false});
-        
+        tokens[0] = TokenConfig({
+            token: dai,
+            tokenType: TokenType.STANDARD,
+            rateProvider: IRateProvider(address(0)),
+            paysYieldFees: false
+        });
+        tokens[1] = TokenConfig({
+            token: usdc,
+            tokenType: TokenType.STANDARD,
+            rateProvider: IRateProvider(address(0)),
+            paysYieldFees: false
+        });
+
         // 50/50 pool
         uint256[] memory weights = new uint256[](2);
         weights[0] = 50e16;
         weights[1] = 50e16;
-        
-        return PoolCreationParams({
-            name: poolName,
-            symbol: poolSymbol,
-            tokens: tokens,
-            normalizedWeights: weights,
-            swapFeePercentage: NORMAL_SWAP_FEE,
-            poolHooksContract: address(0),
-            enableDonation: false,
-            disableUnbalancedLiquidity: false
-        });
+
+        return
+            PoolCreationParams({
+                name: poolName,
+                symbol: poolSymbol,
+                tokens: tokens,
+                normalizedWeights: weights,
+                swapFeePercentage: NORMAL_SWAP_FEE,
+                poolHooksContract: address(0),
+                enableDonation: false,
+                disableUnbalancedLiquidity: false
+            });
     }
 
     function _createMinimizerParams(address owner, uint256 minFee) internal view returns (MinimizerParams memory) {
         IERC20[] memory inputTokens = new IERC20[](1);
         inputTokens[0] = usdc;
-        
-        return MinimizerParams({
-            inputTokens: inputTokens,
-            outputToken: outputToken,
-            initialOwner: owner,
-            minimalFee: minFee
-        });
+
+        return
+            MinimizerParams({
+                inputTokens: inputTokens,
+                outputToken: outputToken,
+                initialOwner: owner,
+                minimalFee: minFee
+            });
     }
 
     function testConstructor() public view {
@@ -93,7 +109,7 @@ contract SwapFeeMinimizerFactoryTest is BaseVaultTest {
 
     function testDeployWeightedPoolWithMinimizer() public {
         bytes32 salt = keccak256("test");
-        
+
         // Deploy pool with minimizer
         (address pool, SwapFeeMinimizer minimizer) = factory.deployWeightedPoolWithMinimizer(
             _createPoolParams(),
@@ -101,21 +117,21 @@ contract SwapFeeMinimizerFactoryTest is BaseVaultTest {
             weightedPoolFactory,
             salt
         );
-        
+
         // Factory registry
         assertEq(address(factory.feeMinimizers(pool)), address(minimizer));
 
         // Pool
         assertTrue(pool != address(0));
         assertTrue(pool.code.length > 0);
-        
+
         // Minimizer
         assertTrue(address(minimizer) != address(0));
         assertEq(minimizer.getPool(), pool);
         assertEq(address(minimizer.getOutputToken()), address(outputToken));
         assertEq(minimizer.getMinimalSwapFee(), MIN_SWAP_FEE);
         assertEq(minimizer.owner(), poolOwner);
-        
+
         // Minimizer is pool's swap fee manager
         PoolRoleAccounts memory roles = vault.getPoolRoleAccounts(pool);
         assertEq(roles.swapFeeManager, address(minimizer));
@@ -123,7 +139,7 @@ contract SwapFeeMinimizerFactoryTest is BaseVaultTest {
 
     function testDeployWithInvalidMinimalFee() public {
         bytes32 salt = keccak256("test");
-        
+
         vm.expectRevert();
         factory.deployWeightedPoolWithMinimizer(
             _createPoolParams(),
@@ -140,28 +156,28 @@ contract SwapFeeMinimizerFactoryTest is BaseVaultTest {
 
     function testGetMinimizerForPool() public {
         bytes32 salt = keccak256("test");
-        
+
         (address pool, SwapFeeMinimizer minimizer) = factory.deployWeightedPoolWithMinimizer(
             _createPoolParams(),
             _createMinimizerParams(poolOwner, MIN_SWAP_FEE),
             weightedPoolFactory,
             salt
         );
-        
+
         SwapFeeMinimizer retrieved = factory.getMinimizerForPool(pool);
         assertEq(address(retrieved), address(minimizer));
     }
 
     function testMinimizerViewFunctions() public {
         bytes32 salt = keccak256("test");
-        
+
         (address pool, SwapFeeMinimizer minimizer) = factory.deployWeightedPoolWithMinimizer(
             _createPoolParams(),
             _createMinimizerParams(poolOwner, MIN_SWAP_FEE),
             weightedPoolFactory,
             salt
         );
-        
+
         assertEq(address(minimizer.getRouter()), address(router));
         assertEq(address(minimizer.getVault()), address(vault));
         assertEq(minimizer.getPool(), pool);
@@ -171,17 +187,32 @@ contract SwapFeeMinimizerFactoryTest is BaseVaultTest {
 
     function testDeployFailsWithDuplicateTokens() public {
         bytes32 salt = keccak256("duplicate-test");
-        
+
         TokenConfig[] memory tokens = new TokenConfig[](3);
-        tokens[0] = TokenConfig({token: dai, tokenType: TokenType.STANDARD, rateProvider: IRateProvider(address(0)), paysYieldFees: false});
-        tokens[1] = TokenConfig({token: usdc, tokenType: TokenType.STANDARD, rateProvider: IRateProvider(address(0)), paysYieldFees: false});
-        tokens[2] = TokenConfig({token: usdc, tokenType: TokenType.STANDARD, rateProvider: IRateProvider(address(0)), paysYieldFees: false}); // Duplicate
-        
+        tokens[0] = TokenConfig({
+            token: dai,
+            tokenType: TokenType.STANDARD,
+            rateProvider: IRateProvider(address(0)),
+            paysYieldFees: false
+        });
+        tokens[1] = TokenConfig({
+            token: usdc,
+            tokenType: TokenType.STANDARD,
+            rateProvider: IRateProvider(address(0)),
+            paysYieldFees: false
+        });
+        tokens[2] = TokenConfig({
+            token: usdc,
+            tokenType: TokenType.STANDARD,
+            rateProvider: IRateProvider(address(0)),
+            paysYieldFees: false
+        }); // Duplicate
+
         uint256[] memory weights = new uint256[](3);
         weights[0] = 33e16; // 33%
         weights[1] = 33e16; // 33%
         weights[2] = 34e16; // 34%
-        
+
         PoolCreationParams memory poolParams = PoolCreationParams({
             name: poolName,
             symbol: poolSymbol,
@@ -192,7 +223,7 @@ contract SwapFeeMinimizerFactoryTest is BaseVaultTest {
             enableDonation: false,
             disableUnbalancedLiquidity: false
         });
-        
+
         // Fails on deploy
         vm.expectRevert();
         factory.deployWeightedPoolWithMinimizer(

--- a/pkg/standalone-utils/test/foundry/SwapFeeMinimizerFactory.t.sol
+++ b/pkg/standalone-utils/test/foundry/SwapFeeMinimizerFactory.t.sol
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import { IRouter } from "@balancer-labs/v3-interfaces/contracts/vault/IRouter.sol";
+import { IBasePoolFactory } from "@balancer-labs/v3-interfaces/contracts/vault/IBasePoolFactory.sol";
+import { TokenConfig, PoolRoleAccounts, TokenType } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+import { IRateProvider } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IRateProvider.sol";
+
+import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVaultTest.sol";
+import { PoolMock } from "@balancer-labs/v3-vault/contracts/test/PoolMock.sol";
+import { RouterMock } from "@balancer-labs/v3-vault/contracts/test/RouterMock.sol";
+import { WeightedPoolFactory } from "@balancer-labs/v3-pool-weighted/contracts/WeightedPoolFactory.sol";
+import { WeightedPool } from "@balancer-labs/v3-pool-weighted/contracts/WeightedPool.sol";
+
+import { SwapFeeMinimizer } from "../../contracts/SwapFeeMinimizer/SwapFeeMinimizer.sol";
+import { SwapFeeMinimizerFactory, PoolCreationParams, MinimizerParams } from "../../contracts/SwapFeeMinimizer/SwapFeeMinimizerFactory.sol";
+
+contract SwapFeeMinimizerFactoryTest is BaseVaultTest {
+    SwapFeeMinimizerFactory factory;
+    WeightedPoolFactory weightedPoolFactory;
+    
+    address poolOwner = makeAddr("poolOwner");
+    address swapUser = makeAddr("swapUser");
+    
+    uint256 constant MIN_SWAP_FEE = 0.001e16; // 0.001%
+    uint256 constant NORMAL_SWAP_FEE = 0.01e16; // 0.01%
+    
+    string poolName = "Test Pool";
+    string poolSymbol = "TEST";
+    IERC20 outputToken;
+
+    function setUp() public override {
+        super.setUp();
+        
+        factory = new SwapFeeMinimizerFactory(router, vault, permit2);
+        
+        // Deploy weighted pool factory
+        weightedPoolFactory = new WeightedPoolFactory(
+            vault,
+            365 days, // pauseWindowDuration
+            "Factory v1", // factoryVersion  
+            "Pool v1" // poolVersion
+        );
+        
+        outputToken = dai; // Tests will minimize fees w/ DAI as outputToken
+    }
+
+    function _createPoolParams() internal view returns (PoolCreationParams memory) {
+        TokenConfig[] memory tokens = new TokenConfig[](2);
+        tokens[0] = TokenConfig({token: dai, tokenType: TokenType.STANDARD, rateProvider: IRateProvider(address(0)), paysYieldFees: false});
+        tokens[1] = TokenConfig({token: usdc, tokenType: TokenType.STANDARD, rateProvider: IRateProvider(address(0)), paysYieldFees: false});
+        
+        // 50/50 pool
+        uint256[] memory weights = new uint256[](2);
+        weights[0] = 50e16;
+        weights[1] = 50e16;
+        
+        return PoolCreationParams({
+            name: poolName,
+            symbol: poolSymbol,
+            tokens: tokens,
+            normalizedWeights: weights,
+            swapFeePercentage: NORMAL_SWAP_FEE,
+            poolHooksContract: address(0),
+            enableDonation: false,
+            disableUnbalancedLiquidity: false
+        });
+    }
+
+    function _createMinimizerParams(address owner, uint256 minFee) internal view returns (MinimizerParams memory) {
+        IERC20[] memory inputTokens = new IERC20[](1);
+        inputTokens[0] = usdc;
+        
+        return MinimizerParams({
+            inputTokens: inputTokens,
+            outputToken: outputToken,
+            initialOwner: owner,
+            minimalFee: minFee
+        });
+    }
+
+    function testConstructor() public view {
+        assertEq(address(factory.router()), address(router));
+        assertEq(address(factory.vault()), address(vault));
+    }
+
+    function testDeployWeightedPoolWithMinimizer() public {
+        bytes32 salt = keccak256("test");
+        
+        // Deploy pool with minimizer
+        (address pool, SwapFeeMinimizer minimizer) = factory.deployWeightedPoolWithMinimizer(
+            _createPoolParams(),
+            _createMinimizerParams(poolOwner, MIN_SWAP_FEE),
+            weightedPoolFactory,
+            salt
+        );
+        
+        // Factory registry
+        assertEq(address(factory.feeMinimizers(pool)), address(minimizer));
+
+        // Pool
+        assertTrue(pool != address(0));
+        assertTrue(pool.code.length > 0);
+        
+        // Minimizer
+        assertTrue(address(minimizer) != address(0));
+        assertEq(minimizer.getPool(), pool);
+        assertEq(address(minimizer.getOutputToken()), address(outputToken));
+        assertEq(minimizer.getMinimalSwapFee(), MIN_SWAP_FEE);
+        assertEq(minimizer.owner(), poolOwner);
+        
+        // Minimizer is pool's swap fee manager
+        PoolRoleAccounts memory roles = vault.getPoolRoleAccounts(pool);
+        assertEq(roles.swapFeeManager, address(minimizer));
+    }
+
+    function testDeployWithInvalidMinimalFee() public {
+        bytes32 salt = keccak256("test");
+        
+        vm.expectRevert();
+        factory.deployWeightedPoolWithMinimizer(
+            _createPoolParams(),
+            _createMinimizerParams(poolOwner, MIN_SWAP_FEE - 1),
+            weightedPoolFactory,
+            salt
+        );
+    }
+
+    function testGetCurrentPoolFailsWhenNoPending() public {
+        vm.expectRevert(SwapFeeMinimizerFactory.NoPendingPool.selector);
+        factory.getCurrentPool();
+    }
+
+    function testGetMinimizerForPool() public {
+        bytes32 salt = keccak256("test");
+        
+        (address pool, SwapFeeMinimizer minimizer) = factory.deployWeightedPoolWithMinimizer(
+            _createPoolParams(),
+            _createMinimizerParams(poolOwner, MIN_SWAP_FEE),
+            weightedPoolFactory,
+            salt
+        );
+        
+        SwapFeeMinimizer retrieved = factory.getMinimizerForPool(pool);
+        assertEq(address(retrieved), address(minimizer));
+    }
+
+    function testMinimizerViewFunctions() public {
+        bytes32 salt = keccak256("test");
+        
+        (address pool, SwapFeeMinimizer minimizer) = factory.deployWeightedPoolWithMinimizer(
+            _createPoolParams(),
+            _createMinimizerParams(poolOwner, MIN_SWAP_FEE),
+            weightedPoolFactory,
+            salt
+        );
+        
+        assertEq(address(minimizer.getRouter()), address(router));
+        assertEq(address(minimizer.getVault()), address(vault));
+        assertEq(minimizer.getPool(), pool);
+        assertEq(address(minimizer.getOutputToken()), address(outputToken));
+        assertEq(minimizer.getMinimalSwapFee(), MIN_SWAP_FEE);
+    }
+
+    function testDeployFailsWithDuplicateTokens() public {
+        bytes32 salt = keccak256("duplicate-test");
+        
+        TokenConfig[] memory tokens = new TokenConfig[](3);
+        tokens[0] = TokenConfig({token: dai, tokenType: TokenType.STANDARD, rateProvider: IRateProvider(address(0)), paysYieldFees: false});
+        tokens[1] = TokenConfig({token: usdc, tokenType: TokenType.STANDARD, rateProvider: IRateProvider(address(0)), paysYieldFees: false});
+        tokens[2] = TokenConfig({token: usdc, tokenType: TokenType.STANDARD, rateProvider: IRateProvider(address(0)), paysYieldFees: false}); // Duplicate
+        
+        uint256[] memory weights = new uint256[](3);
+        weights[0] = 33e16; // 33%
+        weights[1] = 33e16; // 33%
+        weights[2] = 34e16; // 34%
+        
+        PoolCreationParams memory poolParams = PoolCreationParams({
+            name: poolName,
+            symbol: poolSymbol,
+            tokens: tokens,
+            normalizedWeights: weights,
+            swapFeePercentage: NORMAL_SWAP_FEE,
+            poolHooksContract: address(0),
+            enableDonation: false,
+            disableUnbalancedLiquidity: false
+        });
+        
+        // Fails on deploy
+        vm.expectRevert();
+        factory.deployWeightedPoolWithMinimizer(
+            poolParams,
+            _createMinimizerParams(poolOwner, MIN_SWAP_FEE),
+            weightedPoolFactory,
+            salt
+        );
+    }
+}


### PR DESCRIPTION
# Description
This PR adds a new contract, `SwapFeeMinimizer` (with accompanying factory), that allows the `owner` to swap out one specific `outputToken` with as low of a swap fee as possible, regardless of the nominal swap fee of the pool. All other operations with the pool are unchanged, and anyone (`owner` included) can swap with the nominal swap fees in the pool via a typical router. There are a few potential use cases for this functionality, though one notable use case is the ability for a DAO to perform token buybacks on a primary liquidity pool w/o needing to pay the typical swap fee.

## Details
- A new `SwapFeeMinimizer` is deployed atomically alongside a new `WeightedPool`
- Swaps through a given `SwapFeeMinimizer` are constrained to its specific `pool` and `outputToken`
- When an `owner` performs a swap, the contract stores the pool's current swap fee, then pool swap fees are set to `_minimalSwapFee`, the swap occurs, and then the fee is returned to its original level
- Interfaces for swaps are identical to those of the router
- A `SwapFeeManager` is registered as the pool's `PoolRoleAccounts.swapFeeManager`
- The `SwapFeeManager` contract has a passthrough function for `vault.setStaticSwapFeePercentage(...)`, though there is an argument to be made for removing this
- `SwapFeeMinimizer` is `Ownable2Step`

## Architectural Context
The initial plan was for this contract itself to _be_ a router. Changing the architecture from an "is a" context to a "has a" context had significant improvements for simplicity and security, but they come with a few small concessions. With this setup, the `SwapFeeMinimizer` itself has to transfer tokens from the `owner` and be an intermediary with the router, which introduces some allowance handling and minor token accounting. It would have been nice to be able to inherit small parts of the broader router contract, but short of fundamentally rearchitecting the core Balancer router, this was impractical, and the realistic options here came down to:
1. inherit the entire router and expand the scope and bytecode of this contract
2. copy and paste the external swap functions and internal helpers I needed
3. have this contract itself call the router's swap functions and handle token transfers from the `owner`

I went with Option 3 to keep the contract as small as practical, offering simplicity and minimized attack surface. The gas for a fee-minimized swap is a little higher, most notably due to the increased token transfers.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution
cc: grants committee @mendesfabio 
