### PR TITLE
Add a factory for unpausable stable pools

### DIFF
--- a/.changeset/calm-pools-stay.md
+++ b/.changeset/calm-pools-stay.md
@@ -1,0 +1,5 @@
+---
+'@balancer-labs/v3-pool-stable': minor
+---
+
+Add `UnpausableStablePoolFactory`, a special-purpose factory that creates Stable Pools with a pause window duration of zero, making them effectively unpausable.

--- a/pkg/pool-stable/contracts/UnpausableStablePoolFactory.sol
+++ b/pkg/pool-stable/contracts/UnpausableStablePoolFactory.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IPoolVersion } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IPoolVersion.sol";
+import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import {
+    TokenConfig,
+    PoolRoleAccounts,
+    LiquidityManagement
+} from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+
+import { BasePoolFactory } from "@balancer-labs/v3-pool-utils/contracts/BasePoolFactory.sol";
+import { StableMath } from "@balancer-labs/v3-solidity-utils/contracts/math/StableMath.sol";
+import { Version } from "@balancer-labs/v3-solidity-utils/contracts/helpers/Version.sol";
+
+import { StablePool } from "./StablePool.sol";
+
+/**
+ * @notice Unpausable Stable Pool factory.
+ * @dev This is a special purpose pool factory that creates Stable Pools without pause functionality. By design,
+ * pause functionality in V3 is handled by the Vault, and there is no way for a V3 pool to "opt out" of the core
+ * pause mechanism. However, since the pause window duration is configurable (with no lower limit), it is possible
+ * to deploy pools with a pause window duration of 0 seconds, effectively making them unpausable.
+ */
+contract UnpausableStablePoolFactory is IPoolVersion, BasePoolFactory, Version {
+    string private _poolVersion;
+
+    /// @dev Hard-code the pause duration to 0 seconds, making pools created by this factory effectively unpausable.
+    constructor(
+        IVault vault,
+        string memory factoryVersion,
+        string memory poolVersion
+    ) BasePoolFactory(vault, 0, type(StablePool).creationCode) Version(factoryVersion) {
+        _poolVersion = poolVersion;
+    }
+
+    /// @inheritdoc IPoolVersion
+    function getPoolVersion() external view returns (string memory) {
+        return _poolVersion;
+    }
+
+    /**
+     * @notice Deploys a new `StablePool`.
+     * @param name The name of the pool
+     * @param symbol The symbol of the pool
+     * @param tokens An array of descriptors for the tokens the pool will manage
+     * @param amplificationParameter Starting value of the amplificationParameter (see StablePool)
+     * @param roleAccounts Addresses the Vault will allow to change certain pool settings
+     * @param swapFeePercentage Initial swap fee percentage
+     * @param poolHooksContract Contract that implements the hooks for the pool
+     * @param enableDonation If true, the pool will support the donation add liquidity mechanism
+     * @param disableUnbalancedLiquidity If true, only proportional add and remove liquidity are accepted
+     * @param salt The salt value that will be passed to deployment
+     */
+    function create(
+        string memory name,
+        string memory symbol,
+        TokenConfig[] memory tokens,
+        uint256 amplificationParameter,
+        PoolRoleAccounts memory roleAccounts,
+        uint256 swapFeePercentage,
+        address poolHooksContract,
+        bool enableDonation,
+        bool disableUnbalancedLiquidity,
+        bytes32 salt
+    ) external returns (address pool) {
+        // As the Stable Pool deployment does not know about the tokens, and the registration doesn't know about the
+        // pool type, we enforce the token limit at the factory level.
+        if (tokens.length > StableMath.MAX_STABLE_TOKENS) {
+            revert IVaultErrors.MaxTokens();
+        }
+
+        LiquidityManagement memory liquidityManagement = getDefaultLiquidityManagement();
+        liquidityManagement.enableDonation = enableDonation;
+        liquidityManagement.disableUnbalancedLiquidity = disableUnbalancedLiquidity;
+
+        pool = _create(
+            abi.encode(
+                StablePool.NewPoolParams({
+                    name: name,
+                    symbol: symbol,
+                    amplificationParameter: amplificationParameter,
+                    version: _poolVersion
+                }),
+                getVault()
+            ),
+            salt
+        );
+
+        _registerPoolWithVault(
+            pool,
+            tokens,
+            swapFeePercentage,
+            false, // not exempt from protocol fees
+            roleAccounts,
+            poolHooksContract,
+            liquidityManagement
+        );
+    }
+}

--- a/pkg/pool-stable/test/foundry/StablePoolFactory.t.sol
+++ b/pkg/pool-stable/test/foundry/StablePoolFactory.t.sol
@@ -2,42 +2,48 @@
 
 pragma solidity ^0.8.24;
 
-import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
-
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
-import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 
 import { CastingHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/CastingHelpers.sol";
 import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/test/ArrayHelpers.sol";
-import { BalancerPoolToken } from "@balancer-labs/v3-vault/contracts/BalancerPoolToken.sol";
-import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVaultTest.sol";
-import { StableMath } from "@balancer-labs/v3-solidity-utils/contracts/math/StableMath.sol";
 
+import { BaseStablePoolFactoryTest } from "./utils/BaseStablePoolFactoryTest.sol";
 import { StablePoolFactory } from "../../contracts/StablePoolFactory.sol";
-import { StablePoolContractsDeployer } from "./utils/StablePoolContractsDeployer.sol";
 
-contract StablePoolFactoryTest is BaseVaultTest, StablePoolContractsDeployer {
+contract StablePoolFactoryTest is BaseStablePoolFactoryTest {
     using CastingHelpers for address[];
     using ArrayHelpers for *;
 
-    uint256 internal daiIdx;
-    uint256 internal usdcIdx;
-
-    // Maximum swap fee of 10%
-    uint64 public constant MAX_SWAP_FEE_PERCENTAGE = 10e16;
-
     StablePoolFactory internal stablePoolFactory;
-
-    uint256 internal constant DEFAULT_AMP_FACTOR = 200;
 
     function setUp() public override {
         super.setUp();
 
         stablePoolFactory = deployStablePoolFactory(IVault(address(vault)), 365 days, "Factory v1", "Pool v1");
         vm.label(address(stablePoolFactory), "stable pool factory");
+    }
 
-        (daiIdx, usdcIdx) = getSortedIndexes(address(dai), address(usdc));
+    function createStablePool(
+        string memory name,
+        string memory symbol,
+        TokenConfig[] memory tokenConfig,
+        PoolRoleAccounts memory roleAccounts,
+        bool enableDonation
+    ) internal override returns (address) {
+        return
+            stablePoolFactory.create(
+                name,
+                symbol,
+                tokenConfig,
+                DEFAULT_AMP_FACTOR,
+                roleAccounts,
+                MAX_SWAP_FEE_PERCENTAGE,
+                address(0),
+                enableDonation,
+                false, // Do not disable unbalanced add/remove liquidity
+                ZERO_BYTES32
+            );
     }
 
     function testFactoryPausedState() public view {
@@ -45,127 +51,35 @@ contract StablePoolFactoryTest is BaseVaultTest, StablePoolContractsDeployer {
         assertEq(pauseWindowDuration, 365 days);
     }
 
-    function testCreatePoolWithoutDonation() public {
-        address stablePool = _deployAndInitializeStablePool(false);
-
-        // Try to donate but fails because pool does not support donations
-        vm.prank(bob);
-        vm.expectRevert(IVaultErrors.DoesNotSupportDonation.selector);
-        router.donate(stablePool, [poolInitAmount, poolInitAmount].toMemoryArray(), false, bytes(""));
+    function testFactoryVersions() public view {
+        assertEq(stablePoolFactory.version(), "Factory v1", "Wrong factory version");
+        assertEq(stablePoolFactory.getPoolVersion(), "Pool v1", "Wrong pool version");
     }
 
-    function testCreatePoolWithDonation() public {
-        uint256 amountToDonate = poolInitAmount;
-
-        address stablePool = _deployAndInitializeStablePool(true);
-
-        HookTestLocals memory vars = _createHookTestLocals(stablePool);
-
-        // Donates to pool successfully
-        vm.prank(bob);
-        router.donate(stablePool, [amountToDonate, amountToDonate].toMemoryArray(), false, bytes(""));
-
-        _fillAfterHookTestLocals(vars, stablePool);
-
-        // Bob balances
-        assertEq(vars.bob.daiBefore - vars.bob.daiAfter, amountToDonate, "Bob DAI balance is wrong");
-        assertEq(vars.bob.usdcBefore - vars.bob.usdcAfter, amountToDonate, "Bob USDC balance is wrong");
-        assertEq(vars.bob.bptAfter, vars.bob.bptBefore, "Bob BPT balance is wrong");
-
-        // Pool balances
-        assertEq(vars.poolAfter[daiIdx] - vars.poolBefore[daiIdx], amountToDonate, "Pool DAI balance is wrong");
-        assertEq(vars.poolAfter[usdcIdx] - vars.poolBefore[usdcIdx], amountToDonate, "Pool USDC balance is wrong");
-        assertEq(vars.bptSupplyAfter, vars.bptSupplyBefore, "Pool BPT supply is wrong");
-
-        // Vault Balances
-        assertEq(vars.vault.daiAfter - vars.vault.daiBefore, amountToDonate, "Vault DAI balance is wrong");
-        assertEq(vars.vault.usdcAfter - vars.vault.usdcBefore, amountToDonate, "Vault USDC balance is wrong");
-    }
-
-    function testCreatePoolWithTooManyTokens() public {
-        IERC20[] memory bigPoolTokens = new IERC20[](StableMath.MAX_STABLE_TOKENS + 1);
-        for (uint256 i = 0; i < bigPoolTokens.length; ++i) {
-            bigPoolTokens[i] = createERC20(string.concat("TKN", Strings.toString(i)), 18);
-        }
-
-        TokenConfig[] memory tokenConfig = vault.buildTokenConfig(bigPoolTokens);
+    function testPauseManagerCanPausePool() public {
         PoolRoleAccounts memory roleAccounts;
+        roleAccounts.pauseManager = admin;
 
-        vm.expectRevert(IVaultErrors.MaxTokens.selector);
-        stablePoolFactory.create(
-            "Big Pool",
-            "TOO_BIG",
-            tokenConfig,
-            DEFAULT_AMP_FACTOR,
-            roleAccounts,
-            MAX_SWAP_FEE_PERCENTAGE,
-            address(0),
-            false,
-            false,
-            ZERO_BYTES32
-        );
-    }
-
-    function _deployAndInitializeStablePool(bool supportsDonation) private returns (address) {
-        PoolRoleAccounts memory roleAccounts;
         IERC20[] memory tokens = [address(dai), address(usdc)].toMemoryArray().asIERC20();
-
-        address stablePool = stablePoolFactory.create(
-            supportsDonation ? "Pool With Donation" : "Pool Without Donation",
-            supportsDonation ? "PwD" : "PwoD",
+        address stablePool = createStablePool(
+            "Pausable Pool",
+            "PAUSABLE",
             vault.buildTokenConfig(tokens),
-            DEFAULT_AMP_FACTOR,
             roleAccounts,
-            MAX_SWAP_FEE_PERCENTAGE,
-            address(0),
-            supportsDonation,
-            false, // Do not disable unbalanced add/remove liquidity
-            ZERO_BYTES32
+            false
         );
 
-        // Initialize pool
-        vm.prank(lp);
-        router.initialize(stablePool, tokens, [poolInitAmount, poolInitAmount].toMemoryArray(), 0, false, bytes(""));
+        (, uint32 pauseWindowEndTime, , address pauseManager) = vault.getPoolPausedState(stablePool);
+        assertEq(pauseManager, admin, "Wrong pause manager");
+        assertEq(
+            pauseWindowEndTime,
+            stablePoolFactory.getOriginalPauseWindowEndTime(),
+            "Wrong pool pause window end time"
+        );
 
-        return stablePool;
-    }
+        vm.prank(admin);
+        vault.pausePool(stablePool);
 
-    struct WalletState {
-        uint256 daiBefore;
-        uint256 daiAfter;
-        uint256 usdcBefore;
-        uint256 usdcAfter;
-        uint256 bptBefore;
-        uint256 bptAfter;
-    }
-
-    struct HookTestLocals {
-        WalletState bob;
-        WalletState hook;
-        WalletState vault;
-        uint256[] poolBefore;
-        uint256[] poolAfter;
-        uint256 bptSupplyBefore;
-        uint256 bptSupplyAfter;
-    }
-
-    function _createHookTestLocals(address pool) private view returns (HookTestLocals memory vars) {
-        vars.bob.daiBefore = dai.balanceOf(bob);
-        vars.bob.usdcBefore = usdc.balanceOf(bob);
-        vars.bob.bptBefore = IERC20(pool).balanceOf(bob);
-        vars.vault.daiBefore = dai.balanceOf(address(vault));
-        vars.vault.usdcBefore = usdc.balanceOf(address(vault));
-        vars.poolBefore = vault.getRawBalances(pool);
-        vars.bptSupplyBefore = BalancerPoolToken(pool).totalSupply();
-    }
-
-    function _fillAfterHookTestLocals(HookTestLocals memory vars, address pool) private view {
-        vars.bob.daiAfter = dai.balanceOf(bob);
-        vars.bob.usdcAfter = usdc.balanceOf(bob);
-        vars.bob.bptAfter = IERC20(pool).balanceOf(bob);
-        vars.vault.daiAfter = dai.balanceOf(address(vault));
-        vars.vault.usdcAfter = usdc.balanceOf(address(vault));
-        vars.poolAfter = vault.getRawBalances(pool);
-        vars.bptSupplyAfter = BalancerPoolToken(pool).totalSupply();
+        assertTrue(vault.isPoolPaused(stablePool), "Pool not paused");
     }
 }

--- a/pkg/pool-stable/test/foundry/UnpausableStablePoolFactory.t.sol
+++ b/pkg/pool-stable/test/foundry/UnpausableStablePoolFactory.t.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IVaultAdmin } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultAdmin.sol";
+import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+
+import { CastingHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/CastingHelpers.sol";
+import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/test/ArrayHelpers.sol";
+
+import { UnpausableStablePoolFactory } from "../../contracts/UnpausableStablePoolFactory.sol";
+import { BaseStablePoolFactoryTest } from "./utils/BaseStablePoolFactoryTest.sol";
+
+contract UnpausableStablePoolFactoryTest is BaseStablePoolFactoryTest {
+    using CastingHelpers for address[];
+    using ArrayHelpers for *;
+
+    UnpausableStablePoolFactory internal unpausablePoolFactory;
+
+    function setUp() public override {
+        super.setUp();
+
+        unpausablePoolFactory = deployUnpausableStablePoolFactory(IVault(address(vault)), "Factory v1", "Pool v1");
+        vm.label(address(unpausablePoolFactory), "unpausable stable pool factory");
+    }
+
+    function createStablePool(
+        string memory name,
+        string memory symbol,
+        TokenConfig[] memory tokenConfig,
+        PoolRoleAccounts memory roleAccounts,
+        bool enableDonation
+    ) internal override returns (address) {
+        return
+            unpausablePoolFactory.create(
+                name,
+                symbol,
+                tokenConfig,
+                DEFAULT_AMP_FACTOR,
+                roleAccounts,
+                MAX_SWAP_FEE_PERCENTAGE,
+                address(0),
+                enableDonation,
+                false, // Do not disable unbalanced add/remove liquidity
+                ZERO_BYTES32
+            );
+    }
+
+    function testFactoryPausedState() public view {
+        assertEq(unpausablePoolFactory.getPauseWindowDuration(), 0, "Pause window duration is not zero");
+
+        // With a zero duration, the pause window ended at deployment time, so all pools created by this factory
+        // register with a pause window end time of 0.
+        assertEq(
+            unpausablePoolFactory.getOriginalPauseWindowEndTime(),
+            block.timestamp,
+            "Original pause window end time is not the deployment time"
+        );
+        assertEq(unpausablePoolFactory.getNewPoolPauseWindowEndTime(), 0, "New pool pause window end time is not zero");
+    }
+
+    function testFactoryVersions() public view {
+        assertEq(unpausablePoolFactory.version(), "Factory v1", "Wrong factory version");
+        assertEq(unpausablePoolFactory.getPoolVersion(), "Pool v1", "Wrong pool version");
+    }
+
+    function testPoolPauseWindowEndTime() public {
+        address stablePool = _deployAndInitializeStablePool(false);
+
+        (bool paused, uint32 pauseWindowEndTime, , ) = vault.getPoolPausedState(stablePool);
+        assertFalse(paused, "Pool is paused");
+        assertEq(pauseWindowEndTime, 0, "Pool pause window end time is not zero");
+    }
+
+    function testPauseManagerCannotPausePool() public {
+        PoolRoleAccounts memory roleAccounts;
+        roleAccounts.pauseManager = admin;
+
+        IERC20[] memory tokens = [address(dai), address(usdc)].toMemoryArray().asIERC20();
+        address stablePool = createStablePool(
+            "Unpausable Pool",
+            "UNPAUSABLE",
+            vault.buildTokenConfig(tokens),
+            roleAccounts,
+            false
+        );
+
+        // The pause manager passes authentication, but pausing reverts: the pause window has already expired.
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolPauseWindowExpired.selector, stablePool));
+        vault.pausePool(stablePool);
+    }
+
+    function testGovernanceCannotPausePool() public {
+        address stablePool = _deployAndInitializeStablePool(false);
+
+        // Authorize Alice, so that the revert reflects the expired pause window, not failed authentication.
+        authorizer.grantRole(vault.getActionId(IVaultAdmin.pausePool.selector), alice);
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(IVaultErrors.PoolPauseWindowExpired.selector, stablePool));
+        vault.pausePool(stablePool);
+    }
+
+    function testVaultPauseStillPausesPool() public {
+        // Pool-level pausing is disabled, but pools from this factory cannot opt out of a Vault-wide pause.
+        address stablePool = _deployAndInitializeStablePool(false);
+
+        vault.manualPauseVault();
+
+        vm.prank(bob);
+        vm.expectRevert(IVaultErrors.VaultPaused.selector);
+        router.swapSingleTokenExactIn(stablePool, dai, usdc, poolInitAmount / 10, 0, MAX_UINT256, false, bytes(""));
+    }
+}

--- a/pkg/pool-stable/test/foundry/utils/BaseStablePoolFactoryTest.sol
+++ b/pkg/pool-stable/test/foundry/utils/BaseStablePoolFactoryTest.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+
+import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
+import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+
+import { CastingHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/CastingHelpers.sol";
+import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/test/ArrayHelpers.sol";
+import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVaultTest.sol";
+import { StableMath } from "@balancer-labs/v3-solidity-utils/contracts/math/StableMath.sol";
+import { BalancerPoolToken } from "@balancer-labs/v3-vault/contracts/BalancerPoolToken.sol";
+
+import { StablePoolContractsDeployer } from "./StablePoolContractsDeployer.sol";
+
+/**
+ * @notice Shared tests for factories that deploy standard Stable Pools.
+ * @dev These tests apply to any factory whose pools are standard Stable Pools (e.g., `StablePoolFactory` and
+ * `UnpausableStablePoolFactory`). Concrete test contracts deploy the factory under test in `setUp`, and implement
+ * `createStablePool`.
+ */
+abstract contract BaseStablePoolFactoryTest is BaseVaultTest, StablePoolContractsDeployer {
+    using CastingHelpers for address[];
+    using ArrayHelpers for *;
+
+    // Maximum swap fee of 10%.
+    uint64 public constant MAX_SWAP_FEE_PERCENTAGE = 10e16;
+
+    uint256 internal constant DEFAULT_AMP_FACTOR = 200;
+
+    uint256 internal daiIdx;
+    uint256 internal usdcIdx;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        (daiIdx, usdcIdx) = getSortedIndexes(address(dai), address(usdc));
+    }
+
+    /**
+     * @dev Create a pool from the factory under test, with the default amp factor and maximum swap fee, no hooks,
+     * and unbalanced liquidity enabled.
+     */
+    function createStablePool(
+        string memory name,
+        string memory symbol,
+        TokenConfig[] memory tokenConfig,
+        PoolRoleAccounts memory roleAccounts,
+        bool enableDonation
+    ) internal virtual returns (address);
+
+    function testCreatePoolWithoutDonation() public {
+        address stablePool = _deployAndInitializeStablePool(false);
+
+        // Try to donate but fails because pool does not support donations.
+        vm.prank(bob);
+        vm.expectRevert(IVaultErrors.DoesNotSupportDonation.selector);
+        router.donate(stablePool, [poolInitAmount, poolInitAmount].toMemoryArray(), false, bytes(""));
+    }
+
+    function testCreatePoolWithDonation() public {
+        uint256 amountToDonate = poolInitAmount;
+
+        address stablePool = _deployAndInitializeStablePool(true);
+
+        HookTestLocals memory vars = _createHookTestLocals(stablePool);
+
+        // Donates to pool successfully.
+        vm.prank(bob);
+        router.donate(stablePool, [amountToDonate, amountToDonate].toMemoryArray(), false, bytes(""));
+
+        _fillAfterHookTestLocals(vars, stablePool);
+
+        // Bob balances.
+        assertEq(vars.bob.daiBefore - vars.bob.daiAfter, amountToDonate, "Bob DAI balance is wrong");
+        assertEq(vars.bob.usdcBefore - vars.bob.usdcAfter, amountToDonate, "Bob USDC balance is wrong");
+        assertEq(vars.bob.bptAfter, vars.bob.bptBefore, "Bob BPT balance is wrong");
+
+        // Pool balances.
+        assertEq(vars.poolAfter[daiIdx] - vars.poolBefore[daiIdx], amountToDonate, "Pool DAI balance is wrong");
+        assertEq(vars.poolAfter[usdcIdx] - vars.poolBefore[usdcIdx], amountToDonate, "Pool USDC balance is wrong");
+        assertEq(vars.bptSupplyAfter, vars.bptSupplyBefore, "Pool BPT supply is wrong");
+
+        // Vault Balances.
+        assertEq(vars.vault.daiAfter - vars.vault.daiBefore, amountToDonate, "Vault DAI balance is wrong");
+        assertEq(vars.vault.usdcAfter - vars.vault.usdcBefore, amountToDonate, "Vault USDC balance is wrong");
+    }
+
+    function testCreatePoolWithTooManyTokens() public {
+        IERC20[] memory bigPoolTokens = new IERC20[](StableMath.MAX_STABLE_TOKENS + 1);
+        for (uint256 i = 0; i < bigPoolTokens.length; ++i) {
+            bigPoolTokens[i] = createERC20(string.concat("TKN", Strings.toString(i)), 18);
+        }
+
+        TokenConfig[] memory tokenConfig = vault.buildTokenConfig(bigPoolTokens);
+        PoolRoleAccounts memory roleAccounts;
+
+        vm.expectRevert(IVaultErrors.MaxTokens.selector);
+        createStablePool("Big Pool", "TOO_BIG", tokenConfig, roleAccounts, false);
+    }
+
+    function _deployAndInitializeStablePool(bool supportsDonation) internal returns (address) {
+        PoolRoleAccounts memory roleAccounts;
+        IERC20[] memory tokens = [address(dai), address(usdc)].toMemoryArray().asIERC20();
+
+        address stablePool = createStablePool(
+            supportsDonation ? "Pool With Donation" : "Pool Without Donation",
+            supportsDonation ? "PwD" : "PwoD",
+            vault.buildTokenConfig(tokens),
+            roleAccounts,
+            supportsDonation
+        );
+
+        // Initialize pool.
+        vm.prank(lp);
+        router.initialize(stablePool, tokens, [poolInitAmount, poolInitAmount].toMemoryArray(), 0, false, bytes(""));
+
+        return stablePool;
+    }
+
+    struct WalletState {
+        uint256 daiBefore;
+        uint256 daiAfter;
+        uint256 usdcBefore;
+        uint256 usdcAfter;
+        uint256 bptBefore;
+        uint256 bptAfter;
+    }
+
+    struct HookTestLocals {
+        WalletState bob;
+        WalletState hook;
+        WalletState vault;
+        uint256[] poolBefore;
+        uint256[] poolAfter;
+        uint256 bptSupplyBefore;
+        uint256 bptSupplyAfter;
+    }
+
+    function _createHookTestLocals(address pool) private view returns (HookTestLocals memory vars) {
+        vars.bob.daiBefore = dai.balanceOf(bob);
+        vars.bob.usdcBefore = usdc.balanceOf(bob);
+        vars.bob.bptBefore = IERC20(pool).balanceOf(bob);
+        vars.vault.daiBefore = dai.balanceOf(address(vault));
+        vars.vault.usdcBefore = usdc.balanceOf(address(vault));
+        vars.poolBefore = vault.getRawBalances(pool);
+        vars.bptSupplyBefore = BalancerPoolToken(pool).totalSupply();
+    }
+
+    function _fillAfterHookTestLocals(HookTestLocals memory vars, address pool) private view {
+        vars.bob.daiAfter = dai.balanceOf(bob);
+        vars.bob.usdcAfter = usdc.balanceOf(bob);
+        vars.bob.bptAfter = IERC20(pool).balanceOf(bob);
+        vars.vault.daiAfter = dai.balanceOf(address(vault));
+        vars.vault.usdcAfter = usdc.balanceOf(address(vault));
+        vars.poolAfter = vault.getRawBalances(pool);
+        vars.bptSupplyAfter = BalancerPoolToken(pool).totalSupply();
+    }
+}

--- a/pkg/pool-stable/test/foundry/utils/StablePoolContractsDeployer.sol
+++ b/pkg/pool-stable/test/foundry/utils/StablePoolContractsDeployer.sol
@@ -6,6 +6,7 @@ import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol"
 
 import { BaseContractsDeployer } from "@balancer-labs/v3-solidity-utils/test/foundry/utils/BaseContractsDeployer.sol";
 
+import { UnpausableStablePoolFactory } from "../../../contracts/UnpausableStablePoolFactory.sol";
 import { StablePoolFactory } from "../../../contracts/StablePoolFactory.sol";
 import { StablePool } from "../../../contracts/StablePool.sol";
 
@@ -49,6 +50,24 @@ contract StablePoolContractsDeployer is BaseContractsDeployer {
                 );
         } else {
             return new StablePoolFactory(vault, pauseWindowDuration, factoryVersion, poolVersion);
+        }
+    }
+
+    function deployUnpausableStablePoolFactory(
+        IVault vault,
+        string memory factoryVersion,
+        string memory poolVersion
+    ) internal returns (UnpausableStablePoolFactory) {
+        if (reusingArtifacts) {
+            return
+                UnpausableStablePoolFactory(
+                    deployCode(
+                        _computeStablePoolPath("UnpausableStablePoolFactory"),
+                        abi.encode(vault, factoryVersion, poolVersion)
+                    )
+                );
+        } else {
+            return new UnpausableStablePoolFactory(vault, factoryVersion, poolVersion);
         }
     }
 


### PR DESCRIPTION
# Description

Special purpose factory for stable pools that cannot be paused. Since V3 pools structurally cannot opt out of pausing, since it's controlled at the Vault, the only way to implement this is to set the pause window to 0. This is allowed (there's no minimum), and *effectively* makes the pools deployed from this factory unpausable.

The stable pool now has a base test contract, to cut down on duplication.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Changeset is included <!-- run `yarn changeset` -->
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
