### PR TITLE
Run Slither in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,20 @@ jobs:
           name: built-contracts
           path: pkg/
 
+  slither:
+    runs-on: ubuntu-latest
+    needs: lint-and-build
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up environment
+        uses: ./.github/actions/setup
+      - name: Install Slither
+        run: yarn slither-install
+      - name: Run Slither
+        run: yarn slither
+        # Report the existing Slither baseline in CI without blocking unrelated PRs.
+        continue-on-error: true
+
   test-forge-vault:
     runs-on: ubuntu-latest
     needs: lint-and-build

--- a/package.json
+++ b/package.json
@@ -56,8 +56,9 @@
     "test:forge": "yarn workspaces foreach --all --parallel --jobs unlimited --verbose run test:forge",
     "coverage": "yarn workspaces foreach --all --verbose run coverage:all",
     "gas": "yarn workspaces foreach --all --parallel --jobs unlimited --verbose run gas",
-    "slither-install": "python3 -m venv slither && bash -c 'source slither/bin/activate && pip3 install https://github.com/crytic/slither/releases/download/0.10.1/0.10.1.zip'",
-    "slither": "yarn workspaces foreach --parallel --jobs unlimited --verbose run slither",
+    "slither-install": "python3 -m venv slither && bash -c 'source slither/bin/activate && pip3 install \"setuptools<81\" https://github.com/crytic/slither/releases/download/0.10.1/0.10.1.zip'",
+    "slither": "yarn workspaces foreach --all --parallel --jobs unlimited --verbose run slither",
+    "slither:triage": "yarn workspaces foreach --all --parallel --jobs unlimited --verbose run slither:triage",
     "generate-errors": "npx ts-node scripts/generate-errors.ts"
   },
   "workspaces": [


### PR DESCRIPTION
# Description

Adds a dedicated Slither job to the main CI workflow, using the repository's existing Slither install and per-workspace Slither scripts.

This also fixes two blockers I hit while validating the CI path locally:

- `yarn slither` was missing the required Yarn 4 workspace selector (`--all`), so it failed before running any workspace scripts.
- Slither 0.10.1 imports `pkg_resources`; modern `setuptools` releases no longer provide it, so `slither-install` now pins `setuptools<81` inside the venv.

The Slither CI step is currently `continue-on-error` so the existing Slither baseline is reported in CI without blocking unrelated PRs. Once the current baseline is refreshed/triaged, this can be made blocking.

## Type of change

- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [ ] Changeset is included
- [x] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Addresses #1592.

## Validation

- `HUSKY=0 yarn --immutable`
- `yarn slither-install`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`
- `yarn workspaces foreach --all --dry-run run slither`
- `yarn slither` now reaches workspace compilation/Slither execution; it exits nonzero on existing Slither findings, which is why the initial CI job is non-blocking.
