### PR TITLE
Add comment to weighted math about rounding of exponent

### DIFF
--- a/pkg/solidity-utils/contracts/math/WeightedMath.sol
+++ b/pkg/solidity-utils/contracts/math/WeightedMath.sol
@@ -244,7 +244,6 @@ library WeightedMath {
         }
 
         uint256 base = balanceOut.divUp(balanceOut - amountOut);
-        // `base` is always smaller than 1. To round power down, we need to round the exponent up.
         uint256 exponent = weightOut.divUp(weightIn);
         uint256 power = base.powUp(exponent);
 


### PR DESCRIPTION
# Description

Looking the rounding of weighted math, at first, is not intuitive. One could think that, to round power up, we should round exponent up, but it's the other way around because of the base, which is always smaller than 1.

This PR adds a comment to help us identify this nuance in the future.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [x] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge
