### PR TITLE
Improve LBP liquidity and swap validation

### DIFF
--- a/.changeset/gold-women-beg.md
+++ b/.changeset/gold-women-beg.md
@@ -1,0 +1,5 @@
+---
+'@balancer-labs/v3-pool-weighted': minor
+---
+
+Ensure LBPs remain fully redeemable after initialization, proportional liquidity operations, and swaps, and require proportional-only liquidity management.

--- a/.changeset/gold-women-beg.md
+++ b/.changeset/gold-women-beg.md
@@ -1,5 +1,6 @@
 ---
 '@balancer-labs/v3-pool-weighted': minor
+'@balancer-labs/v3-interfaces': minor
 ---
 
-Ensure LBPs remain fully redeemable after initialization, proportional liquidity operations, and swaps, and require proportional-only liquidity management.
+Ensure LBPs remain fully redeemable after initialization, proportional liquidity operations, and swaps, and require proportional-only liquidity management. Add `getMinRedeemableBalance` to `ILBPCommon` and `SwapAmountExceedsBalance` to `IFixedPriceLBPool`.

--- a/pkg/interfaces/contracts/pool-weighted/IFixedPriceLBPool.sol
+++ b/pkg/interfaces/contracts/pool-weighted/IFixedPriceLBPool.sol
@@ -71,6 +71,14 @@ interface IFixedPriceLBPool is ILBPCommon {
     error TokenSwapsInUnsupported();
 
     /**
+     * @notice A swap would take more of the outgoing token than the pool holds.
+     * @dev Fixed-price math does not cap `amountOut` to the available balance.
+     * @param amountOutScaled18 The amount the swap would remove, as an 18-decimal FixedPoint value
+     * @param balanceScaled18 The available balance, as an 18-decimal FixedPoint value
+     */
+    error SwapAmountExceedsBalance(uint256 amountOutScaled18, uint256 balanceScaled18);
+
+    /**
      * @notice Get dynamic pool data relevant to swap/add/remove calculations.
      * @return data A struct containing all dynamic LBP parameters
      */

--- a/pkg/interfaces/contracts/pool-weighted/ILBPCommon.sol
+++ b/pkg/interfaces/contracts/pool-weighted/ILBPCommon.sol
@@ -98,4 +98,13 @@ interface ILBPCommon is IBasePool {
      * @return isSwapEnabled True if the sale is in progress
      */
     function isSwapEnabled() external view returns (bool isSwapEnabled);
+
+    /**
+     * @notice Get the minimum non-zero real balance a swap may leave for a token.
+     * @dev The value is fixed at deployment from the Vault minimum supply and minimum trade amount. Proportional
+     * removals are checked separately. Weighted LBPs also enforce their per-token minimum balances.
+     *
+     * @return minRedeemableBalance The minimum non-zero real balance after a swap
+     */
+    function getMinRedeemableBalance() external view returns (uint256 minRedeemableBalance);
 }

--- a/pkg/pool-utils/contracts/BasePoolFactory.sol
+++ b/pkg/pool-utils/contracts/BasePoolFactory.sol
@@ -177,6 +177,6 @@ abstract contract BasePoolFactory is
      * @return liquidityManagement Liquidity management flags, all initialized to false
      */
     function getDefaultLiquidityManagement() public pure returns (LiquidityManagement memory liquidityManagement) {
-        // solhint-disable-previous-line no-empty-blocks
+        return liquidityManagement;
     }
 }

--- a/pkg/pool-weighted/contracts/lbp/BaseLBPFactory.sol
+++ b/pkg/pool-weighted/contracts/lbp/BaseLBPFactory.sol
@@ -82,7 +82,7 @@ abstract contract BaseLBPFactory is IPoolVersion, BasePoolFactory, ReentrancyGua
     ) internal pure returns (TokenConfig[] memory tokenConfig) {
         tokenConfig = new TokenConfig[](_TWO_TOKENS);
 
-        (tokenConfig[0].token, tokenConfig[1].token) = projectToken < reserveToken
+        (tokenConfig[0].token, tokenConfig[1].token) = address(projectToken) < address(reserveToken)
             ? (projectToken, reserveToken)
             : (reserveToken, projectToken);
     }
@@ -96,6 +96,9 @@ abstract contract BaseLBPFactory is IPoolVersion, BasePoolFactory, ReentrancyGua
         PoolRoleAccounts memory roleAccounts;
         LiquidityManagement memory liquidityManagement = getDefaultLiquidityManagement();
         liquidityManagement.disableUnbalancedLiquidity = true;
+
+        // Validate the registration flags before passing them to the Vault.
+        LBPValidation.validateLiquidityManagement(liquidityManagement);
 
         // This account can change the static swap fee for the pool.
         roleAccounts.swapFeeManager = lbpCommonParams.owner;

--- a/pkg/pool-weighted/contracts/lbp/FixedPriceLBPool.sol
+++ b/pkg/pool-weighted/contracts/lbp/FixedPriceLBPool.sol
@@ -119,12 +119,33 @@ contract FixedPriceLBPool is IFixedPriceLBPool, LBPCommon, BalancerPoolToken, Po
             revert SwapOfProjectTokenIn();
         }
 
-        // Calculated amount is amount out; round down to favor the Vault.
-        // When buying project (reserve in): amountOut = amountIn / rate
-        // When selling project (project in): amountOut = amountIn * rate
-        amountCalculatedScaled18 = request.kind == SwapKind.EXACT_IN
-            ? request.amountGivenScaled18.divDown(_projectTokenRate)
-            : request.amountGivenScaled18.mulUp(_projectTokenRate);
+        // Round the calculated amount in favor of the Vault: amounts out round down, and amounts in round up.
+        // Exact in (reserve in): amountOut = amountIn / rate
+        // Exact out (project out): amountIn = amountOut * rate
+        uint256 amountInScaled18;
+        uint256 amountOutScaled18;
+
+        if (request.kind == SwapKind.EXACT_IN) {
+            amountInScaled18 = request.amountGivenScaled18;
+            amountOutScaled18 = amountInScaled18.divDown(_projectTokenRate);
+            amountCalculatedScaled18 = amountOutScaled18;
+        } else {
+            amountOutScaled18 = request.amountGivenScaled18;
+            amountInScaled18 = amountOutScaled18.mulUp(_projectTokenRate);
+            amountCalculatedScaled18 = amountInScaled18;
+        }
+
+        // Reject requests larger than the available output balance.
+        uint256 balanceOutScaled18 = request.balancesScaled18[request.indexOut];
+        if (amountOutScaled18 > balanceOutScaled18) {
+            revert SwapAmountExceedsBalance(amountOutScaled18, balanceOutScaled18);
+        }
+
+        // Exact-in output rounding makes this a conservative balance estimate.
+        _ensureBalanceIsRedeemable(request.indexOut, balanceOutScaled18 - amountOutScaled18);
+
+        // The stored input balance is at least this value after aggregate fees.
+        _ensureBalanceIsRedeemable(request.indexIn, request.balancesScaled18[request.indexIn] + amountInScaled18);
     }
 
     /**
@@ -132,7 +153,7 @@ contract FixedPriceLBPool is IFixedPriceLBPool, LBPCommon, BalancerPoolToken, Po
      * @dev The invariant is: inv = projectBalance * projectTokenRate + reserveBalance.
      * This represents the total value in the pool, in terms of reserve tokens.
      *
-     * @param balances The current pool balances (in 18-decimal scaling)
+     * @param balances The current pool balances (as an 18-decimal FixedPoint value)
      * @param rounding The rounding direction (up or down)
      * @return invariant The calculated invariant value
      */

--- a/pkg/pool-weighted/contracts/lbp/FixedPriceLBPool.sol
+++ b/pkg/pool-weighted/contracts/lbp/FixedPriceLBPool.sol
@@ -56,7 +56,7 @@ contract FixedPriceLBPool is IFixedPriceLBPool, LBPCommon, BalancerPoolToken, Po
         FactoryParams memory factoryParams,
         uint256 projectTokenRate
     )
-        LBPCommon(lbpCommonParams, factoryParams.trustedRouter)
+        LBPCommon(lbpCommonParams, factoryParams.trustedRouter, factoryParams.vault)
         BalancerPoolToken(factoryParams.vault, lbpCommonParams.name, lbpCommonParams.symbol)
         PoolInfo(factoryParams.vault)
         Version(factoryParams.poolVersion)

--- a/pkg/pool-weighted/contracts/lbp/LBPCommon.sol
+++ b/pkg/pool-weighted/contracts/lbp/LBPCommon.sol
@@ -6,10 +6,12 @@ import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/I
 import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
 import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 import { ISenderGuard } from "@balancer-labs/v3-interfaces/contracts/vault/ISenderGuard.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import "@balancer-labs/v3-interfaces/contracts/pool-weighted/ILBPCommon.sol";
 
 import { InputHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/InputHelpers.sol";
@@ -48,8 +50,54 @@ abstract contract LBPCommon is ILBPCommon, Ownable2Step, BaseHooks {
     // the `tokenIn` of a swap.
     bool internal immutable _blockProjectTokenSwapsIn;
 
+    // Vault state used by the redeemability checks.
+    IVault internal immutable _lbpVault;
+    uint256 internal immutable _poolMinimumTotalSupply;
+    uint256 internal immutable _minimumTradeAmount;
+
+    // Minimum non-zero balance a swap may leave behind.
+    uint256 internal immutable _minRedeemableBalanceScaled18;
+
     /// @notice Swaps are disabled except during the sale (i.e., between and start and end times).
     error SwapsDisabled();
+
+    /**
+     * @notice A swap would leave a token balance that cannot be fully redeemed.
+     * @param tokenIndex Index of the affected token
+     * @param endingBalanceScaled18 Resulting balance, or a conservative lower bound
+     * @param minBalanceScaled18 Minimum allowed non-zero balance
+     */
+    error TokenBalanceBlocksRedemption(uint256 tokenIndex, uint256 endingBalanceScaled18, uint256 minBalanceScaled18);
+
+    /**
+     * @notice Initialization would produce a state that cannot be fully redeemed.
+     * @param totalSupply The resulting pool token supply
+     */
+    error InitialStateBlocksRedemption(uint256 totalSupply);
+
+    /**
+     * @notice A proportional add would produce a state that cannot be fully redeemed.
+     * @param totalSupply The resulting pool token supply
+     */
+    error ResultingStateBlocksRedemption(uint256 totalSupply);
+
+    /**
+     * @notice A proportional removal would leave too little circulating supply to redeem.
+     * @param remainingCirculatingSupply The remaining circulating pool token supply
+     */
+    error RemainingSupplyBlocksRedemption(uint256 remainingCirculatingSupply);
+
+    /**
+     * @notice A proportional removal would leave a token balance that cannot be fully redeemed.
+     * @param tokenIndex Index of the affected token
+     * @param remainingBalanceScaled18 The remaining token balance
+     * @param remainingSupply The remaining pool token supply
+     */
+    error RemainingBalanceBlocksRedemption(
+        uint256 tokenIndex,
+        uint256 remainingBalanceScaled18,
+        uint256 remainingSupply
+    );
 
     /// @notice Removing liquidity is not allowed before the end of the sale.
     error RemovingLiquidityNotAllowed();
@@ -71,8 +119,21 @@ abstract contract LBPCommon is ILBPCommon, Ownable2Step, BaseHooks {
         _;
     }
 
-    constructor(LBPCommonParams memory lbpCommonParams, address trustedRouter) Ownable(lbpCommonParams.owner) {
+    constructor(
+        LBPCommonParams memory lbpCommonParams,
+        address trustedRouter,
+        IVault vault
+    ) Ownable(lbpCommonParams.owner) {
         LBPValidation.validateCommonParams(lbpCommonParams);
+
+        // Cache the Vault minimums used by the redeemability checks.
+        uint256 poolMinimumTotalSupply = vault.getPoolMinimumTotalSupply();
+        uint256 minimumTradeAmount = vault.getMinimumTradeAmount();
+
+        _lbpVault = vault;
+        _poolMinimumTotalSupply = poolMinimumTotalSupply;
+        _minimumTradeAmount = minimumTradeAmount;
+        _minRedeemableBalanceScaled18 = poolMinimumTotalSupply + minimumTradeAmount;
 
         // Set the trusted router (passed down from the factory), and the rest of the immutable variables.
         _trustedRouter = trustedRouter;
@@ -120,6 +181,11 @@ abstract contract LBPCommon is ILBPCommon, Ownable2Step, BaseHooks {
         return _isSwapEnabled();
     }
 
+    /// @inheritdoc ILBPCommon
+    function getMinRedeemableBalance() external view returns (uint256) {
+        return _minRedeemableBalanceScaled18;
+    }
+
     /*******************************************************************************
                                       Pool Hooks
     *******************************************************************************/
@@ -135,7 +201,7 @@ abstract contract LBPCommon is ILBPCommon, Ownable2Step, BaseHooks {
         address,
         address pool,
         TokenConfig[] memory tokenConfig,
-        LiquidityManagement calldata
+        LiquidityManagement calldata liquidityManagement
     ) public view virtual override returns (bool) {
         // These preconditions are guaranteed by the standard LBPoolFactory, but check anyway.
         InputHelpers.ensureInputLengthMatch(_TWO_TOKENS, tokenConfig.length);
@@ -145,6 +211,9 @@ abstract contract LBPCommon is ILBPCommon, Ownable2Step, BaseHooks {
         if (tokenConfig[0].tokenType != TokenType.STANDARD || tokenConfig[1].tokenType != TokenType.STANDARD) {
             revert IVaultErrors.InvalidTokenConfiguration();
         }
+
+        // Redeemability checks assume proportional liquidity operations.
+        LBPValidation.validateLiquidityManagement(liquidityManagement);
 
         return pool == address(this);
     }
@@ -158,6 +227,9 @@ abstract contract LBPCommon is ILBPCommon, Ownable2Step, BaseHooks {
         // Required to enforce single-LP liquidity provision, and ensure all funding occurs before the sale.
         hookFlags.shouldCallBeforeInitialize = true;
         hookFlags.shouldCallBeforeAddLiquidity = true;
+
+        // Validate redeemability after the Vault has computed the initial supply.
+        hookFlags.shouldCallAfterInitialize = true;
 
         // Required to enforce the liquidity can only be withdrawn after the end of the sale.
         hookFlags.shouldCallBeforeRemoveLiquidity = true;
@@ -181,38 +253,76 @@ abstract contract LBPCommon is ILBPCommon, Ownable2Step, BaseHooks {
     }
 
     /**
-     * @notice Allow the owner to add liquidity before the start of the sale.
+     * @notice Ensure initialization produces a fully redeemable state.
+     * @param exactAmountsIn The balances stored after initialization
+     * @param bptAmountOut The pool tokens minted to the initializer
+     * @return success Always true if the resulting state is valid
+     */
+    function onAfterInitialize(
+        uint256[] memory exactAmountsIn,
+        uint256 bptAmountOut,
+        bytes memory
+    ) public view virtual override returns (bool) {
+        uint256 totalSupply = bptAmountOut + _poolMinimumTotalSupply;
+
+        if (bptAmountOut == 0 || _isFullyRedeemable(exactAmountsIn, totalSupply) == false) {
+            revert InitialStateBlocksRedemption(totalSupply);
+        }
+
+        return true;
+    }
+
+    /**
+     * @notice Allow the owner to add proportional liquidity before the sale.
      * @param router The router used for the operation
-     * @return success True (allowing the operation to proceed) if the owner is calling through the trusted router
+     * @param kind The liquidity add kind
+     * @param minBptAmountOut The pool tokens to be minted for a proportional add
+     * @param balancesScaled18 The stored balances before the add
+     * @return success True if the operation may proceed
      */
     function onBeforeAddLiquidity(
         address router,
         address,
-        AddLiquidityKind,
+        AddLiquidityKind kind,
         uint256[] memory,
-        uint256,
-        uint256[] memory,
+        uint256 minBptAmountOut,
+        uint256[] memory balancesScaled18,
         bytes memory
     ) public view virtual override onlyBeforeSale returns (bool) {
-        return router == _trustedRouter && ISenderGuard(router).getSender() == owner();
+        if (router != _trustedRouter || ISenderGuard(router).getSender() != owner()) {
+            return false;
+        }
+
+        if (kind == AddLiquidityKind.PROPORTIONAL) {
+            _ensureAddedStateIsRedeemable(minBptAmountOut, balancesScaled18);
+        }
+
+        return true;
     }
 
     /**
-     * @notice Only remove liquidity before the sale (to correct mistakes) or after the sale (withdrawal of proceeds).
-     * @return success Always true; if removing liquidity is not allowed, revert here with a more specific error
+     * @notice Allow liquidity removal before or after the sale, but not during it.
+     * @param kind The liquidity removal kind
+     * @param maxBptAmountIn The pool tokens to be burned for a proportional removal
+     * @param balancesScaled18 The stored balances before the removal
+     * @return success True if the operation may proceed
      */
     function onBeforeRemoveLiquidity(
         address,
         address,
-        RemoveLiquidityKind,
-        uint256,
+        RemoveLiquidityKind kind,
+        uint256 maxBptAmountIn,
         uint256[] memory,
-        uint256[] memory,
+        uint256[] memory balancesScaled18,
         bytes memory
     ) public view virtual override returns (bool) {
         // Do not allow removing liquidity during the sale.
         if (block.timestamp >= _startTime && block.timestamp <= _endTime) {
             revert RemovingLiquidityNotAllowed();
+        }
+
+        if (kind == RemoveLiquidityKind.PROPORTIONAL) {
+            _ensureRemainderIsRedeemable(maxBptAmountIn, balancesScaled18);
         }
 
         return true;
@@ -224,6 +334,129 @@ abstract contract LBPCommon is ILBPCommon, Ownable2Step, BaseHooks {
 
     function _isSwapEnabled() internal view returns (bool) {
         return block.timestamp >= _startTime && block.timestamp <= _endTime;
+    }
+
+    /**
+     * @notice Ensure a swap leaves the token balance in a redeemable state.
+     * @param tokenIndex Index of the affected token
+     * @param endingBalanceScaled18 Resulting balance, or a conservative lower bound
+     */
+    function _ensureBalanceIsRedeemable(uint256 tokenIndex, uint256 endingBalanceScaled18) internal view {
+        if (endingBalanceScaled18 != 0 && endingBalanceScaled18 < _minRedeemableBalanceScaled18) {
+            revert TokenBalanceBlocksRedemption(tokenIndex, endingBalanceScaled18, _minRedeemableBalanceScaled18);
+        }
+    }
+
+    /**
+     * @notice Ensure a proportional removal preserves full redeemability.
+     * @param bptAmountIn The pool tokens to be burned
+     * @param balancesScaled18 The stored token balances
+     */
+    function _ensureRemainderIsRedeemable(uint256 bptAmountIn, uint256[] memory balancesScaled18) internal view {
+        uint256 totalSupply = _lbpVault.totalSupply(address(this));
+
+        // Leave invalid burn amounts to the Vault.
+        if (bptAmountIn > totalSupply - _poolMinimumTotalSupply) {
+            return;
+        }
+
+        // Do not restrict operations on an already non-redeemable state.
+        if (_isFullyRedeemable(balancesScaled18, totalSupply) == false) {
+            return;
+        }
+
+        uint256 remainingSupply = totalSupply - bptAmountIn;
+        uint256 remainingCirculatingSupply = remainingSupply - _poolMinimumTotalSupply;
+
+        // A full exit leaves no circulating claim.
+        if (remainingCirculatingSupply == 0) {
+            return;
+        }
+
+        // The remaining circulating supply must itself be redeemable.
+        if (remainingCirculatingSupply < _minimumTradeAmount) {
+            revert RemainingSupplyBlocksRedemption(remainingCirculatingSupply);
+        }
+
+        // The pool token supply can exceed 128 bits, so these products need full-precision division.
+        uint256 numTokens = balancesScaled18.length;
+        for (uint256 i = 0; i < numTokens; ++i) {
+            uint256 balance = balancesScaled18[i];
+            uint256 remainingBalance = balance - Math.mulDiv(balance, bptAmountIn, totalSupply);
+            uint256 amountOut = Math.mulDiv(remainingBalance, remainingCirculatingSupply, remainingSupply);
+
+            // Projected balances are conservative; only an exact zero is exempt.
+            if (remainingBalance != 0 && amountOut < _minimumTradeAmount) {
+                revert RemainingBalanceBlocksRedemption(i, remainingBalance, remainingSupply);
+            }
+        }
+    }
+
+    /**
+     * @notice Ensure a proportional add preserves full redeemability.
+     * @param bptAmountOut The pool tokens to be minted
+     * @param balancesScaled18 The stored token balances before the add
+     */
+    function _ensureAddedStateIsRedeemable(uint256 bptAmountOut, uint256[] memory balancesScaled18) internal view {
+        uint256 totalSupply = _lbpVault.totalSupply(address(this));
+
+        // Do not restrict an add that may repair an already non-redeemable state.
+        if (_isFullyRedeemable(balancesScaled18, totalSupply) == false) {
+            return;
+        }
+
+        uint256 addedSupply = totalSupply + bptAmountOut;
+        uint256 addedCirculatingSupply = addedSupply - _poolMinimumTotalSupply;
+
+        if (addedCirculatingSupply != 0 && addedCirculatingSupply < _minimumTradeAmount) {
+            revert ResultingStateBlocksRedemption(addedSupply);
+        }
+
+        // The pool token supply can exceed 128 bits, so these products need full-precision division.
+        uint256 numTokens = balancesScaled18.length;
+        for (uint256 i = 0; i < numTokens; ++i) {
+            uint256 balance = balancesScaled18[i];
+            uint256 addedBalance = balance + Math.mulDiv(balance, bptAmountOut, totalSupply, Math.Rounding.Ceil);
+            uint256 amountOut = Math.mulDiv(addedBalance, addedCirculatingSupply, addedSupply);
+
+            // Projected balances are conservative; only an exact zero is exempt.
+            if (addedBalance != 0 && amountOut < _minimumTradeAmount) {
+                revert ResultingStateBlocksRedemption(addedSupply);
+            }
+        }
+    }
+
+    /**
+     * @notice Return whether all circulating pool tokens can be redeemed proportionally.
+     * @param balancesScaled18 The stored token balances
+     * @param totalSupply The pool token total supply
+     * @return success True if the circulating supply can be fully redeemed
+     */
+    function _isFullyRedeemable(
+        uint256[] memory balancesScaled18,
+        uint256 totalSupply
+    ) internal view returns (bool success) {
+        uint256 circulatingSupply = totalSupply - _poolMinimumTotalSupply;
+
+        if (circulatingSupply == 0) {
+            return true;
+        }
+
+        if (circulatingSupply < _minimumTradeAmount) {
+            return false;
+        }
+
+        // The pool token supply can exceed 128 bits, so these products need full-precision division.
+        uint256 numTokens = balancesScaled18.length;
+        for (uint256 i = 0; i < numTokens; ++i) {
+            uint256 amountOut = Math.mulDiv(balancesScaled18[i], circulatingSupply, totalSupply);
+
+            if (amountOut != 0 && amountOut < _minimumTradeAmount) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     function _computeScalingFactor(IERC20 token) internal view returns (uint256) {

--- a/pkg/pool-weighted/contracts/lbp/LBPValidation.sol
+++ b/pkg/pool-weighted/contracts/lbp/LBPValidation.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import { LiquidityManagement } from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 import "@balancer-labs/v3-interfaces/contracts/pool-weighted/ILBPCommon.sol";
 
 import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
@@ -33,10 +34,13 @@ library LBPValidation {
     /// @notice The reserve token is the zero address.
     error InvalidReserveToken();
 
+    /// @notice The pool was registered with unsupported liquidity operations.
+    error InvalidLiquidityManagement();
+
     /**
      * @notice Validates common LBP parameters.
      * @dev This should be called by both factories for early validation, and pools for direct deployment protection.
-     * Note that the time is also validated here, and unlike previous versions LBPs, the startTime must be in the
+     * Note that the time is also validated here, and unlike previous versions of LBPs, the startTime must be in the
      * future, due to constraints around funding and initialization.
      *
      * @param lbpCommonParams The common LBP parameters to validate
@@ -47,15 +51,15 @@ library LBPValidation {
             revert InvalidOwner();
         }
 
-        if (lbpCommonParams.projectToken == IERC20(address(0))) {
+        if (address(lbpCommonParams.projectToken) == address(0)) {
             revert InvalidProjectToken();
         }
 
-        if (lbpCommonParams.reserveToken == IERC20(address(0))) {
+        if (address(lbpCommonParams.reserveToken) == address(0)) {
             revert InvalidReserveToken();
         }
 
-        if (lbpCommonParams.projectToken == lbpCommonParams.reserveToken) {
+        if (address(lbpCommonParams.projectToken) == address(lbpCommonParams.reserveToken)) {
             revert TokensMustBeDifferent();
         }
 
@@ -65,6 +69,22 @@ library LBPValidation {
             lbpCommonParams.startTime < block.timestamp + INITIALIZATION_PERIOD
         ) {
             revert GradualValueChange.InvalidStartTime(lbpCommonParams.startTime, lbpCommonParams.endTime);
+        }
+    }
+
+    /**
+     * @notice Validate the liquidity operations enabled for an LBP.
+     * @dev LBPs support proportional adds and removals only.
+     * @param liquidityManagement The liquidity operation flags for the pool
+     */
+    function validateLiquidityManagement(LiquidityManagement memory liquidityManagement) internal pure {
+        if (
+            liquidityManagement.disableUnbalancedLiquidity == false ||
+            liquidityManagement.enableAddLiquidityCustom ||
+            liquidityManagement.enableRemoveLiquidityCustom ||
+            liquidityManagement.enableDonation
+        ) {
+            revert InvalidLiquidityManagement();
         }
     }
 }

--- a/pkg/pool-weighted/contracts/lbp/LBPool.sol
+++ b/pkg/pool-weighted/contracts/lbp/LBPool.sol
@@ -60,7 +60,7 @@ contract LBPool is ILBPool, LBPCommon, WeightedPool {
         LBPParams memory lbpParams,
         FactoryParams memory factoryParams
     )
-        LBPCommon(lbpCommonParams, factoryParams.trustedRouter)
+        LBPCommon(lbpCommonParams, factoryParams.trustedRouter, factoryParams.vault)
         WeightedPool(
             _buildWeightedPoolParams(lbpCommonParams, lbpParams, factoryParams.poolVersion),
             factoryParams.vault

--- a/pkg/pool-weighted/contracts/lbp/LBPool.sol
+++ b/pkg/pool-weighted/contracts/lbp/LBPool.sol
@@ -270,8 +270,7 @@ contract LBPool is ILBPool, LBPCommon, WeightedPool {
             ? (calculatedAmountScaled18, request.amountGivenScaled18)
             : (request.amountGivenScaled18, calculatedAmountScaled18);
 
-        // The request holds the real Vault balances again at this point. Check them as well as the weighted-pool
-        // minimums, which may have used the virtual reserve.
+        // The request holds the real Vault balances again at this point; check the balances the Vault will store.
         _ensureBalanceIsRedeemable(request.indexOut, request.balancesScaled18[request.indexOut] - amountOutScaled18);
 
         // The stored input balance is at least this value after aggregate fees.

--- a/pkg/pool-weighted/contracts/lbp/LBPool.sol
+++ b/pkg/pool-weighted/contracts/lbp/LBPool.sol
@@ -238,30 +238,44 @@ contract LBPool is ILBPool, LBPCommon, WeightedPool {
             revert SwapOfProjectTokenIn();
         }
 
+        uint256 calculatedAmountScaled18;
+
         if (_reserveTokenVirtualBalanceScaled18 == 0) {
             // This is not a seedless LBP, fall back on standard Weighted Pool behavior.
-            return super.onSwap(request);
-        }
+            calculatedAmountScaled18 = super.onSwap(request);
+        } else {
+            // Mutate the request to add the virtual balance for seedless LBPs, and restore it later.
+            uint256 originalReserveBalance = request.balancesScaled18[_reserveTokenIndex];
+            request.balancesScaled18[_reserveTokenIndex] += _reserveTokenVirtualBalanceScaled18;
 
-        // Mutate the request to add the virtual balance for seedless LBPs, and restore it later.
-        uint256 originalReserveBalance = request.balancesScaled18[_reserveTokenIndex];
-        request.balancesScaled18[_reserveTokenIndex] += _reserveTokenVirtualBalanceScaled18;
+            calculatedAmountScaled18 = super.onSwap(request);
 
-        uint256 calculatedAmountScaled18 = super.onSwap(request);
+            // If we are returning reserve tokens, ensure we have enough real balance.
+            if (request.indexOut == _reserveTokenIndex) {
+                uint256 reserveAmountOut = request.kind == SwapKind.EXACT_IN
+                    ? calculatedAmountScaled18
+                    : request.amountGivenScaled18;
 
-        // If we are returning reserve tokens, ensure we have enough real balance.
-        if (request.indexOut == _reserveTokenIndex) {
-            uint256 reserveAmountOut = request.kind == SwapKind.EXACT_IN
-                ? calculatedAmountScaled18
-                : request.amountGivenScaled18;
-
-            if (reserveAmountOut > originalReserveBalance) {
-                revert InsufficientRealReserveBalance(reserveAmountOut, originalReserveBalance);
+                if (reserveAmountOut > originalReserveBalance) {
+                    revert InsufficientRealReserveBalance(reserveAmountOut, originalReserveBalance);
+                }
             }
+
+            // Restore the original request reserve balance.
+            request.balancesScaled18[_reserveTokenIndex] = originalReserveBalance;
         }
 
-        // Restore the original request reserve balance.
-        request.balancesScaled18[_reserveTokenIndex] = originalReserveBalance;
+        // Normalize the swap amounts for the real-balance checks.
+        (uint256 amountOutScaled18, uint256 amountInScaled18) = request.kind == SwapKind.EXACT_IN
+            ? (calculatedAmountScaled18, request.amountGivenScaled18)
+            : (request.amountGivenScaled18, calculatedAmountScaled18);
+
+        // The request holds the real Vault balances again at this point. Check them as well as the weighted-pool
+        // minimums, which may have used the virtual reserve.
+        _ensureBalanceIsRedeemable(request.indexOut, request.balancesScaled18[request.indexOut] - amountOutScaled18);
+
+        // The stored input balance is at least this value after aggregate fees.
+        _ensureBalanceIsRedeemable(request.indexIn, request.balancesScaled18[request.indexIn] + amountInScaled18);
 
         return calculatedAmountScaled18;
     }

--- a/pkg/pool-weighted/test/foundry/FixedPriceLBPool.t.sol
+++ b/pkg/pool-weighted/test/foundry/FixedPriceLBPool.t.sol
@@ -566,7 +566,7 @@ contract FixedPriceLBPoolTest is BaseLBPTest, FixedPriceLBPoolContractsDeployer 
             pool,
             tokenConfig,
             LiquidityManagement({
-                disableUnbalancedLiquidity: false,
+                disableUnbalancedLiquidity: true,
                 enableAddLiquidityCustom: false,
                 enableRemoveLiquidityCustom: false,
                 enableDonation: false
@@ -589,7 +589,7 @@ contract FixedPriceLBPoolTest is BaseLBPTest, FixedPriceLBPoolContractsDeployer 
             pool,
             tokenConfig,
             LiquidityManagement({
-                disableUnbalancedLiquidity: false,
+                disableUnbalancedLiquidity: true,
                 enableAddLiquidityCustom: false,
                 enableRemoveLiquidityCustom: false,
                 enableDonation: false
@@ -609,7 +609,7 @@ contract FixedPriceLBPoolTest is BaseLBPTest, FixedPriceLBPoolContractsDeployer 
             address(1), // Wrong pool address
             tokenConfig,
             LiquidityManagement({
-                disableUnbalancedLiquidity: false,
+                disableUnbalancedLiquidity: true,
                 enableAddLiquidityCustom: false,
                 enableRemoveLiquidityCustom: false,
                 enableDonation: false
@@ -632,7 +632,7 @@ contract FixedPriceLBPoolTest is BaseLBPTest, FixedPriceLBPoolContractsDeployer 
             pool, // Correct pool address
             tokenConfig,
             LiquidityManagement({
-                disableUnbalancedLiquidity: false,
+                disableUnbalancedLiquidity: true,
                 enableAddLiquidityCustom: false,
                 enableRemoveLiquidityCustom: false,
                 enableDonation: false
@@ -650,9 +650,10 @@ contract FixedPriceLBPoolTest is BaseLBPTest, FixedPriceLBPoolContractsDeployer 
         assertTrue(flags.shouldCallBeforeAddLiquidity, "shouldCallBeforeAddLiquidity should be true");
         assertTrue(flags.shouldCallBeforeRemoveLiquidity, "shouldCallBeforeRemoveLiquidity should be true");
 
+        assertTrue(flags.shouldCallAfterInitialize, "shouldCallAfterInitialize should be true");
+
         // These should be false
         assertFalse(flags.enableHookAdjustedAmounts, "enableHookAdjustedAmounts should be false");
-        assertFalse(flags.shouldCallAfterInitialize, "shouldCallAfterInitialize should be false");
         assertFalse(flags.shouldCallComputeDynamicSwapFee, "shouldCallComputeDynamicSwapFee should be false");
         assertFalse(flags.shouldCallBeforeSwap, "shouldCallBeforeSwap should be false");
         assertFalse(flags.shouldCallAfterSwap, "shouldCallAfterSwap should be false");

--- a/pkg/pool-weighted/test/foundry/FixedPriceLBPoolMinBalance.t.sol
+++ b/pkg/pool-weighted/test/foundry/FixedPriceLBPoolMinBalance.t.sol
@@ -1,0 +1,710 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { stdError } from "forge-std/StdError.sol";
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IFixedPriceLBPool } from "@balancer-labs/v3-interfaces/contracts/pool-weighted/IFixedPriceLBPool.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import "@balancer-labs/v3-interfaces/contracts/pool-weighted/ILBPCommon.sol";
+
+import { ERC20TestToken } from "@balancer-labs/v3-solidity-utils/contracts/test/ERC20TestToken.sol";
+import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
+
+import { FixedPriceLBPoolContractsDeployer } from "./utils/FixedPriceLBPoolContractsDeployer.sol";
+import { FixedPriceLBPoolFactory } from "../../contracts/lbp/FixedPriceLBPoolFactory.sol";
+import { LBPCommon } from "../../contracts/lbp/LBPCommon.sol";
+import { BaseLBPTest } from "./utils/BaseLBPTest.sol";
+
+contract FixedPriceLBPoolMinBalanceTest is BaseLBPTest, FixedPriceLBPoolContractsDeployer {
+    using FixedPoint for uint256;
+
+    uint256 internal constant RATE = FixedPoint.ONE;
+
+    FixedPriceLBPoolFactory internal lbPoolFactory;
+
+    uint256 internal minRedeemableBalance;
+    uint256 internal minimumTradeAmount;
+
+    function setUp() public virtual override {
+        vaultMockMinTradeAmount = PRODUCTION_MIN_TRADE_AMOUNT;
+        super.setUp();
+
+        minimumTradeAmount = vault.getMinimumTradeAmount();
+        minRedeemableBalance = vault.getPoolMinimumTotalSupply() + minimumTradeAmount;
+    }
+
+    function createPoolFactory() internal virtual override returns (address) {
+        lbPoolFactory = deployFixedPriceLBPoolFactory(
+            IVault(address(vault)),
+            365 days,
+            factoryVersion,
+            poolVersion,
+            address(router)
+        );
+        vm.label(address(lbPoolFactory), "Fixed Price LB pool factory");
+
+        return address(lbPoolFactory);
+    }
+
+    function createPool() internal virtual override returns (address newPool, bytes memory poolArgs) {
+        newPool = _create(projectToken, reserveToken, swapFee);
+        poolArgs = bytes("");
+    }
+
+    function initPool() internal virtual override {
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[projectIdx] = poolInitAmount;
+
+        vm.startPrank(bob);
+        _initPool(pool, initAmounts, 0);
+        vm.stopPrank();
+    }
+
+    function testThresholdIsTightAtTheSmallestRedeemableSupply() public view {
+        uint256 poolMinimumTotalSupply = vault.getPoolMinimumTotalSupply();
+        uint256 smallestRedeemableSupply = poolMinimumTotalSupply + minimumTradeAmount;
+        uint256 circulating = smallestRedeemableSupply - poolMinimumTotalSupply;
+
+        assertEq(
+            (minRedeemableBalance * circulating) / smallestRedeemableSupply,
+            minimumTradeAmount,
+            "The floor does not withdraw exactly the minimum trade amount at the smallest redeemable supply"
+        );
+        assertLt(
+            ((minRedeemableBalance - 1) * circulating) / smallestRedeemableSupply,
+            minimumTradeAmount,
+            "One below the floor is not rejected at the smallest redeemable supply"
+        );
+    }
+
+    function testMinRedeemableBalanceGetter() public view {
+        assertEq(
+            ILBPCommon(pool).getMinRedeemableBalance(),
+            minRedeemableBalance,
+            "The pool reports a floor other than the sum of the two Vault constants"
+        );
+    }
+
+    function testExactOutAllowsZeroOrBalanceAtOrAboveFloor() public {
+        uint256 balance = 10 * minRedeemableBalance;
+        address smallPool = _createAndInitWith(0, balance);
+        _warpIntoSale();
+
+        assertTrue(
+            _exactOutIsAdmitted(smallPool, balance - minRedeemableBalance),
+            "The largest partial buy is refused"
+        );
+        assertFalse(_exactOutIsAdmitted(smallPool, balance - minRedeemableBalance + 1), "The hole does not start here");
+        assertFalse(_exactOutIsAdmitted(smallPool, balance - 1), "The hole does not run to the top");
+        assertTrue(_exactOutIsAdmitted(smallPool, balance), "Buying the whole balance is refused");
+
+        assertEq(minRedeemableBalance - 1, 1_999_999, "Unexpected width for the admissible gap");
+    }
+
+    function testEndingBalanceZeroIsAccepted() public {
+        _warpIntoSale();
+        _buyProjectDownTo(pool, 0);
+
+        assertEq(vault.getCurrentLiveBalances(pool)[projectIdx], 0, "Project balance is not zero");
+        assertTrue(_ownerCanExit(pool), "Owner cannot exit a fully drained pool");
+    }
+
+    function testEndingBalanceOneIsRejected() public {
+        _warpIntoSale();
+
+        uint256 amountOut = _amountToLeave(pool, 1);
+
+        _expectBlocksRedemption(projectIdx, 1);
+        _buyProjectExactOut(pool, amountOut);
+    }
+
+    function testEndingBalanceJustBelowFloorIsRejected() public {
+        _warpIntoSale();
+
+        uint256 amountOut = _amountToLeave(pool, minRedeemableBalance - 1);
+
+        _expectBlocksRedemption(projectIdx, minRedeemableBalance - 1);
+        _buyProjectExactOut(pool, amountOut);
+    }
+
+    function testEndingBalanceAtFloorIsAccepted() public {
+        _warpIntoSale();
+        _buyProjectDownTo(pool, minRedeemableBalance);
+
+        assertEq(vault.getCurrentLiveBalances(pool)[projectIdx], minRedeemableBalance, "Floor not placed exactly");
+        assertTrue(_ownerCanExit(pool), "Owner cannot exit with the balance sitting on the floor");
+    }
+
+    function testEndingBalanceJustAboveFloorIsAccepted() public {
+        _warpIntoSale();
+        _buyProjectDownTo(pool, minRedeemableBalance + 1);
+
+        assertTrue(_ownerCanExit(pool), "Owner cannot exit one above the floor");
+    }
+
+    function testProjectResidualBelowMinimumTradeAmountIsRejected() public {
+        _warpIntoSale();
+
+        uint256 residual = minimumTradeAmount - 1;
+        uint256 amountOut = _amountToLeave(pool, residual);
+
+        _expectBlocksRedemption(projectIdx, residual);
+        _buyProjectExactOut(pool, amountOut);
+    }
+
+    function testProjectResidualAtMinimumTradeAmountIsRejected() public {
+        _warpIntoSale();
+
+        uint256 snapshotId = vm.snapshotState();
+        _forceBalance(pool, projectIdx, minimumTradeAmount);
+        assertFalse(_ownerCanExit(pool), "A balance at the minimum trade amount is not fully redeemable");
+        vm.revertToState(snapshotId);
+
+        uint256 amountOut = _amountToLeave(pool, minimumTradeAmount);
+
+        _expectBlocksRedemption(projectIdx, minimumTradeAmount);
+        _buyProjectExactOut(pool, amountOut);
+    }
+
+    function testExactInAndExactOutAgreeAtTheBoundary() public {
+        address zeroFeePool = _createAndInit(0);
+        _warpIntoSale();
+
+        uint256 snapshotId = vm.snapshotState();
+
+        uint256 amountOut = _amountToLeave(zeroFeePool, minRedeemableBalance - 1);
+
+        _expectBlocksRedemption(projectIdx, minRedeemableBalance - 1);
+        _buyProjectExactOut(zeroFeePool, amountOut);
+        vm.revertToState(snapshotId);
+
+        _expectBlocksRedemption(projectIdx, minRedeemableBalance - 1);
+        _buyProjectExactIn(zeroFeePool, amountOut);
+        vm.revertToState(snapshotId);
+
+        uint256 amountAtFloor = _amountToLeave(zeroFeePool, minRedeemableBalance);
+
+        _buyProjectExactOut(zeroFeePool, amountAtFloor);
+        assertEq(
+            vault.getCurrentLiveBalances(zeroFeePool)[projectIdx],
+            minRedeemableBalance,
+            "Exact-out missed the floor"
+        );
+        vm.revertToState(snapshotId);
+
+        _buyProjectExactIn(zeroFeePool, amountAtFloor);
+        assertEq(
+            vault.getCurrentLiveBalances(zeroFeePool)[projectIdx],
+            minRedeemableBalance,
+            "Exact-in missed the floor"
+        );
+    }
+
+    function testOrdinarySaleIsUnaffected() public {
+        _warpIntoSale();
+
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(pool, reserveToken, projectToken, 100e18, 0, MAX_UINT256, false, bytes(""));
+
+        assertEq(
+            vault.getCurrentLiveBalances(pool)[projectIdx],
+            poolInitAmount - 100e18 + uint256(100e18).mulUp(swapFee),
+            "Ordinary purchase did not go through cleanly"
+        );
+        assertTrue(_ownerCanExit(pool), "Owner cannot exit after an ordinary sale");
+    }
+
+    function testElevenDecimalsCanLeaveOneRawUnit() public {
+        (address lbp, uint256 newProjectIdx, uint256 seedRaw, IERC20 project) = _buildPoolWithProjectDecimals(11);
+
+        _buyExactOut(lbp, reserveToken, project, seedRaw - 1);
+
+        uint256 endingBalance = vault.getCurrentLiveBalances(lbp)[newProjectIdx];
+        assertEq(endingBalance, 1e7, "Unexpected scaled18 value for one raw unit at eleven decimals");
+        assertGe(endingBalance, minRedeemableBalance, "One raw unit at eleven decimals is below the floor");
+        assertTrue(_ownerCanExit(lbp), "Owner cannot exit with one raw unit of an eleven-decimal token left");
+    }
+
+    function testTwelveDecimalsCannotLeaveOneRawUnit() public {
+        (address lbp, uint256 newProjectIdx, uint256 seedRaw, IERC20 project) = _buildPoolWithProjectDecimals(12);
+
+        _expectBlocksRedemption(newProjectIdx, 1e6);
+        _buyExactOut(lbp, reserveToken, project, seedRaw - 1);
+    }
+
+    function testThirteenDecimalsCannotLeaveOneRawUnit() public {
+        (address lbp, uint256 newProjectIdx, uint256 seedRaw, IERC20 project) = _buildPoolWithProjectDecimals(13);
+
+        _expectBlocksRedemption(newProjectIdx, 1e5);
+        _buyExactOut(lbp, reserveToken, project, seedRaw - 1);
+    }
+
+    function testReserveStartsAtZero() public view {
+        assertEq(vault.getCurrentLiveBalances(pool)[reserveIdx], 0, "Reserve does not start at zero");
+    }
+
+    function testZeroFeeFirstPurchaseAtTheMinimumTradeAmountIsRejected() public {
+        address zeroFeePool = _createAndInit(0);
+        _warpIntoSale();
+
+        uint256 snapshotId = vm.snapshotState();
+        _forceBalance(zeroFeePool, reserveIdx, minimumTradeAmount);
+        assertFalse(_ownerCanExit(zeroFeePool), "A reserve balance at the minimum trade amount is fully redeemable");
+        vm.revertToState(snapshotId);
+
+        _expectBlocksRedemption(reserveIdx, minimumTradeAmount);
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(
+            zeroFeePool,
+            reserveToken,
+            projectToken,
+            minimumTradeAmount,
+            0,
+            MAX_UINT256,
+            false,
+            bytes("")
+        );
+    }
+
+    function testZeroFeeFirstPurchaseAtTheFloorIsAccepted() public {
+        address zeroFeePool = _createAndInit(0);
+        _warpIntoSale();
+
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(
+            zeroFeePool,
+            reserveToken,
+            projectToken,
+            minRedeemableBalance,
+            0,
+            MAX_UINT256,
+            false,
+            bytes("")
+        );
+
+        assertEq(
+            vault.getCurrentLiveBalances(zeroFeePool)[reserveIdx],
+            minRedeemableBalance,
+            "First purchase did not leave the reserve on the floor"
+        );
+        assertTrue(_ownerCanExit(zeroFeePool), "Owner cannot exit after a first purchase at the floor");
+    }
+
+    function testNonZeroFeeFirstPurchaseBoundary() public {
+        _warpIntoSale();
+
+        uint256 smallestFirstPurchase = minRedeemableBalance.divUp(FixedPoint.ONE - swapFee);
+        uint256 snapshotId = vm.snapshotState();
+
+        _expectBlocksRedemption(reserveIdx, minRedeemableBalance - 1);
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(
+            pool,
+            reserveToken,
+            projectToken,
+            smallestFirstPurchase - 1,
+            0,
+            MAX_UINT256,
+            false,
+            bytes("")
+        );
+
+        vm.revertToState(snapshotId);
+
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(
+            pool,
+            reserveToken,
+            projectToken,
+            smallestFirstPurchase,
+            0,
+            MAX_UINT256,
+            false,
+            bytes("")
+        );
+
+        assertGe(
+            vault.getCurrentLiveBalances(pool)[reserveIdx],
+            minRedeemableBalance,
+            "Stored reserve fell below the checked lower bound"
+        );
+        assertTrue(_ownerCanExit(pool), "Owner cannot exit after the smallest admitted first purchase");
+    }
+
+    function testNonZeroAggregateFeeFirstPurchaseIsNotOverConstrained() public {
+        _warpIntoSale();
+        vault.manualSetAggregateSwapFeePercentage(pool, 99e16);
+
+        uint256 smallestFirstPurchase = minRedeemableBalance.divUp(FixedPoint.ONE - swapFee);
+
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(
+            pool,
+            reserveToken,
+            projectToken,
+            smallestFirstPurchase,
+            0,
+            MAX_UINT256,
+            false,
+            bytes("")
+        );
+
+        assertGe(
+            vault.getCurrentLiveBalances(pool)[reserveIdx],
+            minRedeemableBalance,
+            "The aggregate fee took the stored reserve below the floor"
+        );
+        assertTrue(_ownerCanExit(pool), "Owner cannot exit with the aggregate fee at its maximum");
+    }
+
+    function testSwapIndicesSelectTheConfiguredRoles() public {
+        _warpIntoSale();
+
+        (uint256 configuredProjectIdx, uint256 configuredReserveIdx) = ILBPCommon(pool).getTokenIndices();
+        assertEq(configuredProjectIdx, projectIdx, "Harness disagrees with the pool on the project index");
+        assertEq(configuredReserveIdx, reserveIdx, "Harness disagrees with the pool on the reserve index");
+
+        vm.prank(alice);
+        vm.expectRevert(LBPCommon.SwapOfProjectTokenIn.selector);
+        router.swapSingleTokenExactIn(pool, projectToken, reserveToken, 1e18, 0, MAX_UINT256, false, bytes(""));
+
+        vm.prank(alice);
+        vm.expectRevert(LBPCommon.SwapOfProjectTokenIn.selector);
+        router.swapSingleTokenExactOut(
+            pool,
+            projectToken,
+            reserveToken,
+            1e18,
+            MAX_UINT256,
+            MAX_UINT256,
+            false,
+            bytes("")
+        );
+    }
+
+    function testZeroSwapFeePoolIsStillCreatable() public {
+        address zeroFeePool = _create(projectToken, reserveToken, 0);
+
+        assertEq(vault.getStaticSwapFeePercentage(zeroFeePool), 0, "A zero swap fee was refused at creation");
+    }
+
+    function testOverdrawReturnsSwapAmountExceedsBalance() public {
+        _warpIntoSale();
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IFixedPriceLBPool.SwapAmountExceedsBalance.selector,
+                poolInitAmount + 1,
+                poolInitAmount
+            )
+        );
+        router.swapSingleTokenExactOut(
+            pool,
+            reserveToken,
+            projectToken,
+            poolInitAmount + 1,
+            MAX_UINT256,
+            MAX_UINT256,
+            false,
+            bytes("")
+        );
+    }
+
+    function testInitializationBelowFloorIsRefused() public {
+        address smallPool = _create(projectToken, reserveToken, swapFee);
+
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[projectIdx] = minRedeemableBalance - 1;
+
+        (IERC20[] memory tokens, , , ) = vault.getPoolTokenInfo(smallPool);
+
+        vm.startPrank(bob);
+        vm.expectPartialRevert(LBPCommon.InitialStateBlocksRedemption.selector);
+        router.initialize(smallPool, tokens, initAmounts, 0, false, bytes(""));
+        vm.stopPrank();
+    }
+
+    function testInitializationAtTheFloorIsAccepted() public {
+        address smallPool = _create(projectToken, reserveToken, swapFee);
+
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[projectIdx] = minRedeemableBalance;
+
+        vm.startPrank(bob);
+        _initPool(smallPool, initAmounts, 0);
+        vm.stopPrank();
+        approveForPool(IERC20(smallPool));
+
+        assertEq(
+            vault.getCurrentLiveBalances(smallPool)[projectIdx],
+            minRedeemableBalance,
+            "The pool was not funded on the floor"
+        );
+        assertTrue(_ownerCanExit(smallPool), "A pool funded on the floor cannot be exited");
+    }
+
+    function testOrdinaryInitializationIsUnaffected() public {
+        address ordinaryPool = _create(projectToken, reserveToken, swapFee);
+
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[projectIdx] = poolInitAmount;
+
+        vm.startPrank(bob);
+        _initPool(ordinaryPool, initAmounts, 0);
+        vm.stopPrank();
+        approveForPool(IERC20(ordinaryPool));
+
+        assertGt(poolInitAmount / minRedeemableBalance, 1e11, "The ordinary seed is not far above the boundary");
+        assertTrue(_ownerCanExit(ordinaryPool), "An ordinary pool cannot be exited");
+    }
+
+    function testPartialWithdrawalWithNonRedeemableRemainderIsRefused() public {
+        _warpIntoSale();
+        _buyProjectDownTo(pool, minRedeemableBalance);
+        _warpPastSale();
+
+        uint256 totalSupply = IERC20(pool).totalSupply();
+        uint256 burn = totalSupply / 2;
+
+        uint256[] memory balances = vault.getCurrentLiveBalances(pool);
+        uint256 remainingProject = balances[projectIdx] - (balances[projectIdx] * burn) / totalSupply;
+        uint256 remainingReserve = balances[reserveIdx] - (balances[reserveIdx] * burn) / totalSupply;
+
+        assertEq(remainingProject, minimumTradeAmount, "The burn does not leave the expected project remainder");
+        assertGt(remainingReserve, 400e18, "The remaining reserve is smaller than expected");
+
+        vm.startPrank(bob);
+        IERC20(pool).approve(address(router), MAX_UINT256);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LBPCommon.RemainingBalanceBlocksRedemption.selector,
+                projectIdx,
+                remainingProject,
+                totalSupply - burn
+            )
+        );
+        router.removeLiquidityProportional(pool, burn, new uint256[](2), false, bytes(""));
+        vm.stopPrank();
+
+        assertTrue(_ownerCanExit(pool), "The full exit no longer clears from the floor");
+    }
+
+    function testRoundedTwelveDecimalRemainderIsRejected() public {
+        (address lbp, uint256 newProjectIdx, uint256 seedRaw, IERC20 project) = _buildPoolWithProjectDecimals(12);
+        uint256 scalingFactor = 1e6;
+
+        _buyExactOut(lbp, reserveToken, project, seedRaw - 2);
+        assertEq(
+            vault.getCurrentLiveBalances(lbp)[newProjectIdx],
+            2 * scalingFactor,
+            "The project balance is not on the floor"
+        );
+
+        _warpPastSale();
+
+        uint256 totalSupply = IERC20(lbp).totalSupply();
+        uint256 balance = vault.getCurrentLiveBalances(lbp)[newProjectIdx];
+
+        uint256 remainingSupply = totalSupply / balance;
+        uint256 burn = totalSupply - remainingSupply;
+
+        assertEq(balance - (balance * burn) / totalSupply, 1, "The projected remainder is not one unit");
+
+        assertGe((balance * burn) / totalSupply, minimumTradeAmount, "The Vault would have refused this anyway");
+
+        uint256 actualRemainder = balance - ((balance * burn) / totalSupply / scalingFactor) * scalingFactor;
+        assertEq(actualRemainder, scalingFactor, "The rounded remainder is not the scaling factor");
+        assertLt(
+            (actualRemainder * (remainingSupply - vault.getPoolMinimumTotalSupply())) / remainingSupply,
+            minimumTradeAmount,
+            "The rounded remainder would remain redeemable"
+        );
+
+        vm.startPrank(bob);
+        IERC20(lbp).approve(address(router), MAX_UINT256);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LBPCommon.RemainingBalanceBlocksRedemption.selector,
+                newProjectIdx,
+                1,
+                remainingSupply
+            )
+        );
+        router.removeLiquidityProportional(lbp, burn, new uint256[](2), false, bytes(""));
+        vm.stopPrank();
+
+        assertTrue(_ownerCanExit(lbp), "The full exit is refused on the twelve-decimal pool");
+    }
+
+    function _create(IERC20 project, IERC20 reserve, uint256 staticSwapFee) internal returns (address newPool) {
+        LBPCommonParams memory lbpCommonParams = LBPCommonParams({
+            name: "FixedPriceLBPool",
+            symbol: "FLBP",
+            owner: bob,
+            projectToken: project,
+            reserveToken: reserve,
+            startTime: uint32(block.timestamp + DEFAULT_START_OFFSET),
+            endTime: uint32(block.timestamp + DEFAULT_END_OFFSET),
+            blockProjectTokenSwapsIn: true
+        });
+
+        newPool = lbPoolFactory.create(lbpCommonParams, RATE, staticSwapFee, bytes32(_saltCounter++), address(0));
+    }
+
+    function _exactOutIsAdmitted(address lbp, uint256 amountOutRaw) internal returns (bool ok) {
+        uint256 snapshotId = vm.snapshotState();
+
+        vm.prank(alice);
+        try
+            router.swapSingleTokenExactOut(
+                lbp,
+                reserveToken,
+                projectToken,
+                amountOutRaw,
+                MAX_UINT256,
+                MAX_UINT256,
+                false,
+                bytes("")
+            )
+        returns (uint256) {
+            ok = true;
+        } catch {
+            ok = false;
+        }
+
+        vm.revertToState(snapshotId);
+    }
+
+    function _createAndInit(uint256 staticSwapFee) internal returns (address newPool) {
+        return _createAndInitWith(staticSwapFee, poolInitAmount);
+    }
+
+    function _createAndInitWith(uint256 staticSwapFee, uint256 projectAmount) internal returns (address newPool) {
+        newPool = _create(projectToken, reserveToken, staticSwapFee);
+
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[projectIdx] = projectAmount;
+
+        vm.startPrank(bob);
+        _initPool(newPool, initAmounts, 0);
+        vm.stopPrank();
+
+        approveForPool(IERC20(newPool));
+    }
+
+    function _warpIntoSale() internal {
+        vm.warp(block.timestamp + DEFAULT_START_OFFSET + 1);
+    }
+
+    function _warpPastSale() internal {
+        vm.warp(block.timestamp + DEFAULT_END_OFFSET + 1);
+    }
+
+    function _amountToLeave(address lbp, uint256 target) internal view returns (uint256) {
+        (uint256 poolProjectIdx, ) = ILBPCommon(lbp).getTokenIndices();
+
+        return vault.getCurrentLiveBalances(lbp)[poolProjectIdx] - target;
+    }
+
+    function _buyProjectExactOut(address lbp, uint256 amountOutRaw) internal {
+        _buyExactOut(lbp, reserveToken, projectToken, amountOutRaw);
+    }
+
+    function _buyExactOut(address lbp, IERC20 reserve, IERC20 project, uint256 amountOutRaw) internal {
+        vm.prank(alice);
+        router.swapSingleTokenExactOut(lbp, reserve, project, amountOutRaw, MAX_UINT256, MAX_UINT256, false, bytes(""));
+    }
+
+    function _buyProjectExactIn(address lbp, uint256 amountOutRaw) internal {
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, amountOutRaw, 0, MAX_UINT256, false, bytes(""));
+    }
+
+    function _buyProjectDownTo(address lbp, uint256 target) internal {
+        _buyProjectExactOut(lbp, _amountToLeave(lbp, target));
+    }
+
+    function _expectBlocksRedemption(uint256 tokenIndex, uint256 endingBalance) internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LBPCommon.TokenBalanceBlocksRedemption.selector,
+                tokenIndex,
+                endingBalance,
+                minRedeemableBalance
+            )
+        );
+    }
+
+    function _forceBalance(address lbp, uint256 tokenIndex, uint256 balanceScaled18) internal {
+        uint256[] memory balances = vault.getCurrentLiveBalances(lbp);
+        balances[tokenIndex] = balanceScaled18;
+
+        vault.manualSetPoolBalances(lbp, balances, balances);
+    }
+
+    function _ownerCanExit(address lbp) internal returns (bool ok) {
+        uint256 snapshotId = vm.snapshotState();
+
+        vm.warp(block.timestamp + DEFAULT_END_OFFSET + 1);
+
+        uint256 ownerBpt = IERC20(lbp).balanceOf(bob);
+
+        vm.startPrank(bob);
+        IERC20(lbp).approve(address(router), MAX_UINT256);
+
+        try router.removeLiquidityProportional(lbp, ownerBpt, new uint256[](2), false, bytes("")) returns (
+            uint256[] memory
+        ) {
+            ok = true;
+        } catch {
+            ok = false;
+        }
+        vm.stopPrank();
+
+        vm.revertToState(snapshotId);
+    }
+
+    function _buildPoolWithProjectDecimals(
+        uint8 decimals
+    ) internal returns (address lbp, uint256 newProjectIdx, uint256 seedRaw, IERC20 project) {
+        ERC20TestToken newToken = createERC20("P", decimals);
+        project = newToken;
+
+        seedRaw = 1_000 * 10 ** decimals;
+        _fund(newToken, seedRaw * 10);
+
+        lbp = _create(project, reserveToken, 0);
+
+        uint256 newReserveIdx;
+        (newProjectIdx, newReserveIdx) = getSortedIndexes(address(project), address(reserveToken));
+
+        IERC20[] memory poolTokens = new IERC20[](2);
+        poolTokens[newProjectIdx] = project;
+        poolTokens[newReserveIdx] = reserveToken;
+
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[newProjectIdx] = seedRaw;
+
+        vm.prank(bob);
+        router.initialize(lbp, poolTokens, initAmounts, 0, false, bytes(""));
+
+        _warpIntoSale();
+    }
+
+    function _fund(ERC20TestToken token, uint256 amount) internal {
+        address[3] memory who = [address(bob), address(alice), address(lp)];
+
+        for (uint256 i = 0; i < who.length; ++i) {
+            token.mint(who[i], amount);
+
+            vm.startPrank(who[i]);
+            token.approve(address(permit2), type(uint256).max);
+            permit2.approve(address(token), address(router), type(uint160).max, type(uint48).max);
+            vm.stopPrank();
+        }
+    }
+}

--- a/pkg/pool-weighted/test/foundry/FixedPriceLBPoolMinBalance.t.sol
+++ b/pkg/pool-weighted/test/foundry/FixedPriceLBPoolMinBalance.t.sol
@@ -2,8 +2,6 @@
 
 pragma solidity ^0.8.24;
 
-import { stdError } from "forge-std/StdError.sol";
-
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { IFixedPriceLBPool } from "@balancer-labs/v3-interfaces/contracts/pool-weighted/IFixedPriceLBPool.sol";

--- a/pkg/pool-weighted/test/foundry/LBPRedeemableRemoval.t.sol
+++ b/pkg/pool-weighted/test/foundry/LBPRedeemableRemoval.t.sol
@@ -1,0 +1,1367 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IERC20Errors } from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
+import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import { ILBPool } from "@balancer-labs/v3-interfaces/contracts/pool-weighted/ILBPool.sol";
+import "@balancer-labs/v3-interfaces/contracts/pool-weighted/ILBPCommon.sol";
+import {
+    RemoveLiquidityKind,
+    RemoveLiquidityParams
+} from "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
+
+import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
+
+import { FixedPriceLBPoolContractsDeployer } from "./utils/FixedPriceLBPoolContractsDeployer.sol";
+import { FixedPriceLBPoolFactory } from "../../contracts/lbp/FixedPriceLBPoolFactory.sol";
+import { WeightedLBPTest } from "./utils/WeightedLBPTest.sol";
+import { LBPCommon } from "../../contracts/lbp/LBPCommon.sol";
+import { BaseLBPTest } from "./utils/BaseLBPTest.sol";
+import { IVaultAdmin } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultAdmin.sol";
+import { WeightedPool } from "../../contracts/WeightedPool.sol";
+
+contract LBPoolRedeemableRemovalTest is WeightedLBPTest {
+    using FixedPoint for uint256;
+
+    uint256 internal constant LOW_PROJECT_WEIGHT = 10e16;
+    uint256 internal constant MIN_WEIGHTED_SWAP_FEE = 0.001e16;
+
+    uint256 internal poolMinimumTotalSupply;
+    uint256 internal minimumTradeAmount;
+    uint256 internal minRedeemableBalance;
+
+    uint256 internal saleStart;
+    uint256 internal saleEnd;
+
+    function setUp() public virtual override {
+        vaultMockMinTradeAmount = PRODUCTION_MIN_TRADE_AMOUNT;
+        super.setUp();
+
+        poolMinimumTotalSupply = vault.getPoolMinimumTotalSupply();
+        minimumTradeAmount = vault.getMinimumTradeAmount();
+        minRedeemableBalance = poolMinimumTotalSupply + minimumTradeAmount;
+
+        saleStart = block.timestamp + DEFAULT_START_OFFSET;
+        saleEnd = block.timestamp + DEFAULT_END_OFFSET;
+    }
+
+    function createPool() internal virtual override returns (address newPool, bytes memory poolArgs) {
+        return
+            _createLBPool(
+                address(0),
+                uint32(block.timestamp + DEFAULT_START_OFFSET),
+                uint32(block.timestamp + DEFAULT_END_OFFSET),
+                DEFAULT_PROJECT_TOKENS_SWAP_IN
+            );
+    }
+
+    function testMaximalBurnIsPermittedAtTheFloorWithNoCarveOut() public {
+        address lbp = _buildSeededAtTheFloor();
+
+        assertTrue(_fullyRedeemable(lbp), "The maximal burn is refused at the floor");
+
+        uint256[] memory amountsOut = _remove(lbp, IERC20(lbp).totalSupply() - poolMinimumTotalSupply);
+
+        assertGt(amountsOut[reserveIdx], 0, "The maximal burn paid out no reserve");
+        assertEq(IERC20(lbp).totalSupply(), poolMinimumTotalSupply, "Pool tokens are still outstanding");
+    }
+
+    function testNearTotalWithdrawalIsRefusedAtTheFloor() public {
+        address lbp = _buildSeededAtTheFloor();
+
+        uint256 nearTotal = _burnLeaving(lbp, minimumTradeAmount);
+        assertFalse(_removalIsAdmitted(lbp, nearTotal), "The near-total withdrawal is admitted at the floor");
+
+        assertTrue(_fullyRedeemable(lbp), "The full exit is refused at the floor");
+    }
+
+    function testNinetyNinePointNineNinePercentWithdrawalIsAdmittedOnAHealthyPool() public {
+        address lbp = _buildSeeded(DEFAULT_WEIGHT, true);
+        vm.warp(saleEnd + 1);
+
+        uint256 circulating = IERC20(lbp).totalSupply() - poolMinimumTotalSupply;
+        uint256 burn = (circulating * 9999) / 10000;
+
+        assertTrue(_removalIsAdmitted(lbp, burn), "A 99.99 percent withdrawal is refused on a healthy pool");
+
+        _remove(lbp, burn);
+        assertTrue(_fullyRedeemable(lbp), "The remainder cannot be redeemed after a 99.99 percent withdrawal");
+    }
+
+    function testBurnLeavingSubMinimumPoolTokensIsRefusedOnAHealthyPool() public {
+        address lbp = _buildSeeded(DEFAULT_WEIGHT, true);
+        vm.warp(saleEnd + 1);
+
+        uint256 burn = _burnLeaving(lbp, minimumTradeAmount - 1);
+
+        vm.startPrank(bob);
+        IERC20(lbp).approve(address(router), MAX_UINT256);
+        vm.expectRevert(
+            abi.encodeWithSelector(LBPCommon.RemainingSupplyBlocksRedemption.selector, minimumTradeAmount - 1)
+        );
+        router.removeLiquidityProportional(lbp, burn, new uint256[](2), false, bytes(""));
+        vm.stopPrank();
+
+        assertTrue(
+            _removalIsAdmitted(lbp, _burnLeaving(lbp, minimumTradeAmount)),
+            "Leaving exactly the minimum trade amount outstanding is refused"
+        );
+    }
+
+    function testBurnRegionsAtTheFloorAreNonMonotone() public {
+        address lbp = _buildSeededAtTheFloor();
+
+        uint256 circulating = IERC20(lbp).totalSupply() - poolMinimumTotalSupply;
+
+        assertTrue(_removalIsAdmitted(lbp, circulating), "The maximal burn is refused");
+
+        assertFalse(_removalIsAdmitted(lbp, _burnLeaving(lbp, 1)), "Leaving one pool token is admitted");
+        assertFalse(
+            _removalIsAdmitted(lbp, _burnLeaving(lbp, minimumTradeAmount - 1)),
+            "Leaving one below the minimum trade amount is admitted"
+        );
+        assertFalse(
+            _removalIsAdmitted(lbp, _burnLeaving(lbp, minimumTradeAmount)),
+            "Leaving exactly the minimum trade amount is admitted"
+        );
+
+        assertFalse(_removalIsAdmitted(lbp, (circulating * 3) / 4), "Burning three quarters is admitted");
+        assertFalse(_removalIsAdmitted(lbp, circulating / 2), "Burning half is admitted");
+        assertFalse(_removalIsAdmitted(lbp, circulating / 4), "Burning a quarter is admitted");
+
+        uint256 largestSmallBurn = _largestZeroPayoutBurn(lbp, projectIdx);
+        assertGt(largestSmallBurn, minimumTradeAmount, "The band of small burns is empty");
+        assertTrue(_removalIsAdmitted(lbp, minimumTradeAmount), "The smallest legal burn is refused");
+        assertTrue(_removalIsAdmitted(lbp, largestSmallBurn), "The top of the small-burn band is refused");
+
+        _remove(lbp, largestSmallBurn);
+        assertTrue(_fullyRedeemable(lbp), "An admitted partial burn left a state that is not fully redeemable");
+    }
+
+    function testSmallBurnsAreAdmittedUntilTheVaultsOwnMinimumApplies() public {
+        address lbp = _buildSeededAtTheFloor();
+
+        uint256 totalSupply = IERC20(lbp).totalSupply();
+        uint256 blockingBalance = vault.getCurrentLiveBalances(lbp)[projectIdx];
+        uint256 largestZeroPayoutBurn = totalSupply / blockingBalance;
+
+        assertGt(largestZeroPayoutBurn, minimumTradeAmount, "The band of small burns is empty");
+
+        assertTrue(_removalIsAdmitted(lbp, minimumTradeAmount), "The smallest legal burn is refused");
+        assertTrue(_removalIsAdmitted(lbp, largestZeroPayoutBurn), "The top of the small-burn band is refused");
+
+        assertEq((blockingBalance * (largestZeroPayoutBurn + 1)) / totalSupply, 1, "The boundary is not where it is");
+
+        vm.startPrank(bob);
+        IERC20(lbp).approve(address(router), MAX_UINT256);
+        vm.expectRevert(IVaultErrors.TradeAmountTooSmall.selector);
+        router.removeLiquidityProportional(lbp, largestZeroPayoutBurn + 1, new uint256[](2), false, bytes(""));
+        vm.stopPrank();
+    }
+
+    function testRemovalPreservesTheRatioUpToRounding() public {
+        address lbp = _buildSeeded(LOW_PROJECT_WEIGHT, true);
+        vm.warp(saleEnd + 1);
+
+        uint256 totalSupply = IERC20(lbp).totalSupply();
+        uint256[] memory balancesBefore = vault.getCurrentLiveBalances(lbp);
+        uint256 burn = (totalSupply - poolMinimumTotalSupply) / 3;
+
+        _remove(lbp, burn);
+
+        uint256 remainingSupply = totalSupply - burn;
+        uint256[] memory remaining = vault.getCurrentLiveBalances(lbp);
+
+        for (uint256 i = 0; i < 2; ++i) {
+            uint256 expected = balancesBefore[i] - (balancesBefore[i] * burn) / totalSupply;
+
+            assertEq(remaining[i], expected, "The removal did not leave what the identity predicts");
+
+            assertGe(remaining[i] * totalSupply, balancesBefore[i] * remainingSupply, "The ratio moved the unsafe way");
+        }
+    }
+
+    function testNonRedeemablePoolCanStillRemoveWhatTheVaultPermits() public {
+        address lbp = _buildSeeded(DEFAULT_WEIGHT, true);
+        vm.warp(saleEnd + 1);
+
+        _forceBalance(lbp, projectIdx, minimumTradeAmount);
+        assertFalse(_fullyRedeemable(lbp), "The forced state is fully redeemable");
+
+        uint256 zeroPayoutBurn = _largestZeroPayoutBurn(lbp, projectIdx);
+        assertGe(zeroPayoutBurn, minimumTradeAmount, "There is no burn the Vault would permit here");
+
+        uint256 reserveBefore = vault.getCurrentLiveBalances(lbp)[reserveIdx];
+        uint256[] memory amountsOut = _remove(lbp, zeroPayoutBurn);
+
+        assertGt(amountsOut[reserveIdx], 0, "The partial removal paid out no reserve");
+        assertLt(vault.getCurrentLiveBalances(lbp)[reserveIdx], reserveBefore, "The reserve balance did not move");
+
+        for (uint256 i = 0; i < 20; ++i) {
+            uint256 burn = _largestZeroPayoutBurn(lbp, projectIdx);
+            if (burn < minimumTradeAmount || _removalIsAdmitted(lbp, burn) == false) {
+                break;
+            }
+            _remove(lbp, burn);
+        }
+
+        assertLt(
+            vault.getCurrentLiveBalances(lbp)[reserveIdx],
+            reserveBefore,
+            "Repeated removals did not reduce the reserve"
+        );
+
+        assertFalse(_fullyRedeemable(lbp), "The partial removal restored full redeemability");
+    }
+
+    function testNonRedeemablePoolStillGetsTheVaultsOwnErrors() public {
+        address lbp = _buildSeeded(DEFAULT_WEIGHT, true);
+        vm.warp(saleEnd + 1);
+
+        _forceBalance(lbp, projectIdx, minimumTradeAmount);
+
+        vm.startPrank(bob);
+        IERC20(lbp).approve(address(router), MAX_UINT256);
+        vm.expectRevert(IVaultErrors.TradeAmountTooSmall.selector);
+        router.removeLiquidityProportional(lbp, minimumTradeAmount - 1, new uint256[](2), false, bytes(""));
+        vm.stopPrank();
+    }
+
+    function testOverLargeBurnKeepsTheVaultsError() public {
+        address lbp = _buildSeeded(DEFAULT_WEIGHT, true);
+        vm.warp(saleEnd + 1);
+
+        uint256 tooMuch = IERC20(lbp).totalSupply() - poolMinimumTotalSupply + 1;
+
+        vm.startPrank(bob);
+        IERC20(lbp).approve(address(router), MAX_UINT256);
+        vm.expectPartialRevert(IERC20Errors.ERC20InsufficientBalance.selector);
+        router.removeLiquidityProportional(lbp, tooMuch, new uint256[](2), false, bytes(""));
+        vm.stopPrank();
+    }
+
+    function testHealthyPoolRemovalsAreUnaffected() public {
+        address lbp = _buildSeeded(DEFAULT_WEIGHT, true);
+        vm.warp(saleEnd + 1);
+
+        uint256 circulating = IERC20(lbp).totalSupply() - poolMinimumTotalSupply;
+
+        for (uint256 percent = 1; percent <= 100; ++percent) {
+            assertTrue(_removalIsAdmitted(lbp, (circulating * percent) / 100), "A healthy-pool withdrawal was refused");
+        }
+    }
+
+    function testMidSaleRemovalsAreUnaffected() public {
+        address lbp = _buildSeeded(LOW_PROJECT_WEIGHT, true);
+        _fundBuyer();
+
+        vm.warp(saleStart + 1);
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, 200e18, 0, MAX_UINT256, false, bytes(""));
+
+        vm.warp(saleEnd + 1);
+
+        uint256 circulating = IERC20(lbp).totalSupply() - poolMinimumTotalSupply;
+
+        for (uint256 percent = 1; percent <= 100; ++percent) {
+            assertTrue(_removalIsAdmitted(lbp, (circulating * percent) / 100), "A mid-sale withdrawal was refused");
+        }
+    }
+
+    function testRepeatedPartialWithdrawalsPreserveFullExit() public {
+        address lbp = _buildSeeded(LOW_PROJECT_WEIGHT, true);
+        vm.warp(saleEnd + 1);
+
+        for (uint256 i = 0; i < 8; ++i) {
+            uint256 circulating = IERC20(lbp).totalSupply() - poolMinimumTotalSupply;
+
+            _remove(lbp, circulating / 2);
+            assertTrue(_fullyRedeemable(lbp), "A halving left a state that is not fully redeemable");
+        }
+
+        assertTrue(_fullyRedeemable(lbp), "The full exit does not clear after eight halvings");
+    }
+
+    function testPreSaleRemovalIsStillAvailable() public {
+        address lbp = _buildSeeded(DEFAULT_WEIGHT, true);
+
+        uint256 circulating = IERC20(lbp).totalSupply() - poolMinimumTotalSupply;
+
+        assertTrue(_removalIsAdmitted(lbp, circulating / 4), "A pre-sale correction was refused");
+        assertTrue(_removalIsAdmitted(lbp, circulating), "A pre-sale full withdrawal was refused");
+    }
+
+    function testInitializingBelowTheSmallestBurnableSupplyIsRefused() public {
+        address lbp = _createSeeded(99e16);
+
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[projectIdx] = minimumTradeAmount;
+        initAmounts[reserveIdx] = 1e24;
+
+        assertLt(1_513_558 - poolMinimumTotalSupply, minimumTradeAmount, "The expected boundary has changed");
+
+        _initExpectingRevert(
+            lbp,
+            initAmounts,
+            abi.encodeWithSelector(LBPCommon.InitialStateBlocksRedemption.selector, 1_513_558)
+        );
+    }
+
+    function testInitializingWithATokenShareBelowTheMinimumIsRefused() public {
+        address lbp = _createSeeded(99e16);
+
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[projectIdx] = poolInitAmount;
+        initAmounts[reserveIdx] = minimumTradeAmount;
+
+        uint256 expectedSupply = 707_945_784_384_123_750_561;
+        uint256 circulating = expectedSupply - poolMinimumTotalSupply;
+
+        assertGt(circulating, minimumTradeAmount, "The expected boundary has changed");
+        assertEq((minimumTradeAmount * circulating) / expectedSupply, minimumTradeAmount - 1, "Payout moved");
+
+        _initExpectingRevert(
+            lbp,
+            initAmounts,
+            abi.encodeWithSelector(LBPCommon.InitialStateBlocksRedemption.selector, expectedSupply)
+        );
+    }
+
+    function testInitializationMintingNoPoolTokensIsRefused() public {
+        address lbp = _createSeeded(DEFAULT_WEIGHT);
+
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[projectIdx] = poolMinimumTotalSupply + 1;
+        initAmounts[reserveIdx] = poolMinimumTotalSupply + 1;
+
+        _initExpectingRevert(
+            lbp,
+            initAmounts,
+            abi.encodeWithSelector(LBPCommon.InitialStateBlocksRedemption.selector, poolMinimumTotalSupply)
+        );
+    }
+
+    function testInitializingOneUnitAboveTheBoundaryIsAccepted() public {
+        address lbp = _createSeeded(99e16);
+
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[projectIdx] = poolInitAmount;
+        initAmounts[reserveIdx] = minimumTradeAmount + 1;
+
+        _init(lbp, initAmounts);
+
+        vm.warp(saleEnd + 1);
+        assertTrue(_fullyRedeemable(lbp), "A pool one unit above the boundary cannot be exited");
+    }
+
+    function testOrdinaryInitializationsAreUnaffected() public {
+        address balanced = _buildSeeded(DEFAULT_WEIGHT, true);
+        address lopsided = _buildSeeded(1e16, true);
+        address seedless = _buildSeedless();
+
+        vm.warp(saleEnd + 1);
+
+        assertTrue(_fullyRedeemable(balanced), "A balanced seeded pool cannot be exited");
+        assertTrue(_fullyRedeemable(lopsided), "A one percent weight pool cannot be exited");
+        assertTrue(_fullyRedeemable(seedless), "A seedless pool cannot be exited");
+    }
+
+    function testSeedlessInitializationIsCheckedOnTheRealBalances() public {
+        address seedless = _buildSeedless();
+
+        assertEq(vault.getCurrentLiveBalances(seedless)[reserveIdx], 0, "The real reserve is not zero");
+
+        vm.warp(saleEnd + 1);
+        assertTrue(_fullyRedeemable(seedless), "A seedless pool with a zero real reserve cannot be exited");
+    }
+
+    function testAddFromOneUnitBalanceIsRejected() public {
+        address lbp = _buildSeeded(DEFAULT_WEIGHT, true);
+        _forceBalance(lbp, projectIdx, 1);
+
+        assertTrue(_fullyRedeemable(lbp), "A one unit balance is not redeemable to begin with");
+
+        uint256 totalSupply = IERC20(lbp).totalSupply();
+        uint256 bptOut = totalSupply / 4;
+
+        uint256 amountIn = (1 * bptOut + totalSupply - 1) / totalSupply;
+        assertEq(amountIn, 1, "The amount in is not one unit");
+        assertLt(amountIn, minimumTradeAmount, "The Vault would not have refused this on its own");
+
+        _addExpectingRevert(
+            lbp,
+            bptOut,
+            abi.encodeWithSelector(LBPCommon.ResultingStateBlocksRedemption.selector, totalSupply + bptOut)
+        );
+
+        assertTrue(_fullyRedeemable(lbp), "The refused add changed the pool");
+    }
+
+    function testAddToFullyRedeemedPoolMustRemainRedeemable() public {
+        address lbp = _createSeeded(DEFAULT_WEIGHT);
+
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[projectIdx] = 1e21;
+        initAmounts[reserveIdx] = 1e24;
+        _init(lbp, initAmounts);
+
+        _remove(lbp, IERC20(lbp).totalSupply() - poolMinimumTotalSupply);
+
+        assertEq(IERC20(lbp).totalSupply(), poolMinimumTotalSupply, "The pool was not fully redeemed");
+        assertTrue(_fullyRedeemable(lbp), "A fully redeemed pool should have no outstanding redemption claim");
+
+        uint256[] memory residues = vault.getCurrentLiveBalances(lbp);
+        assertEq(residues[projectIdx], 31_623, "The project residue moved");
+        assertEq(residues[reserveIdx], 31_622_777, "The reserve residue moved");
+
+        uint256 bptOut = 31_622_522;
+        uint256 addedSupply = poolMinimumTotalSupply + bptOut;
+        uint256 addedProject = residues[projectIdx] +
+            (residues[projectIdx] * bptOut + poolMinimumTotalSupply - 1) /
+            poolMinimumTotalSupply;
+
+        assertEq(
+            (addedProject * (addedSupply - poolMinimumTotalSupply)) / addedSupply,
+            minimumTradeAmount - 1,
+            "The add no longer leaves one unit under the minimum"
+        );
+
+        _addExpectingRevert(
+            lbp,
+            bptOut,
+            abi.encodeWithSelector(LBPCommon.ResultingStateBlocksRedemption.selector, addedSupply)
+        );
+
+        assertTrue(_tryAdd(lbp, 1e21), "A redeemable re-funding was refused");
+        assertTrue(_fullyRedeemable(lbp), "The re-funded pool is not fully redeemable");
+    }
+
+    function testAdmittedAddsPreserveRedeemability() public {
+        uint256[8] memory balances = [uint256(0), 1, 2, 999_999, 1_000_000, 2_000_000, 1e12, 1e21];
+        uint256 admitted;
+
+        for (uint256 i = 0; i < balances.length; ++i) {
+            for (uint256 j = 0; j < 5; ++j) {
+                uint256 snapshotId = vm.snapshotState();
+
+                address lbp = _buildSeeded(DEFAULT_WEIGHT, true);
+
+                if (j % 2 == 0) {
+                    _remove(lbp, IERC20(lbp).totalSupply() - poolMinimumTotalSupply);
+                } else {
+                    _forceBalance(lbp, projectIdx, balances[i]);
+                }
+
+                uint256 totalSupply = IERC20(lbp).totalSupply();
+                uint256[5] memory adds = [
+                    uint256(1),
+                    minimumTradeAmount,
+                    totalSupply / 1000,
+                    totalSupply,
+                    totalSupply * 1000
+                ];
+
+                if (_fullyRedeemable(lbp) && _tryAdd(lbp, adds[j])) {
+                    ++admitted;
+                    assertTrue(_fullyRedeemable(lbp), "An admitted add broke full redeemability");
+                }
+
+                vm.revertToState(snapshotId);
+            }
+        }
+
+        assertGt(admitted, 0, "The scan admitted no adds");
+    }
+
+    function testAddToNonRedeemablePoolCanRestoreRedeemability() public {
+        address lbp = _buildSeeded(DEFAULT_WEIGHT, true);
+
+        _forceBalance(lbp, projectIdx, minimumTradeAmount);
+        assertFalse(_fullyRedeemable(lbp), "The forced state is fully redeemable");
+
+        _add(lbp, IERC20(lbp).totalSupply());
+
+        assertTrue(_fullyRedeemable(lbp), "The add did not restore redeemability the pool");
+    }
+
+    function testOrdinaryAddsAreUnaffected() public {
+        address balanced = _buildSeeded(DEFAULT_WEIGHT, true);
+        address lopsided = _buildSeeded(1e16, true);
+        address seedless = _buildSeedless();
+
+        _add(balanced, IERC20(balanced).totalSupply() / 2);
+        _add(lopsided, IERC20(lopsided).totalSupply() / 2);
+        _add(seedless, IERC20(seedless).totalSupply() / 2);
+
+        assertEq(vault.getCurrentLiveBalances(seedless)[reserveIdx], 0, "The seedless real reserve stopped at zero");
+
+        vm.warp(saleEnd + 1);
+        assertTrue(_fullyRedeemable(balanced), "A balanced pool cannot be exited after an ordinary add");
+        assertTrue(_fullyRedeemable(lopsided), "A one percent weight pool cannot be exited after an ordinary add");
+        assertTrue(_fullyRedeemable(seedless), "A seedless pool cannot be exited after an ordinary add");
+    }
+
+    function testRepeatedAddsPreserveRedeemabilityAcrossLifecycle() public {
+        address lbp = _buildSeeded(LOW_PROJECT_WEIGHT, true);
+        _fundBuyer();
+
+        for (uint256 i = 0; i < 4; ++i) {
+            _add(lbp, IERC20(lbp).totalSupply() / 3);
+        }
+
+        vm.warp(saleStart + 1);
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, 200e18, 0, MAX_UINT256, false, bytes(""));
+
+        vm.warp(saleEnd + 1);
+        uint256 circulating = IERC20(lbp).totalSupply() - poolMinimumTotalSupply;
+        _remove(lbp, circulating / 2);
+
+        assertTrue(_fullyRedeemable(lbp), "The pool is not fully redeemable after adds, a swap and a removal");
+    }
+
+    function testSplitHoldersCannotIndividuallyExitAtFloor() public {
+        address lbp = _buildSeededAtTheFloor();
+
+        uint256 circulating = IERC20(lbp).totalSupply() - poolMinimumTotalSupply;
+
+        vm.prank(bob);
+        IERC20(lbp).transfer(alice, circulating / 100);
+
+        uint256 majority = IERC20(lbp).balanceOf(bob);
+
+        uint256[] memory balances = vault.getCurrentLiveBalances(lbp);
+        uint256 totalSupply = IERC20(lbp).totalSupply();
+        assertGe(majority, minimumTradeAmount, "The majority burn is below the Vault's own minimum");
+        assertGe((balances[projectIdx] * majority) / totalSupply, minimumTradeAmount, "Project payout is too small");
+        assertGe((balances[reserveIdx] * majority) / totalSupply, minimumTradeAmount, "Reserve payout is too small");
+
+        for (uint256 percent = 1; percent <= 100; ++percent) {
+            assertFalse(_removalIsAdmitted(lbp, (majority * percent) / 100), "A majority fraction was admitted");
+        }
+
+        uint256 minority = IERC20(lbp).balanceOf(alice);
+
+        vm.prank(alice);
+        IERC20(lbp).transfer(bob, minority);
+        assertTrue(_fullyRedeemable(lbp), "The exit does not clear once the holders consolidate");
+    }
+
+    function testSubMinimumBptRemainderRejectsOwnerWithdrawal() public {
+        address lbp = _buildSeeded(DEFAULT_WEIGHT, true);
+        vm.warp(saleEnd + 1);
+
+        vm.prank(bob);
+        IERC20(lbp).transfer(alice, minimumTradeAmount - 1);
+
+        uint256 ownerPosition = IERC20(lbp).balanceOf(bob);
+
+        vm.startPrank(bob);
+        IERC20(lbp).approve(address(router), MAX_UINT256);
+        vm.expectRevert(
+            abi.encodeWithSelector(LBPCommon.RemainingSupplyBlocksRedemption.selector, minimumTradeAmount - 1)
+        );
+        router.removeLiquidityProportional(lbp, ownerPosition, new uint256[](2), false, bytes(""));
+        vm.stopPrank();
+
+        assertTrue(_removalIsAdmitted(lbp, ownerPosition - 1), "Stranding one pool token does not clear it");
+    }
+
+    function testFloorStateRejectsNonRedeemablePartialBurns() public {
+        address lbp = _buildSeededAtTheFloor();
+
+        assertEq(
+            vault.getCurrentLiveBalances(lbp)[projectIdx],
+            minRedeemableBalance,
+            "The buyer did not stop on the swap-side floor"
+        );
+
+        uint256 circulating = IERC20(lbp).totalSupply() - poolMinimumTotalSupply;
+        uint256 refused;
+        for (uint256 percent = 50; percent < 100; ++percent) {
+            if (_removalIsAdmitted(lbp, (circulating * percent) / 100) == false) {
+                ++refused;
+            }
+        }
+        assertEq(refused, 50, "Some fraction of the circulating supply is still non-redeemable");
+
+        uint256 nonRedeemableBurn = _burnLeavingNonRedeemableRemainder(lbp, projectIdx);
+        vm.startPrank(bob);
+        IERC20(lbp).approve(address(router), MAX_UINT256);
+        _expectRemainingBalanceBlocksRedemption(lbp, nonRedeemableBurn, projectIdx);
+        router.removeLiquidityProportional(lbp, nonRedeemableBurn, new uint256[](2), false, bytes(""));
+        vm.stopPrank();
+
+        assertTrue(_fullyRedeemable(lbp), "The full exit does not clear from the floor");
+    }
+
+    function testSwapThenSafePartialRemovalStaysRedeemable() public {
+        address lbp = _buildSeeded(LOW_PROJECT_WEIGHT, true);
+        _fundBuyer();
+
+        vm.warp(saleStart + 1);
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, 200e18, 0, MAX_UINT256, false, bytes(""));
+
+        vm.warp(saleEnd + 1);
+
+        uint256 circulating = IERC20(lbp).totalSupply() - poolMinimumTotalSupply;
+        _remove(lbp, circulating / 2);
+
+        assertTrue(_fullyRedeemable(lbp), "The pool is not fully redeemable after a swap and a partial removal");
+    }
+
+    function testPreSaleRemovalThenSwapStaysRedeemable() public {
+        address lbp = _buildSeeded(LOW_PROJECT_WEIGHT, true);
+        _fundBuyer();
+
+        uint256 circulating = IERC20(lbp).totalSupply() - poolMinimumTotalSupply;
+        _remove(lbp, circulating / 2);
+
+        vm.warp(saleStart + 1);
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, 100e18, 0, MAX_UINT256, false, bytes(""));
+
+        vm.warp(saleEnd + 1);
+        assertTrue(_fullyRedeemable(lbp), "The pool is not fully redeemable after a pre-sale removal and a swap");
+    }
+
+    function testDirectVaultRemovalAppliesRedeemabilityCheck() public {
+        address lbp = _buildSeededAtTheFloor();
+
+        vm.prank(bob);
+        IERC20(lbp).approve(address(this), MAX_UINT256);
+
+        uint256 circulating = IERC20(lbp).totalSupply() - poolMinimumTotalSupply;
+        bytes memory nonRedeemableCall = abi.encodeCall(
+            this.removeDirectlyHook,
+            (lbp, _burnLeavingNonRedeemableRemainder(lbp, projectIdx))
+        );
+        bytes memory maximalCall = abi.encodeCall(this.removeDirectlyHook, (lbp, circulating));
+
+        vm.expectPartialRevert(LBPCommon.RemainingBalanceBlocksRedemption.selector);
+        vault.unlock(nonRedeemableCall);
+
+        vault.unlock(maximalCall);
+        assertEq(IERC20(lbp).totalSupply(), poolMinimumTotalSupply, "The direct maximal burn did not go through");
+    }
+
+    function removeDirectlyHook(address lbp, uint256 burn) external {
+        (, uint256[] memory amountsOut, ) = vault.removeLiquidity(
+            RemoveLiquidityParams({
+                pool: lbp,
+                from: bob,
+                maxBptAmountIn: burn,
+                minAmountsOut: new uint256[](2),
+                kind: RemoveLiquidityKind.PROPORTIONAL,
+                userData: bytes("")
+            })
+        );
+
+        IERC20[] memory tokens = vault.getPoolTokens(lbp);
+        for (uint256 i = 0; i < tokens.length; ++i) {
+            if (amountsOut[i] > 0) {
+                vault.sendTo(tokens[i], bob, amountsOut[i]);
+            }
+        }
+    }
+
+    function testQueryReportsTheSameRefusal() public {
+        address lbp = _buildSeededAtTheFloor();
+
+        uint256 circulating = IERC20(lbp).totalSupply() - poolMinimumTotalSupply;
+        uint256 nonRedeemableBurn = _burnLeavingNonRedeemableRemainder(lbp, projectIdx);
+
+        _prankStaticCall();
+        vm.expectPartialRevert(LBPCommon.RemainingBalanceBlocksRedemption.selector);
+        router.queryRemoveLiquidityProportional(lbp, nonRedeemableBurn, bob, bytes(""));
+
+        _prankStaticCall();
+        uint256[] memory amountsOut = router.queryRemoveLiquidityProportional(lbp, circulating, bob, bytes(""));
+        assertGt(amountsOut[reserveIdx], 0, "The maximal burn returns no reserve");
+    }
+
+    function testSeedlessRemovalUsesTheRealReserveNotTheAugmentedOne() public {
+        address lbp = _buildSeedless();
+        _fundBuyer();
+
+        vm.warp(saleStart + 1);
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, 100e18, 0, MAX_UINT256, false, bytes(""));
+
+        vm.warp(saleEnd + 1);
+        _forceBalance(lbp, reserveIdx, minRedeemableBalance);
+
+        (, uint256 virtualReserve) = ILBPool(lbp).getReserveTokenVirtualBalance();
+        assertGt(virtualReserve, minRedeemableBalance, "The virtual balance is not large enough for this test");
+
+        uint256 nonRedeemableBurn = _burnLeavingNonRedeemableRemainder(lbp, reserveIdx);
+
+        vm.startPrank(bob);
+        IERC20(lbp).approve(address(router), MAX_UINT256);
+        _expectRemainingBalanceBlocksRedemption(lbp, nonRedeemableBurn, reserveIdx);
+        router.removeLiquidityProportional(lbp, nonRedeemableBurn, new uint256[](2), false, bytes(""));
+        vm.stopPrank();
+
+        assertTrue(_fullyRedeemable(lbp), "The full exit does not clear on a seedless pool at the floor");
+    }
+
+    function testSeedlessWithAZeroRealReserveIsFullyRedeemable() public {
+        address lbp = _buildSeedless();
+        vm.warp(saleEnd + 1);
+
+        assertEq(vault.getCurrentLiveBalances(lbp)[reserveIdx], 0, "The real reserve is not zero");
+        assertTrue(_fullyRedeemable(lbp), "A seedless pool with a zero real reserve cannot be exited");
+
+        uint256 circulating = IERC20(lbp).totalSupply() - poolMinimumTotalSupply;
+        assertTrue(_removalIsAdmitted(lbp, circulating / 2), "A partial withdrawal against a zero reserve is refused");
+    }
+
+    function testNonEighteenDecimalPoolIsGovernedByTheInheritedMinimum() public {
+        uint256 saved = reserveTokenVirtualBalanceNon18;
+        reserveTokenVirtualBalanceNon18 = 0;
+
+        (address lbp, ) = _createLBPoolWithCustomWeightsNon18(
+            address(0),
+            DEFAULT_WEIGHT,
+            FixedPoint.ONE - DEFAULT_WEIGHT,
+            DEFAULT_WEIGHT,
+            FixedPoint.ONE - DEFAULT_WEIGHT,
+            uint32(saleStart),
+            uint32(saleEnd),
+            true
+        );
+
+        reserveTokenVirtualBalanceNon18 = saved;
+
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[projectIdxNon18] = poolInitAmountsNon18[projectIdxNon18];
+        initAmounts[reserveIdxNon18] = poolInitAmountsNon18[reserveIdxNon18];
+
+        vm.startPrank(bob);
+        _initPool(lbp, initAmounts, 0);
+        vm.stopPrank();
+
+        approveForPool(IERC20(lbp));
+
+        uint256 inherited = WeightedPool(lbp).getMinTokenBalances()[projectIdxNon18];
+        assertGt(
+            inherited,
+            ILBPCommon(lbp).getMinRedeemableBalance(),
+            "The inherited minimum is not the larger of the two at eight decimals"
+        );
+
+        vm.warp(saleEnd + 1);
+        assertTrue(_fullyRedeemable(lbp), "The full withdrawal is refused on the non-eighteen-decimal pool");
+    }
+
+    function testRecoveryWithdrawalCanLeaveNonRedeemableState() public {
+        address lbp = _buildSeeded(LOW_PROJECT_WEIGHT, true);
+        vm.warp(saleEnd + 1);
+        approveForPool(IERC20(lbp));
+
+        assertTrue(_fullyRedeemable(lbp), "The pool is not redeemable before the recovery withdrawal");
+
+        authorizer.grantRole(vault.getActionId(IVaultAdmin.enableRecoveryMode.selector), admin);
+        vm.prank(admin);
+        vault.enableRecoveryMode(lbp);
+
+        uint256 burn = IERC20(lbp).balanceOf(bob) - (minimumTradeAmount - 1);
+        vm.prank(bob);
+        router.removeLiquidityRecovery(lbp, burn, new uint256[](2));
+
+        authorizer.grantRole(vault.getActionId(IVaultAdmin.disableRecoveryMode.selector), admin);
+        vm.prank(admin);
+        vault.disableRecoveryMode(lbp);
+
+        uint256 circulating = IERC20(lbp).totalSupply() - poolMinimumTotalSupply;
+        assertGt(circulating, 0, "No circulating supply remains");
+        assertLt(circulating, minimumTradeAmount, "The remaining supply is not inside the band");
+        assertFalse(_fullyRedeemable(lbp), "The recovery withdrawal left a fully redeemable state");
+    }
+
+    function testFullyRedeemedPoolCanStillTradeWithoutCirculatingSupply() public {
+        uint256 saved = reserveTokenVirtualBalance;
+        reserveTokenVirtualBalance = 1e18;
+
+        (address lbp, ) = _createLBPoolWithCustomWeights(
+            address(0),
+            DEFAULT_WEIGHT,
+            FixedPoint.ONE - DEFAULT_WEIGHT,
+            DEFAULT_WEIGHT,
+            FixedPoint.ONE - DEFAULT_WEIGHT,
+            uint32(saleStart),
+            uint32(saleEnd),
+            true
+        );
+
+        reserveTokenVirtualBalance = saved;
+
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[projectIdx] = 1e24;
+
+        _initWith(lbp, initAmounts[projectIdx], 0);
+        vault.manualSetStaticSwapFeePercentage(lbp, MIN_WEIGHTED_SWAP_FEE);
+        _fundBuyer();
+
+        _remove(lbp, IERC20(lbp).totalSupply() - poolMinimumTotalSupply);
+        assertEq(IERC20(lbp).totalSupply(), poolMinimumTotalSupply, "Something is still circulating");
+
+        vm.warp(saleStart + 1);
+
+        uint256 reserveBefore = vault.getCurrentLiveBalances(lbp)[reserveIdx];
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, 1e17, 0, MAX_UINT256, false, bytes(""));
+
+        assertGt(
+            vault.getCurrentLiveBalances(lbp)[reserveIdx],
+            reserveBefore,
+            "The fully redeemed pool did not accept the purchase"
+        );
+        assertEq(IERC20(lbp).totalSupply() - poolMinimumTotalSupply, 0, "A claim on the reserve appeared");
+    }
+
+    function _burnLeaving(address lbp, uint256 remainingCirculating) internal view returns (uint256) {
+        return IERC20(lbp).totalSupply() - poolMinimumTotalSupply - remainingCirculating;
+    }
+
+    function _largestRoundingToZeroRemainder(address lbp, uint256 tokenIndex) internal view returns (uint256) {
+        uint256 totalSupply = IERC20(lbp).totalSupply();
+        uint256 balance = vault.getCurrentLiveBalances(lbp)[tokenIndex];
+
+        return totalSupply / balance - poolMinimumTotalSupply;
+    }
+
+    function _burnLeavingNonRedeemableRemainder(address lbp, uint256 tokenIndex) internal view returns (uint256) {
+        return _burnLeaving(lbp, _largestRoundingToZeroRemainder(lbp, tokenIndex) + 1);
+    }
+
+    function _largestZeroPayoutBurn(address lbp, uint256 tokenIndex) internal view returns (uint256) {
+        uint256 totalSupply = IERC20(lbp).totalSupply();
+        uint256 balance = vault.getCurrentLiveBalances(lbp)[tokenIndex];
+
+        return (totalSupply - 1) / balance;
+    }
+
+    function _removalIsAdmitted(address lbp, uint256 burn) internal returns (bool ok) {
+        uint256 snapshotId = vm.snapshotState();
+
+        vm.startPrank(bob);
+        IERC20(lbp).approve(address(router), MAX_UINT256);
+        try router.removeLiquidityProportional(lbp, burn, new uint256[](2), false, bytes("")) returns (
+            uint256[] memory
+        ) {
+            ok = true;
+        } catch {
+            ok = false;
+        }
+        vm.stopPrank();
+
+        vm.revertToState(snapshotId);
+    }
+
+    function _remove(address lbp, uint256 burn) internal returns (uint256[] memory amountsOut) {
+        vm.startPrank(bob);
+        IERC20(lbp).approve(address(router), MAX_UINT256);
+        amountsOut = router.removeLiquidityProportional(lbp, burn, new uint256[](2), false, bytes(""));
+        vm.stopPrank();
+    }
+
+    function _expectRemainingBalanceBlocksRedemption(address lbp, uint256 burn, uint256 tokenIndex) internal {
+        uint256 totalSupply = IERC20(lbp).totalSupply();
+        uint256 balance = vault.getCurrentLiveBalances(lbp)[tokenIndex];
+        uint256 remainingBalance = balance - (balance * burn) / totalSupply;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LBPCommon.RemainingBalanceBlocksRedemption.selector,
+                tokenIndex,
+                remainingBalance,
+                totalSupply - burn
+            )
+        );
+    }
+
+    function _fullyRedeemable(address lbp) internal returns (bool ok) {
+        return _removalIsAdmitted(lbp, IERC20(lbp).totalSupply() - poolMinimumTotalSupply);
+    }
+
+    function _forceBalance(address lbp, uint256 tokenIndex, uint256 balanceScaled18) internal {
+        uint256[] memory balances = vault.getCurrentLiveBalances(lbp);
+        balances[tokenIndex] = balanceScaled18;
+
+        vault.manualSetPoolBalances(lbp, balances, balances);
+    }
+
+    function _initExpectingRevert(address lbp, uint256[] memory amounts, bytes memory expectedError) internal {
+        (IERC20[] memory tokens, , , ) = vault.getPoolTokenInfo(lbp);
+
+        vm.startPrank(bob);
+        vm.expectRevert(expectedError);
+        router.initialize(lbp, tokens, amounts, 0, false, bytes(""));
+        vm.stopPrank();
+    }
+
+    function _wideMaxAmountsIn() internal pure returns (uint256[] memory maxAmountsIn) {
+        maxAmountsIn = new uint256[](2);
+        maxAmountsIn[0] = MAX_UINT128;
+        maxAmountsIn[1] = MAX_UINT128;
+    }
+
+    function _fundOwner() internal {
+        deal(address(projectToken), bob, 1e30);
+        deal(address(reserveToken), bob, 1e30);
+    }
+
+    function _add(address lbp, uint256 bptAmountOut) internal {
+        _fundOwner();
+        uint256[] memory maxAmountsIn = _wideMaxAmountsIn();
+
+        vm.startPrank(bob);
+        router.addLiquidityProportional(lbp, maxAmountsIn, bptAmountOut, false, bytes(""));
+        vm.stopPrank();
+    }
+
+    function _addExpectingRevert(address lbp, uint256 bptAmountOut, bytes memory expectedError) internal {
+        _fundOwner();
+        uint256[] memory maxAmountsIn = _wideMaxAmountsIn();
+
+        vm.startPrank(bob);
+        vm.expectRevert(expectedError);
+        router.addLiquidityProportional(lbp, maxAmountsIn, bptAmountOut, false, bytes(""));
+        vm.stopPrank();
+    }
+
+    function _tryAdd(address lbp, uint256 bptAmountOut) internal returns (bool ok) {
+        _fundOwner();
+        uint256[] memory maxAmountsIn = _wideMaxAmountsIn();
+
+        vm.startPrank(bob);
+        try router.addLiquidityProportional(lbp, maxAmountsIn, bptAmountOut, false, bytes("")) returns (
+            uint256[] memory
+        ) {
+            ok = true;
+        } catch {
+            ok = false;
+        }
+        vm.stopPrank();
+    }
+
+    function _init(address lbp, uint256[] memory amounts) internal {
+        (IERC20[] memory tokens, , , ) = vault.getPoolTokenInfo(lbp);
+
+        vm.startPrank(bob);
+        router.initialize(lbp, tokens, amounts, 0, false, bytes(""));
+        vm.stopPrank();
+
+        approveForPool(IERC20(lbp));
+    }
+
+    function _createSeeded(uint256 projectWeight) internal returns (address lbp) {
+        uint256 saved = reserveTokenVirtualBalance;
+        reserveTokenVirtualBalance = 0;
+
+        (lbp, ) = _createLBPoolWithCustomWeights(
+            address(0),
+            projectWeight,
+            FixedPoint.ONE - projectWeight,
+            projectWeight,
+            FixedPoint.ONE - projectWeight,
+            uint32(saleStart),
+            uint32(saleEnd),
+            true
+        );
+
+        reserveTokenVirtualBalance = saved;
+
+        deal(address(projectToken), bob, 1e30);
+        deal(address(reserveToken), bob, 1e30);
+    }
+
+    function _buildSeeded(uint256 projectWeight, bool blockProjectIn) internal returns (address lbp) {
+        uint256 saved = reserveTokenVirtualBalance;
+        reserveTokenVirtualBalance = 0;
+
+        (lbp, ) = _createLBPoolWithCustomWeights(
+            address(0),
+            projectWeight,
+            FixedPoint.ONE - projectWeight,
+            projectWeight,
+            FixedPoint.ONE - projectWeight,
+            uint32(saleStart),
+            uint32(saleEnd),
+            blockProjectIn
+        );
+
+        reserveTokenVirtualBalance = saved;
+
+        _initWith(lbp, poolInitAmount, poolInitAmount);
+        vault.manualSetStaticSwapFeePercentage(lbp, MIN_WEIGHTED_SWAP_FEE);
+    }
+
+    function _buildSeedless() internal returns (address lbp) {
+        uint256 saved = reserveTokenVirtualBalance;
+        reserveTokenVirtualBalance = poolInitAmount;
+
+        (lbp, ) = _createLBPoolWithCustomWeights(
+            address(0),
+            LOW_PROJECT_WEIGHT,
+            FixedPoint.ONE - LOW_PROJECT_WEIGHT,
+            LOW_PROJECT_WEIGHT,
+            FixedPoint.ONE - LOW_PROJECT_WEIGHT,
+            uint32(saleStart),
+            uint32(saleEnd),
+            false
+        );
+
+        reserveTokenVirtualBalance = saved;
+
+        _initWith(lbp, poolInitAmount, 0);
+        vault.manualSetStaticSwapFeePercentage(lbp, MIN_WEIGHTED_SWAP_FEE);
+    }
+
+    function _buildSeededAtTheFloor() internal returns (address lbp) {
+        lbp = _buildSeeded(LOW_PROJECT_WEIGHT, true);
+
+        vm.warp(saleEnd + 1);
+        _forceBalance(lbp, projectIdx, minRedeemableBalance);
+    }
+
+    function _initWith(address lbp, uint256 projectAmount, uint256 reserveAmount) internal {
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[projectIdx] = projectAmount;
+        initAmounts[reserveIdx] = reserveAmount;
+
+        vm.startPrank(bob);
+        _initPool(lbp, initAmounts, 0);
+        vm.stopPrank();
+
+        approveForPool(IERC20(lbp));
+    }
+
+    function _fundBuyer() internal {
+        deal(address(reserveToken), alice, 1e30);
+
+        vm.startPrank(alice);
+        reserveToken.approve(address(permit2), type(uint256).max);
+        permit2.approve(address(reserveToken), address(router), type(uint160).max, type(uint48).max);
+        vm.stopPrank();
+    }
+}
+
+contract FixedPriceLBPoolRedeemableRemovalTest is BaseLBPTest, FixedPriceLBPoolContractsDeployer {
+    using FixedPoint for uint256;
+
+    uint256 internal constant RATE = FixedPoint.ONE;
+
+    FixedPriceLBPoolFactory internal lbPoolFactory;
+
+    uint256 internal poolMinimumTotalSupply;
+    uint256 internal minimumTradeAmount;
+    uint256 internal minRedeemableBalance;
+
+    function setUp() public virtual override {
+        vaultMockMinTradeAmount = PRODUCTION_MIN_TRADE_AMOUNT;
+        super.setUp();
+
+        poolMinimumTotalSupply = vault.getPoolMinimumTotalSupply();
+        minimumTradeAmount = vault.getMinimumTradeAmount();
+        minRedeemableBalance = poolMinimumTotalSupply + minimumTradeAmount;
+    }
+
+    function createPoolFactory() internal virtual override returns (address) {
+        lbPoolFactory = deployFixedPriceLBPoolFactory(
+            IVault(address(vault)),
+            365 days,
+            factoryVersion,
+            poolVersion,
+            address(router)
+        );
+        vm.label(address(lbPoolFactory), "Fixed Price LB pool factory");
+
+        return address(lbPoolFactory);
+    }
+
+    function createPool() internal virtual override returns (address newPool, bytes memory poolArgs) {
+        newPool = _create(swapFee);
+        poolArgs = bytes("");
+    }
+
+    function initPool() internal virtual override {
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[projectIdx] = poolInitAmount;
+
+        vm.startPrank(bob);
+        _initPool(pool, initAmounts, 0);
+        vm.stopPrank();
+    }
+
+    function testBothRatiosAreBelowOneMidSale() public {
+        _warpIntoSale();
+
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(pool, reserveToken, projectToken, 400e18, 0, MAX_UINT256, false, bytes(""));
+
+        uint256 totalSupply = IERC20(pool).totalSupply();
+        uint256[] memory balances = vault.getCurrentLiveBalances(pool);
+
+        assertLt(balances[projectIdx], totalSupply, "The project ratio is not below one");
+        assertLt(balances[reserveIdx], totalSupply, "The reserve ratio is not below one");
+    }
+
+    function testMaximalBurnIsPermittedAtTheFloor() public {
+        _buildAtTheFloor();
+
+        assertTrue(_fullyRedeemable(pool), "The maximal burn is refused at the floor");
+    }
+
+    function testNearTotalWithdrawalIsRefusedAtTheFloor() public {
+        _buildAtTheFloor();
+
+        uint256 nearTotal = _burnLeaving(pool, minimumTradeAmount);
+
+        assertFalse(_removalIsAdmitted(pool, nearTotal), "The near-total withdrawal is admitted at the floor");
+        assertTrue(_fullyRedeemable(pool), "The full exit is refused at the floor");
+    }
+
+    function testNonRedeemablePartialBurnsAreRefusedAtFloor() public {
+        _buildAtTheFloor();
+
+        uint256 circulating = IERC20(pool).totalSupply() - poolMinimumTotalSupply;
+
+        assertFalse(_removalIsAdmitted(pool, circulating / 2), "Burning half is admitted at the floor");
+        assertFalse(_removalIsAdmitted(pool, (circulating * 3) / 5), "Burning three fifths is admitted at the floor");
+        assertFalse(
+            _removalIsAdmitted(pool, _burnLeaving(pool, minimumTradeAmount - 1)),
+            "Leaving sub-minimum pool tokens is admitted"
+        );
+    }
+
+    function testHealthyPoolRemovalsAreUnaffected() public {
+        _warpPastSale();
+
+        uint256 circulating = IERC20(pool).totalSupply() - poolMinimumTotalSupply;
+
+        for (uint256 percent = 1; percent <= 100; ++percent) {
+            assertTrue(_removalIsAdmitted(pool, (circulating * percent) / 100), "A healthy withdrawal was refused");
+        }
+    }
+
+    function testRepeatedPartialWithdrawalsCompose() public {
+        _warpIntoSale();
+
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(pool, reserveToken, projectToken, 400e18, 0, MAX_UINT256, false, bytes(""));
+
+        _warpPastSale();
+
+        for (uint256 i = 0; i < 8; ++i) {
+            uint256 circulating = IERC20(pool).totalSupply() - poolMinimumTotalSupply;
+
+            _remove(pool, circulating / 2);
+            assertTrue(_fullyRedeemable(pool), "A halving left a state that is not fully redeemable");
+        }
+    }
+
+    function testPoolFundedBelowTheMinimumBurnIsRefused() public {
+        address smallPool = _create(swapFee);
+
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[projectIdx] = minRedeemableBalance - 1;
+
+        (IERC20[] memory tokens, , , ) = vault.getPoolTokenInfo(smallPool);
+
+        vm.startPrank(bob);
+        vm.expectPartialRevert(LBPCommon.InitialStateBlocksRedemption.selector);
+        router.initialize(smallPool, tokens, initAmounts, 0, false, bytes(""));
+        vm.stopPrank();
+    }
+
+    function testNonRedeemablePoolCanStillRemoveWhatTheVaultPermits() public {
+        _warpIntoSale();
+
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(pool, reserveToken, projectToken, 400e18, 0, MAX_UINT256, false, bytes(""));
+
+        _warpPastSale();
+        _forceBalance(pool, projectIdx, minimumTradeAmount);
+
+        assertFalse(_fullyRedeemable(pool), "The forced state is fully redeemable");
+
+        uint256 zeroPayoutBurn = _largestZeroPayoutBurn(pool, projectIdx);
+        uint256 reserveBefore = vault.getCurrentLiveBalances(pool)[reserveIdx];
+
+        uint256[] memory amountsOut = _remove(pool, zeroPayoutBurn);
+
+        assertGt(amountsOut[reserveIdx], 0, "The partial removal paid out no reserve");
+        assertLt(vault.getCurrentLiveBalances(pool)[reserveIdx], reserveBefore, "The reserve did not move");
+        assertFalse(_fullyRedeemable(pool), "The partial removal restored full redeemability");
+    }
+
+    function testAddIntoAFullyRedeemedPoolIsRefusedBelowTheBoundary() public {
+        _remove(pool, IERC20(pool).totalSupply() - poolMinimumTotalSupply);
+
+        uint256[] memory residues = vault.getCurrentLiveBalances(pool);
+        assertEq(residues[projectIdx], poolMinimumTotalSupply, "Unexpected project residue after the full exit");
+        assertEq(IERC20(pool).totalSupply(), poolMinimumTotalSupply, "Something is still circulating");
+
+        uint256[] memory maxAmountsIn = new uint256[](2);
+        maxAmountsIn[0] = MAX_UINT128;
+        maxAmountsIn[1] = MAX_UINT128;
+
+        uint256 tooSmall = minimumTradeAmount - 1;
+        vm.prank(bob);
+        vm.expectRevert(
+            abi.encodeWithSelector(LBPCommon.ResultingStateBlocksRedemption.selector, poolMinimumTotalSupply + tooSmall)
+        );
+        router.addLiquidityProportional(pool, maxAmountsIn, tooSmall, false, bytes(""));
+
+        vm.prank(bob);
+        router.addLiquidityProportional(pool, maxAmountsIn, minimumTradeAmount, false, bytes(""));
+
+        _warpPastSale();
+        assertTrue(_fullyRedeemable(pool), "The pool is not redeemable after the admitted add");
+    }
+
+    function testRedeemabilityCheckUsesFullPrecisionArithmetic() public {
+        // A rate above one gives a pool token supply above 128 bits from a project amount the Vault can hold.
+        address lbp = _create(swapFee, 1e33);
+
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[projectIdx] = 1e24;
+
+        vm.startPrank(bob);
+        _initPool(lbp, initAmounts, 0);
+        vm.stopPrank();
+
+        assertGt(IERC20(lbp).totalSupply(), 2 ** 128, "The pool token supply does not exceed 128 bits");
+
+        // Buy enough project tokens that the reserve balance times the circulating supply exceeds 256 bits.
+        _warpIntoSale();
+        deal(address(reserveToken), alice, 12e37);
+
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, 12e37, 0, MAX_UINT256, false, bytes(""));
+
+        uint256 totalSupply = IERC20(lbp).totalSupply();
+        uint256[] memory balances = vault.getCurrentLiveBalances(lbp);
+        assertGt(
+            balances[reserveIdx],
+            type(uint256).max / (totalSupply - poolMinimumTotalSupply),
+            "Reserve balance times circulating supply fits in 256 bits"
+        );
+
+        // A partial removal whose own products fit is admitted, and it leaves a fully redeemable state.
+        _warpPastSale();
+        uint256 burn = totalSupply / 10;
+        uint256[] memory amountsOut = _remove(lbp, burn);
+
+        assertEq(amountsOut[projectIdx], (balances[projectIdx] * burn) / totalSupply, "Wrong project amount out");
+        assertEq(amountsOut[reserveIdx], (balances[reserveIdx] * burn) / totalSupply, "Wrong reserve amount out");
+        assertTrue(_fullyRedeemable(lbp), "The remaining state is not fully redeemable");
+    }
+
+    function _create(uint256 staticSwapFee) internal returns (address newPool) {
+        return _create(staticSwapFee, RATE);
+    }
+
+    function _create(uint256 staticSwapFee, uint256 rate) internal returns (address newPool) {
+        LBPCommonParams memory lbpCommonParams = LBPCommonParams({
+            name: "FixedPriceLBPool",
+            symbol: "FLBP",
+            owner: bob,
+            projectToken: projectToken,
+            reserveToken: reserveToken,
+            startTime: uint32(block.timestamp + DEFAULT_START_OFFSET),
+            endTime: uint32(block.timestamp + DEFAULT_END_OFFSET),
+            blockProjectTokenSwapsIn: true
+        });
+
+        newPool = lbPoolFactory.create(lbpCommonParams, rate, staticSwapFee, bytes32(_saltCounter++), address(0));
+    }
+
+    function _buildAtTheFloor() internal {
+        _warpIntoSale();
+
+        uint256 amountOut = vault.getCurrentLiveBalances(pool)[projectIdx] - minRedeemableBalance;
+
+        vm.prank(alice);
+        router.swapSingleTokenExactOut(
+            pool,
+            reserveToken,
+            projectToken,
+            amountOut,
+            MAX_UINT256,
+            MAX_UINT256,
+            false,
+            bytes("")
+        );
+
+        _warpPastSale();
+    }
+
+    function _burnLeaving(address lbp, uint256 remainingCirculating) internal view returns (uint256) {
+        return IERC20(lbp).totalSupply() - poolMinimumTotalSupply - remainingCirculating;
+    }
+
+    function _largestRoundingToZeroRemainder(address lbp, uint256 tokenIndex) internal view returns (uint256) {
+        uint256 totalSupply = IERC20(lbp).totalSupply();
+        uint256 balance = vault.getCurrentLiveBalances(lbp)[tokenIndex];
+
+        return totalSupply / balance - poolMinimumTotalSupply;
+    }
+
+    function _largestZeroPayoutBurn(address lbp, uint256 tokenIndex) internal view returns (uint256) {
+        uint256 totalSupply = IERC20(lbp).totalSupply();
+        uint256 balance = vault.getCurrentLiveBalances(lbp)[tokenIndex];
+
+        return (totalSupply - 1) / balance;
+    }
+
+    function _removalIsAdmitted(address lbp, uint256 burn) internal returns (bool ok) {
+        uint256 snapshotId = vm.snapshotState();
+
+        vm.startPrank(bob);
+        IERC20(lbp).approve(address(router), MAX_UINT256);
+        try router.removeLiquidityProportional(lbp, burn, new uint256[](2), false, bytes("")) returns (
+            uint256[] memory
+        ) {
+            ok = true;
+        } catch {
+            ok = false;
+        }
+        vm.stopPrank();
+
+        vm.revertToState(snapshotId);
+    }
+
+    function _remove(address lbp, uint256 burn) internal returns (uint256[] memory amountsOut) {
+        vm.startPrank(bob);
+        IERC20(lbp).approve(address(router), MAX_UINT256);
+        amountsOut = router.removeLiquidityProportional(lbp, burn, new uint256[](2), false, bytes(""));
+        vm.stopPrank();
+    }
+
+    function _fullyRedeemable(address lbp) internal returns (bool ok) {
+        return _removalIsAdmitted(lbp, IERC20(lbp).totalSupply() - poolMinimumTotalSupply);
+    }
+
+    function _forceBalance(address lbp, uint256 tokenIndex, uint256 balanceScaled18) internal {
+        uint256[] memory balances = vault.getCurrentLiveBalances(lbp);
+        balances[tokenIndex] = balanceScaled18;
+
+        vault.manualSetPoolBalances(lbp, balances, balances);
+    }
+
+    function _warpIntoSale() internal {
+        vm.warp(block.timestamp + DEFAULT_START_OFFSET + 1);
+    }
+
+    function _warpPastSale() internal {
+        vm.warp(block.timestamp + DEFAULT_END_OFFSET + 1);
+    }
+}

--- a/pkg/pool-weighted/test/foundry/LBPool.t.sol
+++ b/pkg/pool-weighted/test/foundry/LBPool.t.sol
@@ -640,7 +640,7 @@ contract LBPoolTest is WeightedLBPTest {
             pool,
             tokenConfig,
             LiquidityManagement({
-                disableUnbalancedLiquidity: false,
+                disableUnbalancedLiquidity: true,
                 enableAddLiquidityCustom: false,
                 enableRemoveLiquidityCustom: false,
                 enableDonation: false
@@ -663,7 +663,7 @@ contract LBPoolTest is WeightedLBPTest {
             pool,
             tokenConfig,
             LiquidityManagement({
-                disableUnbalancedLiquidity: false,
+                disableUnbalancedLiquidity: true,
                 enableAddLiquidityCustom: false,
                 enableRemoveLiquidityCustom: false,
                 enableDonation: false
@@ -683,7 +683,7 @@ contract LBPoolTest is WeightedLBPTest {
             address(1), // Wrong pool address
             tokenConfig,
             LiquidityManagement({
-                disableUnbalancedLiquidity: false,
+                disableUnbalancedLiquidity: true,
                 enableAddLiquidityCustom: false,
                 enableRemoveLiquidityCustom: false,
                 enableDonation: false
@@ -706,7 +706,7 @@ contract LBPoolTest is WeightedLBPTest {
             pool, // Correct pool address
             tokenConfig,
             LiquidityManagement({
-                disableUnbalancedLiquidity: false,
+                disableUnbalancedLiquidity: true,
                 enableAddLiquidityCustom: false,
                 enableRemoveLiquidityCustom: false,
                 enableDonation: false
@@ -714,6 +714,46 @@ contract LBPoolTest is WeightedLBPTest {
         );
 
         assertTrue(success, "onRegister should return true when parameters are valid");
+    }
+
+    // Reject each unsupported liquidity-management flag independently.
+    function testOnRegisterRefusesUnsupportedLiquidityManagement() public {
+        TokenConfig[] memory tokenConfig = vault.buildTokenConfig(
+            [address(dai), address(usdc)].toMemoryArray().asIERC20()
+        );
+
+        LiquidityManagement[4] memory bad = [
+            LiquidityManagement({
+                disableUnbalancedLiquidity: false,
+                enableAddLiquidityCustom: false,
+                enableRemoveLiquidityCustom: false,
+                enableDonation: false
+            }),
+            LiquidityManagement({
+                disableUnbalancedLiquidity: true,
+                enableAddLiquidityCustom: true,
+                enableRemoveLiquidityCustom: false,
+                enableDonation: false
+            }),
+            LiquidityManagement({
+                disableUnbalancedLiquidity: true,
+                enableAddLiquidityCustom: false,
+                enableRemoveLiquidityCustom: true,
+                enableDonation: false
+            }),
+            LiquidityManagement({
+                disableUnbalancedLiquidity: true,
+                enableAddLiquidityCustom: false,
+                enableRemoveLiquidityCustom: false,
+                enableDonation: true
+            })
+        ];
+
+        for (uint256 i = 0; i < bad.length; ++i) {
+            vm.prank(address(vault));
+            vm.expectRevert(LBPValidation.InvalidLiquidityManagement.selector);
+            IHooks(pool).onRegister(poolFactory, pool, tokenConfig, bad[i]);
+        }
     }
 
     function testGetHookFlags() public view {
@@ -724,9 +764,10 @@ contract LBPoolTest is WeightedLBPTest {
         assertTrue(flags.shouldCallBeforeAddLiquidity, "shouldCallBeforeAddLiquidity should be true");
         assertTrue(flags.shouldCallBeforeRemoveLiquidity, "shouldCallBeforeRemoveLiquidity should be true");
 
+        assertTrue(flags.shouldCallAfterInitialize, "shouldCallAfterInitialize should be true");
+
         // These should be false
         assertFalse(flags.enableHookAdjustedAmounts, "enableHookAdjustedAmounts should be false");
-        assertFalse(flags.shouldCallAfterInitialize, "shouldCallAfterInitialize should be false");
         assertFalse(flags.shouldCallComputeDynamicSwapFee, "shouldCallComputeDynamicSwapFee should be false");
         assertFalse(flags.shouldCallBeforeSwap, "shouldCallBeforeSwap should be false");
         assertFalse(flags.shouldCallAfterSwap, "shouldCallAfterSwap should be false");

--- a/pkg/pool-weighted/test/foundry/LBPoolMinBalance.t.sol
+++ b/pkg/pool-weighted/test/foundry/LBPoolMinBalance.t.sol
@@ -1,0 +1,779 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IWeightedPool } from "@balancer-labs/v3-interfaces/contracts/pool-weighted/IWeightedPool.sol";
+import { ILBPCommon } from "@balancer-labs/v3-interfaces/contracts/pool-weighted/ILBPCommon.sol";
+import { ILBPool } from "@balancer-labs/v3-interfaces/contracts/pool-weighted/ILBPool.sol";
+
+import { WeightedMath } from "@balancer-labs/v3-solidity-utils/contracts/math/WeightedMath.sol";
+import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
+
+import { LBPCommon } from "../../contracts/lbp/LBPCommon.sol";
+import { WeightedLBPTest } from "./utils/WeightedLBPTest.sol";
+
+contract LBPoolMinBalanceTest is WeightedLBPTest {
+    using FixedPoint for uint256;
+
+    uint256 internal constant LOW_PROJECT_WEIGHT = 10e16;
+    uint256 internal constant MIN_WEIGHTED_SWAP_FEE = 0.001e16;
+
+    uint256 internal minRedeemableBalance;
+    uint256 internal minimumTradeAmount;
+
+    uint256 internal saleStart;
+    uint256 internal saleEnd;
+
+    function setUp() public virtual override {
+        vaultMockMinTradeAmount = PRODUCTION_MIN_TRADE_AMOUNT;
+        super.setUp();
+
+        minimumTradeAmount = vault.getMinimumTradeAmount();
+        minRedeemableBalance = vault.getPoolMinimumTotalSupply() + minimumTradeAmount;
+
+        saleStart = block.timestamp + DEFAULT_START_OFFSET;
+        saleEnd = block.timestamp + DEFAULT_END_OFFSET;
+    }
+
+    function createPool() internal virtual override returns (address newPool, bytes memory poolArgs) {
+        return
+            _createLBPool(
+                address(0),
+                uint32(block.timestamp + DEFAULT_START_OFFSET),
+                uint32(block.timestamp + DEFAULT_END_OFFSET),
+                DEFAULT_PROJECT_TOKENS_SWAP_IN
+            );
+    }
+
+    function testInheritedMinimumIsNotTheLimitASwapEnforces() public view {
+        uint256 redeemableFloor = ILBPCommon(pool).getMinRedeemableBalance();
+        uint256[] memory inherited = IWeightedPool(pool).getMinTokenBalances();
+
+        assertEq(redeemableFloor, minRedeemableBalance, "The pool reports an unexpected redeemable floor");
+        assertLt(inherited[projectIdx], redeemableFloor, "The inherited project minimum is not below the floor");
+        assertLt(inherited[reserveIdx], redeemableFloor, "The inherited reserve minimum is not below the floor");
+    }
+
+    function testSeedlessReserveBelowMinimumTradeAmountIsRejected() public {
+        address lbp = _buildSeedless(false);
+        uint256 realReserve = _accrueReserve(lbp, 100e18);
+
+        uint256 residual = minimumTradeAmount - 1;
+
+        uint256 snapshotId = vm.snapshotState();
+        _forceBalance(lbp, reserveIdx, residual);
+        assertFalse(_ownerCanExit(lbp), "A real reserve below the minimum trade amount is not fully redeemable");
+        vm.revertToState(snapshotId);
+
+        _expectBlocksRedemption(reserveIdx, residual);
+        _sellProjectExactOut(lbp, realReserve - residual);
+    }
+
+    function testInheritedChecksPassOnTheAugmentedReserve() public {
+        address lbp = _buildSeedless(false);
+        uint256 realReserve = _accrueReserve(lbp, 100e18);
+
+        (, uint256 virtualReserve) = ILBPool(lbp).getReserveTokenVirtualBalance();
+        uint256 augmented = realReserve + virtualReserve;
+
+        uint256 residual = minimumTradeAmount - 1;
+        uint256 amountOut = realReserve - residual;
+
+        uint256 inheritedFloor = IWeightedPool(lbp).getMinTokenBalances()[reserveIdx];
+
+        assertGt(augmented - amountOut, inheritedFloor, "The inherited floor would have caught this swap");
+        assertLt(residual, inheritedFloor, "The real balance is not below the inherited floor");
+        assertGt(augmented.mulDown(30e16), amountOut, "The maximum-out ratio would have caught this swap");
+        assertLt(realReserve.mulDown(30e16), amountOut, "The maximum-out ratio on the real balance would allow it");
+
+        _expectBlocksRedemption(reserveIdx, residual);
+        _sellProjectExactOut(lbp, amountOut);
+    }
+
+    function testSeedlessRealReserveAtTheMinimumTradeAmountIsRejected() public {
+        address lbp = _buildSeedless(false);
+        uint256 realReserve = _accrueReserve(lbp, 100e18);
+
+        uint256 snapshotId = vm.snapshotState();
+        _forceBalance(lbp, reserveIdx, minimumTradeAmount);
+        assertFalse(_ownerCanExit(lbp), "A real reserve at the minimum trade amount is not fully redeemable");
+        vm.revertToState(snapshotId);
+
+        _expectBlocksRedemption(reserveIdx, minimumTradeAmount);
+        _sellProjectExactOut(lbp, realReserve - minimumTradeAmount);
+    }
+
+    function testSeedlessRealReserveZeroIsAccepted() public {
+        address lbp = _buildSeedless(false);
+        uint256 realReserve = _accrueReserve(lbp, 100e18);
+
+        _sellProjectExactOut(lbp, realReserve);
+
+        assertEq(vault.getCurrentLiveBalances(lbp)[reserveIdx], 0, "Real reserve is not zero");
+        assertTrue(_ownerCanExit(lbp), "Owner cannot exit with the real reserve fully swept");
+    }
+
+    function testSeedlessRealReserveFloorBoundary() public {
+        address lbp = _buildSeedless(false);
+        uint256 realReserve = _accrueReserve(lbp, 100e18);
+
+        uint256 snapshotId = vm.snapshotState();
+
+        uint256 amountJustBelow = realReserve - (minRedeemableBalance - 1);
+        _expectBlocksRedemption(reserveIdx, minRedeemableBalance - 1);
+        _sellProjectExactOut(lbp, amountJustBelow);
+
+        vm.revertToState(snapshotId);
+
+        _sellProjectExactOut(lbp, realReserve - minRedeemableBalance);
+        assertEq(
+            vault.getCurrentLiveBalances(lbp)[reserveIdx],
+            minRedeemableBalance,
+            "The floor was not placed exactly"
+        );
+        assertTrue(_ownerCanExit(lbp), "Owner cannot exit with the real reserve sitting on the floor");
+    }
+
+    function testSeededProjectSideExactInBottomsOutAtTheFloor() public {
+        address lbp = _buildSeeded(LOW_PROJECT_WEIGHT, true);
+        _fundBuyer();
+
+        _warpIntoSale();
+
+        uint256 swaps;
+        while (swaps < 100) {
+            uint256[] memory balances = vault.getCurrentLiveBalances(lbp);
+            if (balances[projectIdx] <= 8e6) {
+                break;
+            }
+
+            uint256 amountIn = balances[reserveIdx].mulDown(30e16);
+
+            vm.prank(alice);
+            try
+                router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, amountIn, 0, MAX_UINT256, false, "")
+            returns (uint256) {
+                ++swaps;
+            } catch {
+                break;
+            }
+        }
+
+        assertGt(swaps, 0, "The walk made no progress");
+
+        uint256 lowest = _lowestReachableProjectBalance(lbp);
+
+        assertEq(lowest, minRedeemableBalance, "Exact-in can still reach a balance below the floor");
+        assertTrue(_ownerCanExit(lbp), "Owner cannot exit at the lowest reachable balance");
+    }
+
+    function testSeededProjectSideAtMinimumWeightBottomsOutAtTheFloor() public {
+        address lbp = _buildSeeded(1e16, true);
+        _fundBuyer();
+
+        _warpIntoSale();
+
+        uint256[] memory balances = vault.getCurrentLiveBalances(lbp);
+        uint256 amountIn = balances[reserveIdx].mulDown(30e16);
+
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, amountIn, 0, MAX_UINT256, false, "");
+
+        uint256 lowest = _lowestReachableProjectBalance(lbp);
+
+        assertEq(lowest, minRedeemableBalance, "Exact-in can still reach a balance below the floor at 1 percent");
+        assertTrue(_ownerCanExit(lbp), "Owner cannot exit at the lowest reachable balance");
+    }
+
+    function testSeededProjectSideAtAnExpensiveWeightStillStopsAtTheFloor() public {
+        address lbp = _buildSeeded(30e16, true);
+        _fundBuyer();
+
+        _warpIntoSale();
+
+        uint256 swaps;
+        while (swaps < 100) {
+            uint256[] memory balances = vault.getCurrentLiveBalances(lbp);
+            if (balances[projectIdx] <= 8e6) {
+                break;
+            }
+
+            uint256 amountIn = balances[reserveIdx].mulDown(30e16);
+
+            vm.prank(alice);
+            try
+                router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, amountIn, 0, MAX_UINT256, false, "")
+            returns (uint256) {
+                ++swaps;
+            } catch {
+                break;
+            }
+        }
+
+        uint256 lowest = _lowestReachableProjectBalance(lbp);
+
+        assertGe(lowest, minRedeemableBalance, "Exact-in reached a balance below the floor at 30 percent");
+        assertTrue(_ownerCanExit(lbp), "Owner cannot exit at the lowest reachable balance");
+    }
+
+    function testSeededBidirectionalReserveSideExactInStopsAtTheFloor() public {
+        address lbp = _buildSeeded(99e16, false);
+        _fundSeller();
+
+        _warpIntoSale();
+
+        uint256 swaps;
+        while (swaps < 100) {
+            uint256[] memory balances = vault.getCurrentLiveBalances(lbp);
+            if (balances[reserveIdx] <= 8e6) {
+                break;
+            }
+
+            uint256 amountIn = balances[projectIdx].mulDown(30e16);
+
+            vm.prank(lp);
+            try
+                router.swapSingleTokenExactIn(lbp, projectToken, reserveToken, amountIn, 0, MAX_UINT256, false, "")
+            returns (uint256) {
+                ++swaps;
+            } catch {
+                break;
+            }
+        }
+
+        assertGt(swaps, 0, "The reserve-side walk made no progress");
+
+        uint256 lowest = _lowestReachableReserveBalance(lbp);
+
+        assertEq(lowest, minRedeemableBalance, "Exact-in can still reach a real reserve below the floor");
+        assertTrue(_ownerCanExit(lbp), "Owner cannot exit at the lowest reachable real reserve");
+    }
+
+    function testSeedlessFirstPurchaseIsHeldToTheFloor() public {
+        address lbp = _buildSeedless(false);
+        vault.manualSetStaticSwapFeePercentage(lbp, MIN_WEIGHTED_SWAP_FEE);
+
+        _warpIntoSale();
+
+        uint256 smallest = _smallestFirstPurchase(lbp);
+        assertGe(smallest, minRedeemableBalance, "The smallest admitted first purchase is below the floor");
+
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, smallest, 0, MAX_UINT256, false, "");
+
+        uint256 storedReserve = vault.getCurrentLiveBalances(lbp)[reserveIdx];
+        assertGe(storedReserve, minRedeemableBalance, "The stored real reserve is below the floor");
+        assertTrue(_ownerCanExit(lbp), "Owner cannot exit after the smallest admitted first purchase");
+    }
+
+    function testSeedlessFirstPurchaseInsideTheBandIsRejected() public {
+        address lbp = _buildSeedlessWithWeights(LOW_PROJECT_WEIGHT);
+        vault.manualSetStaticSwapFeePercentage(lbp, MIN_WEIGHTED_SWAP_FEE);
+
+        _warpIntoSale();
+
+        uint256 purchase = 1_223_014;
+        uint256 storedIfAdmitted = purchase - purchase.mulUp(MIN_WEIGHTED_SWAP_FEE);
+
+        assertLt(storedIfAdmitted, minRedeemableBalance, "The test purchase is not below the floor");
+
+        _expectBlocksRedemption(reserveIdx, storedIfAdmitted);
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, purchase, 0, MAX_UINT256, false, "");
+    }
+
+    function testSeedlessFirstPurchaseWithAMaximalAggregateFee() public {
+        address lbp = _buildSeedlessWithWeights(LOW_PROJECT_WEIGHT);
+        vault.manualSetStaticSwapFeePercentage(lbp, MIN_WEIGHTED_SWAP_FEE);
+        vault.manualSetAggregateSwapFeePercentage(lbp, 99.9e16);
+
+        _warpIntoSale();
+
+        uint256 smallest = _smallestFirstPurchase(lbp);
+
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, smallest, 0, MAX_UINT256, false, "");
+
+        assertGe(
+            vault.getCurrentLiveBalances(lbp)[reserveIdx],
+            minRedeemableBalance,
+            "The aggregate fee took the stored real reserve below the floor"
+        );
+        assertTrue(_ownerCanExit(lbp), "Owner cannot exit with the aggregate fee near its maximum");
+    }
+
+    function testSeededPoolStillRefusesTheDrawdownWithMaxOutRatio() public {
+        address lbp = _buildSeeded(HIGH_WEIGHT, false);
+
+        _warpIntoSale();
+
+        uint256 realReserve = vault.getCurrentLiveBalances(lbp)[reserveIdx];
+        uint256 amountOut = realReserve - (minimumTradeAmount - 1);
+
+        vm.prank(lp);
+        vm.expectRevert(WeightedMath.MaxOutRatio.selector);
+        router.swapSingleTokenExactOut(lbp, projectToken, reserveToken, amountOut, MAX_UINT256, MAX_UINT256, false, "");
+    }
+
+    function testUnidirectionalSeedlessStillBlocksReserveOut() public {
+        address lbp = _buildSeedless(true);
+        uint256 realReserve = _accrueReserve(lbp, 100e18);
+
+        uint256 amountOut = realReserve - (minimumTradeAmount - 1);
+
+        vm.prank(lp);
+        vm.expectRevert(LBPCommon.SwapOfProjectTokenIn.selector);
+        router.swapSingleTokenExactOut(lbp, projectToken, reserveToken, amountOut, MAX_UINT256, MAX_UINT256, false, "");
+    }
+
+    function testExactOutMinimumIsUnchanged() public {
+        address lbp = _buildSeeded(HIGH_WEIGHT, false);
+
+        _warpIntoSale();
+
+        uint256 exactOutFloor = (7 * minimumTradeAmount) / 3;
+        assertGt(exactOutFloor, minRedeemableBalance, "The exact-out floor is not above the redeemable floor");
+
+        uint256 balance = vault.getCurrentLiveBalances(lbp)[reserveIdx];
+        uint256 steps;
+
+        while (steps < 200) {
+            uint256 amountOut = balance.mulDown(30e16);
+            if (amountOut < minimumTradeAmount) {
+                break;
+            }
+
+            vm.prank(lp);
+            try
+                router.swapSingleTokenExactOut(
+                    lbp,
+                    projectToken,
+                    reserveToken,
+                    amountOut,
+                    MAX_UINT256,
+                    MAX_UINT256,
+                    false,
+                    ""
+                )
+            returns (uint256) {
+                balance = vault.getCurrentLiveBalances(lbp)[reserveIdx];
+            } catch {
+                break;
+            }
+            ++steps;
+        }
+
+        assertGt(steps, 0, "The exact-out walk made no progress");
+        assertGt(balance, exactOutFloor, "Exact-out reached below its own minimum");
+        assertTrue(_ownerCanExit(lbp), "Owner cannot exit after an exact-out walk");
+    }
+
+    function testBalanceBelowFloorHasNoAvailableSwap() public {
+        address lbp = _buildSeeded(HIGH_WEIGHT, true);
+
+        _warpIntoSale();
+        _forceBalance(lbp, projectIdx, minimumTradeAmount);
+
+        vm.prank(alice);
+        vm.expectRevert(WeightedMath.MaxOutRatio.selector);
+        router.swapSingleTokenExactOut(
+            lbp,
+            reserveToken,
+            projectToken,
+            minimumTradeAmount,
+            MAX_UINT256,
+            MAX_UINT256,
+            false,
+            ""
+        );
+
+        vm.prank(alice);
+        vm.expectRevert(LBPCommon.SwapOfProjectTokenIn.selector);
+        router.swapSingleTokenExactIn(lbp, projectToken, reserveToken, 1e18, 0, MAX_UINT256, false, "");
+
+        assertFalse(_ownerCanExit(lbp), "The forced state is not fully redeemable");
+    }
+
+    function testBalanceAtFloorBlocksFurtherSwapsButAllowsWithdrawal() public {
+        address lbp = _buildSeeded(HIGH_WEIGHT, true);
+
+        _warpIntoSale();
+        _forceBalance(lbp, projectIdx, minRedeemableBalance);
+
+        vm.prank(alice);
+        vm.expectRevert(WeightedMath.MaxOutRatio.selector);
+        router.swapSingleTokenExactOut(
+            lbp,
+            reserveToken,
+            projectToken,
+            minRedeemableBalance,
+            MAX_UINT256,
+            MAX_UINT256,
+            false,
+            ""
+        );
+
+        vm.prank(alice);
+        vm.expectRevert(WeightedMath.MaxOutRatio.selector);
+        router.swapSingleTokenExactOut(
+            lbp,
+            reserveToken,
+            projectToken,
+            minimumTradeAmount,
+            MAX_UINT256,
+            MAX_UINT256,
+            false,
+            ""
+        );
+
+        uint256 maximalAmountIn = vault.getCurrentLiveBalances(lbp)[reserveIdx].mulDown(30e16);
+
+        vm.prank(alice);
+        vm.expectPartialRevert(LBPCommon.TokenBalanceBlocksRedemption.selector);
+        router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, maximalAmountIn, 0, MAX_UINT256, false, "");
+
+        assertTrue(_ownerCanExit(lbp), "Owner cannot withdraw from a balance sitting on the floor");
+    }
+
+    function testPartialWithdrawalFromFloorIsRefused() public {
+        address lbp = _buildSeeded(LOW_PROJECT_WEIGHT, true);
+        _fundBuyer();
+
+        _warpIntoSale();
+
+        uint256 swaps;
+        while (swaps < 100) {
+            uint256[] memory balances = vault.getCurrentLiveBalances(lbp);
+            if (balances[projectIdx] <= 8e6) {
+                break;
+            }
+
+            uint256 amountIn = balances[reserveIdx].mulDown(30e16);
+
+            vm.prank(alice);
+            try
+                router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, amountIn, 0, MAX_UINT256, false, "")
+            returns (uint256) {
+                ++swaps;
+            } catch {
+                break;
+            }
+        }
+
+        assertEq(_lowestReachableProjectBalance(lbp), minRedeemableBalance, "The buyer did not stop on the floor");
+
+        vm.warp(saleEnd + 1);
+
+        assertTrue(_ownerCanExit(lbp), "The single full withdrawal does not clear from the floor");
+
+        uint256 totalSupply = IERC20(lbp).totalSupply();
+        uint256 burn = totalSupply / 2;
+
+        uint256[] memory endingBalances = vault.getCurrentLiveBalances(lbp);
+        uint256 endingProject = endingBalances[projectIdx];
+        uint256 endingReserve = endingBalances[reserveIdx];
+
+        uint256 remainingProject = endingProject - (endingProject * burn) / totalSupply;
+        uint256 remainingReserve = endingReserve - (endingReserve * burn) / totalSupply;
+
+        assertLt(remainingProject, minRedeemableBalance, "The remainder would not be inside the band");
+
+        uint256 maximalBurn = totalSupply - vault.getPoolMinimumTotalSupply();
+        uint256 residueAfterAFullExit = endingReserve - (endingReserve * maximalBurn) / totalSupply;
+
+        assertGt(remainingReserve, residueAfterAFullExit, "Partial withdrawal does not leave additional reserve");
+
+        vm.startPrank(bob);
+        IERC20(lbp).approve(address(router), MAX_UINT256);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LBPCommon.RemainingBalanceBlocksRedemption.selector,
+                projectIdx,
+                remainingProject,
+                totalSupply - burn
+            )
+        );
+        router.removeLiquidityProportional(lbp, burn, new uint256[](2), false, "");
+        vm.stopPrank();
+
+        assertTrue(_ownerCanExit(lbp), "The full exit no longer clears from the floor");
+    }
+
+    function testOrdinaryLifecycleOnEveryConfiguration() public {
+        address seeded = _buildSeeded(HIGH_WEIGHT, true);
+        address seedlessBuyOnly = _buildSeedless(true);
+        address seedlessBidirectional = _buildSeedless(false);
+
+        _accrueReserve(seeded, 100e18);
+        _accrueReserve(seedlessBuyOnly, 100e18);
+        _accrueReserve(seedlessBidirectional, 100e18);
+
+        assertTrue(_ownerCanExit(seeded), "Owner cannot exit a seeded sale");
+        assertTrue(_ownerCanExit(seedlessBuyOnly), "Owner cannot exit a seedless buy-only sale");
+        assertTrue(_ownerCanExit(seedlessBidirectional), "Owner cannot exit a seedless bidirectional sale");
+    }
+
+    function _buildSeedless(bool blockProjectIn) internal returns (address lbp) {
+        uint256 saved = reserveTokenVirtualBalance;
+        reserveTokenVirtualBalance = poolInitAmount;
+
+        (lbp, ) = _createLBPool(address(0), uint32(saleStart), uint32(saleEnd), blockProjectIn);
+
+        reserveTokenVirtualBalance = saved;
+
+        _initWith(lbp, poolInitAmount, 0);
+    }
+
+    function _buildSeedlessWithWeights(uint256 projectWeight) internal returns (address lbp) {
+        uint256 saved = reserveTokenVirtualBalance;
+        reserveTokenVirtualBalance = poolInitAmount;
+
+        (lbp, ) = _createLBPoolWithCustomWeights(
+            address(0),
+            projectWeight,
+            FixedPoint.ONE - projectWeight,
+            projectWeight,
+            FixedPoint.ONE - projectWeight,
+            uint32(saleStart),
+            uint32(saleEnd),
+            false
+        );
+
+        reserveTokenVirtualBalance = saved;
+
+        _initWith(lbp, poolInitAmount, 0);
+    }
+
+    function _buildSeeded(uint256 projectWeight, bool blockProjectIn) internal returns (address lbp) {
+        uint256 saved = reserveTokenVirtualBalance;
+        reserveTokenVirtualBalance = 0;
+
+        (lbp, ) = _createLBPoolWithCustomWeights(
+            address(0),
+            projectWeight,
+            FixedPoint.ONE - projectWeight,
+            projectWeight,
+            FixedPoint.ONE - projectWeight,
+            uint32(saleStart),
+            uint32(saleEnd),
+            blockProjectIn
+        );
+
+        reserveTokenVirtualBalance = saved;
+
+        _initWith(lbp, poolInitAmount, poolInitAmount);
+
+        vault.manualSetStaticSwapFeePercentage(lbp, MIN_WEIGHTED_SWAP_FEE);
+    }
+
+    function _warpIntoSale() internal {
+        if (block.timestamp <= saleStart) {
+            vm.warp(saleStart + 1);
+        }
+    }
+
+    function _initWith(address lbp, uint256 projectAmount, uint256 reserveAmount) internal {
+        uint256[] memory initAmounts = new uint256[](2);
+        initAmounts[projectIdx] = projectAmount;
+        initAmounts[reserveIdx] = reserveAmount;
+
+        vm.startPrank(bob);
+        _initPool(lbp, initAmounts, 0);
+        vm.stopPrank();
+
+        approveForPool(IERC20(lbp));
+    }
+
+    function _accrueReserve(address lbp, uint256 amountIn) internal returns (uint256 realReserve) {
+        _warpIntoSale();
+
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, amountIn, 0, MAX_UINT256, false, "");
+
+        realReserve = vault.getCurrentLiveBalances(lbp)[reserveIdx];
+    }
+
+    function _sellProjectExactOut(address lbp, uint256 amountOutRaw) internal {
+        vm.prank(lp);
+        router.swapSingleTokenExactOut(
+            lbp,
+            projectToken,
+            reserveToken,
+            amountOutRaw,
+            MAX_UINT256,
+            MAX_UINT256,
+            false,
+            ""
+        );
+    }
+
+    function _fundBuyer() internal {
+        deal(address(reserveToken), alice, 1e30);
+
+        vm.startPrank(alice);
+        reserveToken.approve(address(permit2), type(uint256).max);
+        permit2.approve(address(reserveToken), address(router), type(uint160).max, type(uint48).max);
+        vm.stopPrank();
+    }
+
+    function _fundSeller() internal {
+        deal(address(projectToken), lp, 1e30);
+
+        vm.startPrank(lp);
+        projectToken.approve(address(permit2), type(uint256).max);
+        permit2.approve(address(projectToken), address(router), type(uint160).max, type(uint48).max);
+        vm.stopPrank();
+    }
+
+    function _lowestReachableReserveBalance(address lbp) internal returns (uint256 lowest) {
+        uint256 lo = minimumTradeAmount;
+        uint256 hi = vault.getCurrentLiveBalances(lbp)[projectIdx].mulDown(30e16);
+        uint256 chosen;
+
+        for (uint256 i = 0; i < 128 && lo <= hi; ++i) {
+            uint256 mid = (lo + hi) / 2;
+            uint256 trial = vm.snapshotState();
+
+            bool ok;
+
+            vm.prank(lp);
+            try router.swapSingleTokenExactIn(lbp, projectToken, reserveToken, mid, 0, MAX_UINT256, false, "") returns (
+                uint256
+            ) {
+                ok = true;
+            } catch {
+                ok = false;
+            }
+
+            vm.revertToState(trial);
+
+            if (ok) {
+                chosen = mid;
+                lo = mid + 1;
+            } else {
+                hi = mid - 1;
+            }
+        }
+
+        require(chosen != 0, "No sale was admitted");
+
+        vm.prank(lp);
+        router.swapSingleTokenExactIn(lbp, projectToken, reserveToken, chosen, 0, MAX_UINT256, false, "");
+
+        lowest = vault.getCurrentLiveBalances(lbp)[reserveIdx];
+    }
+
+    function _lowestReachableProjectBalance(address lbp) internal returns (uint256 lowest) {
+        uint256 lo = minimumTradeAmount;
+        uint256 hi = vault.getCurrentLiveBalances(lbp)[reserveIdx].mulDown(30e16);
+        uint256 chosen;
+
+        lowest = type(uint256).max;
+
+        for (uint256 i = 0; i < 128 && lo <= hi; ++i) {
+            uint256 mid = (lo + hi) / 2;
+            uint256 trial = vm.snapshotState();
+
+            bool ok;
+            uint256 resultingBalance;
+
+            vm.prank(alice);
+            try router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, mid, 0, MAX_UINT256, false, "") returns (
+                uint256
+            ) {
+                ok = true;
+                resultingBalance = vault.getCurrentLiveBalances(lbp)[projectIdx];
+            } catch {
+                ok = false;
+            }
+
+            vm.revertToState(trial);
+
+            if (ok) {
+                chosen = mid;
+                lowest = resultingBalance;
+                lo = mid + 1;
+            } else {
+                hi = mid - 1;
+            }
+        }
+
+        require(chosen != 0, "No purchase was admitted");
+
+        vm.prank(alice);
+        router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, chosen, 0, MAX_UINT256, false, "");
+
+        lowest = vault.getCurrentLiveBalances(lbp)[projectIdx];
+    }
+
+    function _smallestFirstPurchase(address lbp) internal returns (uint256 smallest) {
+        uint256 lo = 1;
+        uint256 hi = 1e12;
+        smallest = hi;
+
+        for (uint256 i = 0; i < 64 && lo <= hi; ++i) {
+            uint256 mid = (lo + hi) / 2;
+            uint256 trial = vm.snapshotState();
+
+            bool ok;
+
+            vm.prank(alice);
+            try router.swapSingleTokenExactIn(lbp, reserveToken, projectToken, mid, 0, MAX_UINT256, false, "") returns (
+                uint256
+            ) {
+                ok = true;
+            } catch {
+                ok = false;
+            }
+
+            vm.revertToState(trial);
+
+            if (ok) {
+                smallest = mid;
+                hi = mid - 1;
+            } else {
+                lo = mid + 1;
+            }
+        }
+    }
+
+    function _expectBlocksRedemption(uint256 tokenIndex, uint256 endingBalance) internal {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LBPCommon.TokenBalanceBlocksRedemption.selector,
+                tokenIndex,
+                endingBalance,
+                minRedeemableBalance
+            )
+        );
+    }
+
+    function _forceBalance(address lbp, uint256 tokenIndex, uint256 balanceScaled18) internal {
+        uint256[] memory balances = vault.getCurrentLiveBalances(lbp);
+        balances[tokenIndex] = balanceScaled18;
+
+        vault.manualSetPoolBalances(lbp, balances, balances);
+    }
+
+    function _ownerCanExit(address lbp) internal returns (bool ok) {
+        uint256 snapshotId = vm.snapshotState();
+
+        vm.warp(saleEnd + 1);
+
+        uint256 ownerBpt = IERC20(lbp).balanceOf(bob);
+
+        vm.startPrank(bob);
+        IERC20(lbp).approve(address(router), MAX_UINT256);
+
+        try router.removeLiquidityProportional(lbp, ownerBpt, new uint256[](2), false, "") returns (uint256[] memory) {
+            ok = true;
+        } catch {
+            ok = false;
+        }
+        vm.stopPrank();
+
+        vm.revertToState(snapshotId);
+    }
+}


### PR DESCRIPTION
# Description

This PR improves LBP handling across initialization, proportional liquidity operations, and swaps.

* Require LBPs to use proportional-only liquidity management.
* Validate initialization and proportional liquidity changes against Vault minimums.
* Apply real-balance checks to weighted and fixed-price LBP swaps.
* Return a dedicated error when a fixed-price swap requests more output than the pool holds.
* Expose the minimum non-zero real balance used for swap validation.
* Use full-precision arithmetic for proportional balance calculations.
* Add boundary and lifecycle coverage for weighted, seedless, and fixed-price LBPs.

The changes preserve normal LBP behavior while making the supported liquidity and balance constraints explicit.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Changeset is included <!-- run `yarn changeset` -->
- [X] Complex code has been commented, including external interfaces
- [X] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
