### PR TITLE
Remove stale comments

### DIFF
--- a/pkg/vault/contracts/BatchRouterHooks.sol
+++ b/pkg/vault/contracts/BatchRouterHooks.sol
@@ -225,8 +225,7 @@ abstract contract BatchRouterHooks is BatchRouterCommon {
 
         // Remove liquidity is not transient for BPT, meaning the caller needs to have the required amount
         // when performing the operation. These tokens might be the output of a previous step, in which case
-        // the user will have a BPT credit. In the prepaid case, we assume BPT tokens are transferred to the
-        // Router, and not the Vault.
+        // the user will have a BPT credit.
         if (isFirstStep) {
             if (stepExactAmountIn > 0 && sender != address(this)) {
                 // If this is the first step, the sender must have the tokens. Therefore, we can transfer them to the
@@ -562,8 +561,7 @@ abstract contract BatchRouterHooks is BatchRouterCommon {
 
         // Remove liquidity is not transient for BPT, meaning the caller needs to have the required amount when
         // performing the operation. In this case, the BPT amount needed for the operation is not known in advance,
-        // so we take a flashloan for all the available reserves. In the prepaid case, we assume BPT tokens were
-        // transferred to the Router, and not the Vault.
+        // so we take a flashloan for all the available reserves.
         //
         // The last step is the one that defines the inputs for this path. The caller should have enough
         // BPT to burn already if that's the case, so we just skip this step if so.


### PR DESCRIPTION
# Description

Tiny one that removes some obsolete comments. We simplified the prepaid router UX in #1574, but there are still comments referring to the previous code.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [X] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
