### PR TITLE
Fix price impact helper for proportional adds

### DIFF
--- a/pkg/standalone-utils/contracts/PriceImpactHelper.sol
+++ b/pkg/standalone-utils/contracts/PriceImpactHelper.sol
@@ -42,6 +42,11 @@ contract PriceImpactHelper is CallAndRevert {
             deltas[i] = proportionalAmountsOut[i].toInt256() - exactAmountsIn[i].toInt256();
         }
 
+        (bool hasPositiveDelta, bool hasNegativeDelta) = _hasPositiveAndNegative(deltas);
+        if (!hasPositiveDelta || !hasNegativeDelta) {
+            return 0;
+        }
+
         // query add liquidity for each delta, so we know how unbalanced each amount in is in terms of BPT
         int256[] memory deltaBPTs = new int256[](exactAmountsIn.length);
         for (uint256 i = 0; i < exactAmountsIn.length; i++) {
@@ -53,7 +58,12 @@ contract PriceImpactHelper is CallAndRevert {
 
         // calculate price impact ABA with remaining delta and its respective exactAmountIn
         // remaining delta is always negative, so by multiplying by -1 we get a positive number
-        uint256 delta = (-deltas[remainingDeltaIndex]).toUint256();
+        int256 remainingDelta = deltas[remainingDeltaIndex];
+        if (remainingDelta == 0) {
+            return 0;
+        }
+
+        uint256 delta = (-remainingDelta).toUint256();
         return delta.divDown(exactAmountsIn[remainingDeltaIndex]) / 2;
     }
 
@@ -182,54 +192,80 @@ contract PriceImpactHelper is CallAndRevert {
         int256[] memory deltaBPTs,
         address sender
     ) internal returns (uint256) {
+        uint256 nonZeroDeltaBPTs = _countNonZero(deltaBPTs);
+        if (nonZeroDeltaBPTs == 0) {
+            return 0;
+        }
+
         // Index of closest from 0 negative number in deltaBPTs array.
-        uint256 maxNegativeDeltaIndex = 0;
+        uint256 maxNegativeDeltaIndex = _maxNegativeIndex(deltaBPTs);
         IERC20[] memory poolTokens = _vault.getPoolTokens(pool);
 
-        for (uint256 i = 0; i < deltas.length - 1; i++) {
+        for (uint256 i = 0; i < nonZeroDeltaBPTs - 1; i++) {
             // get minPositiveDeltaIndex and maxNegativeDeltaIndex
             uint256 minPositiveDeltaIndex = _minPositiveIndex(deltaBPTs);
             maxNegativeDeltaIndex = _maxNegativeIndex(deltaBPTs);
 
-            uint256 givenTokenIndex;
-            uint256 resultTokenIndex;
-            uint256 resultAmount;
-
             if (deltaBPTs[minPositiveDeltaIndex] < -deltaBPTs[maxNegativeDeltaIndex]) {
-                givenTokenIndex = minPositiveDeltaIndex;
-                resultTokenIndex = maxNegativeDeltaIndex;
-                resultAmount = _querySwapSingleTokenExactIn(
+                uint256 resultAmount = _querySwapSingleTokenExactIn(
                     pool,
-                    poolTokens[givenTokenIndex],
-                    poolTokens[resultTokenIndex],
-                    deltas[givenTokenIndex].toUint256(),
+                    poolTokens[minPositiveDeltaIndex],
+                    poolTokens[maxNegativeDeltaIndex],
+                    deltas[minPositiveDeltaIndex].toUint256(),
+                    sender
+                );
+
+                // Update deltas and deltaBPTs
+                deltas[minPositiveDeltaIndex] = 0;
+                deltaBPTs[minPositiveDeltaIndex] = 0;
+                deltas[maxNegativeDeltaIndex] += resultAmount.toInt256();
+                deltaBPTs[maxNegativeDeltaIndex] = _queryAddLiquidityUnbalancedForTokenDeltas(
+                    pool,
+                    maxNegativeDeltaIndex,
+                    deltas,
                     sender
                 );
             } else {
-                givenTokenIndex = maxNegativeDeltaIndex;
-                resultTokenIndex = minPositiveDeltaIndex;
-                resultAmount = _querySwapSingleTokenExactOut(
+                uint256 resultAmount = _querySwapSingleTokenExactOut(
                     pool,
-                    poolTokens[resultTokenIndex],
-                    poolTokens[givenTokenIndex],
-                    (-deltas[givenTokenIndex]).toUint256(),
+                    poolTokens[minPositiveDeltaIndex],
+                    poolTokens[maxNegativeDeltaIndex],
+                    (-deltas[maxNegativeDeltaIndex]).toUint256(),
+                    sender
+                );
+
+                // Update deltas and deltaBPTs
+                deltas[maxNegativeDeltaIndex] = 0;
+                deltaBPTs[maxNegativeDeltaIndex] = 0;
+                deltas[minPositiveDeltaIndex] += resultAmount.toInt256();
+                deltaBPTs[minPositiveDeltaIndex] = _queryAddLiquidityUnbalancedForTokenDeltas(
+                    pool,
+                    minPositiveDeltaIndex,
+                    deltas,
                     sender
                 );
             }
-
-            // Update deltas and deltaBPTs
-            deltas[givenTokenIndex] = 0;
-            deltaBPTs[givenTokenIndex] = 0;
-            deltas[resultTokenIndex] += resultAmount.toInt256();
-            deltaBPTs[resultTokenIndex] = _queryAddLiquidityUnbalancedForTokenDeltas(
-                pool,
-                resultTokenIndex,
-                deltas,
-                sender
-            );
         }
 
         return maxNegativeDeltaIndex;
+    }
+
+    function _countNonZero(int256[] memory array) internal pure returns (uint256 count) {
+        for (uint256 i = 0; i < array.length; i++) {
+            if (array[i] != 0) {
+                count++;
+            }
+        }
+    }
+
+    function _hasPositiveAndNegative(int256[] memory array) internal pure returns (bool hasPositive, bool hasNegative) {
+        for (uint256 i = 0; i < array.length; i++) {
+            if (array[i] > 0) {
+                hasPositive = true;
+            } else if (array[i] < 0) {
+                hasNegative = true;
+            }
+        }
     }
 
     // returns the index of the smallest positive integer in an array - i.e. [3, 2, -2, -3] returns 1

--- a/pkg/standalone-utils/contracts/test/PriceImpactHelperMock.sol
+++ b/pkg/standalone-utils/contracts/test/PriceImpactHelperMock.sol
@@ -35,4 +35,8 @@ contract PriceImpactHelperMock is PriceImpactHelper {
     function maxNegativeIndex(int256[] memory array) external pure returns (uint256) {
         return _maxNegativeIndex(array);
     }
+
+    function countNonZero(int256[] memory array) external pure returns (uint256) {
+        return _countNonZero(array);
+    }
 }

--- a/pkg/standalone-utils/test/foundry/PriceImpact.t.sol
+++ b/pkg/standalone-utils/test/foundry/PriceImpact.t.sol
@@ -113,4 +113,19 @@ contract PriceImpactTest is BaseVaultTest {
 
         vm.stopPrank();
     }
+
+    function testProportionalAddLiquidityHasZeroPriceImpact() public {
+        vm.startPrank(address(0), address(0));
+        uint256 snapshot = vm.snapshotState();
+
+        uint256 amountIn = poolInitAmount / 2;
+        uint256[] memory amountsIn = [amountIn, amountIn].toMemoryArray();
+
+        uint256 priceImpact = priceImpactHelper.calculateAddLiquidityUnbalancedPriceImpact(pool, amountsIn, address(0));
+        vm.revertToState(snapshot);
+
+        assertEq(priceImpact, 0, "proportional liquidity add should have no price impact");
+
+        vm.stopPrank();
+    }
 }

--- a/pkg/standalone-utils/test/foundry/PriceImpactUnit.t.sol
+++ b/pkg/standalone-utils/test/foundry/PriceImpactUnit.t.sol
@@ -39,6 +39,31 @@ contract PriceImpactUnitTest is BaseVaultTest {
         assertEq(expectedIndex, minIndex, "expected min value index wrong");
     }
 
+    function testCountNonZero__Fuzz(int256[10] memory arrayRaw) public view {
+        int256[] memory array = new int256[](arrayRaw.length);
+        uint256 expectedCount = 0;
+
+        for (uint256 i = 0; i < arrayRaw.length; i++) {
+            array[i] = arrayRaw[i];
+            if (arrayRaw[i] != 0) {
+                expectedCount++;
+            }
+        }
+
+        assertEq(priceImpactHelper.countNonZero(array), expectedCount, "non-zero count is wrong");
+    }
+
+    function testZeroOutDeltasReturnsZeroForAllZeroDeltaBPTs() public {
+        int256[] memory deltas = new int256[](2);
+        int256[] memory deltaBPTs = new int256[](2);
+
+        uint256 remainingDeltaIndex = priceImpactHelper.zeroOutDeltas(pool, deltas, deltaBPTs, address(this));
+
+        assertEq(remainingDeltaIndex, 0, "remaining delta index is wrong");
+        assertEq(deltas[0], 0, "first delta changed");
+        assertEq(deltas[1], 0, "second delta changed");
+    }
+
     function testQueryAddLiquidityUnbalancedForTokenDeltas__Fuzz(
         int256[10] memory deltasRaw,
         uint256 length,


### PR DESCRIPTION
## Summary
- Return zero price impact for proportional or near-proportional add-liquidity inputs where deltas do not contain both positive and negative sides.
- Avoid running the delta zero-out path when all delta BPT values are zero, and only iterate over non-zero delta BPTs.
- Add unit and integration coverage for the all-zero delta path and proportional add-liquidity price impact.

Closes #1208

## Testing
- `prettier --write pkg/standalone-utils/contracts/PriceImpactHelper.sol pkg/standalone-utils/contracts/test/PriceImpactHelperMock.sol pkg/standalone-utils/test/foundry/PriceImpactUnit.t.sol pkg/standalone-utils/test/foundry/PriceImpact.t.sol`
- `FOUNDRY_ALLOW_PATHS=[...] forge test --match-path test/foundry/PriceImpactUnit.t.sol`
- `FOUNDRY_ALLOW_PATHS=[...] forge test --match-path test/foundry/PriceImpact.t.sol`
- `git diff --check`